### PR TITLE
Rename to rollout-operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-cortex-operator
+/rollout-operator

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/grafana/cortex-operator/pkg/controller"
+	"github.com/grafana/rollout-operator/pkg/controller"
 
 	// Required to get the GCP auth provider working.
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/grafana/cortex-operator
+module github.com/grafana/rollout-operator
 
 go 1.16
 


### PR DESCRIPTION
There's no cortex / ingester specific code in the operator, so we agreed on give it a generic name "rollout-operator" because it coordinates rollouts.