### PR TITLE
Increased timeout for golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,3 +30,5 @@ jobs:
         with:
           go-version: '^1.16.5'
       - uses: golangci/golangci-lint-action@v2
+        with:
+          args: --timeout=5m

--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,4 @@ test:
 
 .PHONY: lint
 lint:
-	golangci-lint run
+	golangci-lint run --timeout=5m


### PR DESCRIPTION
I've seen the linter timing out in CI ([example](https://github.com/grafana/rollout-operator/runs/3084828280)), so in this PR I'm increasing the timeout (default is 1m) to see if it fixes it.