### PR TITLE
Detect as not-ready pods which are terminating but their readiness probe hasn't failed yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main / unreleased
 
 * [ENHANCEMENT] Improve log messages about not read statefulset. #19
+* [BUGFIX] Detect as not-ready pods which are terminating but their readiness probe hasn't failed yet. #20
 
 ## v0.1.1
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -417,12 +417,12 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 
 	// Ensure all pods in this StatefulSet are Ready, otherwise we consider a rollout is in progress
 	// (in any case, it's not safe to proceed with other StatefulSets).
-	if sts.Status.Replicas != sts.Status.ReadyReplicas {
+	if hasNotReadyPods, err := c.hasStatefulSetNotReadyPods(sts); err != nil {
+		return true, errors.Wrapf(err, "unable to check if StatefulSet %s has not ready pods", sts.Name)
+	} else if hasNotReadyPods {
 		level.Info(c.logger).Log(
 			"msg", "StatefulSet pods are all updated but StatefulSet has some not-Ready replicas",
-			"statefulset", sts.Name,
-			"replicas", sts.Status.Replicas,
-			"ready_replicas", sts.Status.ReadyReplicas)
+			"statefulset", sts.Name)
 
 		return true, nil
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -234,7 +235,12 @@ func (c *RolloutController) reconcileStatefulSetsGroup(ctx context.Context, grou
 	// Find StatefulSets with some not-Ready pods.
 	notReadySets := make([]*v1.StatefulSet, 0, len(sets))
 	for _, sts := range sets {
-		if sts.Status.Replicas != sts.Status.ReadyReplicas {
+		hasNotReadyPods, err := c.hasStatefulSetNotReadyPods(sts)
+		if err != nil {
+			return errors.Wrapf(err, "unable to check if StatefulSet %s has not ready pods", sts.Name)
+		}
+
+		if hasNotReadyPods {
 			notReadySets = append(notReadySets, sts)
 		}
 	}
@@ -245,7 +251,7 @@ func (c *RolloutController) reconcileStatefulSetsGroup(ctx context.Context, grou
 	// get back to Ready first before proceeding.
 	if len(notReadySets) > 1 {
 		// Do not return error because it's not an actionable error with regards to the operator behaviour.
-		level.Warn(c.logger).Log("msg", "StatefulSets have some not-Ready pods, skipping reconcile", "notReadyStatefulSets", len(notReadySets))
+		level.Warn(c.logger).Log("msg", "StatefulSets have some not-Ready pods, skipping reconcile", "not_ready_statefulsets", len(notReadySets))
 		return nil
 	}
 
@@ -291,6 +297,63 @@ func (c *RolloutController) listStatefulSetsWithRolloutGroup() ([]*v1.StatefulSe
 	}
 
 	return deepCopy, nil
+}
+
+func (c *RolloutController) hasStatefulSetNotReadyPods(sts *v1.StatefulSet) (bool, error) {
+	// We can quickly check the number of ready replicas reported by the StatefulSet.
+	// If they don't match the total number of replicas, then we're sure there are some
+	// not ready pods.
+	if sts.Status.Replicas != sts.Status.ReadyReplicas {
+		return true, nil
+	}
+
+	// The number of ready replicas reported by the StatefulSet match the total number of
+	// replicas. However, there's still no guarantee that all pods are running. For example,
+	// a terminating pod (which we don't consider "ready") may have not yet failed the
+	// readiness probe for the consecutive number of times required to switch its status
+	// to not-ready. For this reason, we list all StatefulSet pods and check them one-by-one.
+	notReadyPods, err := c.listNotReadyPodsByStatefulSet(sts)
+	if err != nil {
+		return false, err
+	}
+	if len(notReadyPods) == 0 {
+		return false, nil
+	}
+
+	// Log which pods have been detected as not-ready. This may be useful for debugging.
+	level.Info(c.logger).Log(
+		"msg", "StatefulSet status is reporting all pods ready, but the rollout operator has found some not-Ready pods",
+		"statefulset", sts.Name,
+		"not_ready_pods", strings.Join(podNames(notReadyPods), " "))
+
+	return true, nil
+}
+
+func (c *RolloutController) listNotReadyPodsByStatefulSet(sts *v1.StatefulSet) ([]*corev1.Pod, error) {
+	// Select all pods belonging to the input StatefulSet.
+	podsSelector := labels.NewSelector().Add(
+		mustNewLabelsRequirement("name", selection.Equals, []string{sts.Spec.Template.Labels["name"]}),
+	)
+
+	all, err := c.listPods(podsSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build a list of not-ready ones. We don't pre-allocate this list cause most of the times we
+	// expect all pods are running and ready.
+	var notReady []*corev1.Pod
+
+	for _, pod := range all {
+		if !isPodRunningAndReady(pod) {
+			notReady = append(notReady, pod)
+		}
+	}
+
+	// Sort pods in order to provide a deterministic behaviour.
+	sortPods(notReady)
+
+	return notReady, nil
 }
 
 // listPods returns pods matching the provided labels selector. Please remember to call

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -257,7 +257,7 @@ func (c *RolloutController) reconcileStatefulSetsGroup(ctx context.Context, grou
 
 	// If there's a StatefulSet with not-Ready pods we also want that one to be the first one to reconcile.
 	if len(notReadySets) == 1 {
-		level.Info(c.logger).Log("msg", "A StatefulSet has some not-Ready pods, reconcile it first", "statefulset", notReadySets[0].Name)
+		level.Info(c.logger).Log("msg", "a StatefulSet has some not-Ready pods, reconcile it first", "statefulset", notReadySets[0].Name)
 		sets = moveStatefulSetToFront(sets, notReadySets[0])
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -207,7 +207,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 				mockStatefulSetPod("ingester-zone-a-2", testLastRevisionHash),
 			},
 		},
-		"should not proceed with the next StatefulSet if there's another one with not-Ready pods": {
+		"should not proceed with the next StatefulSet if there's another one with not-Ready pods reported by the StatefulSet": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-a", withReplicas(3, 2)),
 				mockStatefulSet("ingester-zone-b", withPrevRevision()),
@@ -216,6 +216,22 @@ func TestRolloutController_Reconcile(t *testing.T) {
 				mockStatefulSetPod("ingester-zone-a-0", testLastRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-1", testLastRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-2", testLastRevisionHash),
+				mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
+			},
+		},
+		"should not proceed with the next StatefulSet if there's another one with not-Ready pods but NOT reported by the StatefulSet yet": {
+			statefulSets: []runtime.Object{
+				mockStatefulSet("ingester-zone-a", withReplicas(3, 3)),
+				mockStatefulSet("ingester-zone-b", withPrevRevision()),
+			},
+			pods: []runtime.Object{
+				mockStatefulSetPod("ingester-zone-a-0", testLastRevisionHash),
+				mockStatefulSetPod("ingester-zone-a-1", testLastRevisionHash),
+				mockStatefulSetPod("ingester-zone-a-2", testLastRevisionHash, func(pod *corev1.Pod) {
+					pod.DeletionTimestamp = now()
+				}),
 				mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -47,7 +47,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 			},
 			expectedErr: "ingester-zone-a has RollingUpdate update strategy",
 		},
-		"should do nothing if multiple StatefulSets have not-Ready pods": {
+		"should do nothing if multiple StatefulSets have not-Ready pods reported by the StatefulSet": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-a", withPrevRevision(), withReplicas(3, 2)),
 				mockStatefulSet("ingester-zone-b", withPrevRevision(), withReplicas(3, 1)),
@@ -59,6 +59,40 @@ func TestRolloutController_Reconcile(t *testing.T) {
 				mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
+			},
+		},
+		"should do nothing if multiple StatefulSets have not-Ready pods but NOT reported by the StatefulSet status yet": {
+			statefulSets: []runtime.Object{
+				mockStatefulSet("ingester-zone-a", withPrevRevision(), withReplicas(3, 3)),
+				mockStatefulSet("ingester-zone-b", withPrevRevision(), withReplicas(3, 3)),
+			},
+			pods: []runtime.Object{
+				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash, func(pod *corev1.Pod) {
+					pod.DeletionTimestamp = now()
+				}),
+				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash, func(pod *corev1.Pod) {
+					pod.DeletionTimestamp = now()
+				}),
+			},
+		},
+		"should do nothing if multiple StatefulSets have not-Ready pods but ONLY reported by 1 StatefulSet status": {
+			statefulSets: []runtime.Object{
+				mockStatefulSet("ingester-zone-a", withPrevRevision(), withReplicas(3, 2)),
+				mockStatefulSet("ingester-zone-b", withPrevRevision(), withReplicas(3, 3)),
+			},
+			pods: []runtime.Object{
+				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash, func(pod *corev1.Pod) {
+					pod.DeletionTimestamp = now()
+				}),
 			},
 		},
 		"should do nothing if all pods are updated": {
@@ -145,8 +179,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 			},
 			pods: []runtime.Object{
 				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash, func(pod *corev1.Pod) {
-					ts := metav1.Now()
-					pod.DeletionTimestamp = &ts
+					pod.DeletionTimestamp = now()
 				}),
 				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
@@ -418,6 +451,13 @@ func mockStatefulSetPod(name, revision string, overrides ...func(pod *corev1.Pod
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "application",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+					Ready: true,
+				},
+			},
 		},
 	}
 

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -47,7 +47,7 @@ func isPodRunningAndReady(pod *corev1.Pod) bool {
 	}
 
 	// All containers must be running and ready.
-	for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
+	for i := 0; i < len(pod.Status.ContainerStatuses); i++ {
 		container := pod.Status.ContainerStatuses[i]
 
 		if !container.Ready || container.State.Running == nil {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -25,6 +25,39 @@ func sortPods(pods []*corev1.Pod) {
 	})
 }
 
+// podNames returns the names of input pods.
+func podNames(pods []*corev1.Pod) []string {
+	names := make([]string, 0, len(pods))
+	for _, pod := range pods {
+		names = append(names, pod.Name)
+	}
+	return names
+}
+
+// isPodRunningAndReady returns whether the input pod is running and ready.
+func isPodRunningAndReady(pod *corev1.Pod) bool {
+	// The pod phase must be "running".
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+
+	// It must not be in the terminating state.
+	if pod.DeletionTimestamp != nil {
+		return false
+	}
+
+	// All containers must be running and ready.
+	for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
+		container := pod.Status.ContainerStatuses[i]
+
+		if !container.Ready || container.State.Running == nil {
+			return false
+		}
+	}
+
+	return true
+}
+
 // moveStatefulSetToFront returns a new slice where the input StatefulSet toMove is moved
 // at the beginning. Comparison is done via pointer equality.
 func moveStatefulSetToFront(sets []*v1.StatefulSet, toMove *v1.StatefulSet) []*v1.StatefulSet {

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -47,6 +47,99 @@ func TestSortPods(t *testing.T) {
 	assert.Equal(t, expected, input)
 }
 
+func TestPodNames(t *testing.T) {
+	input := []*corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "ingester-11"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "ingester-0"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "ingester-10"}},
+	}
+
+	assert.Equal(t, []string{"ingester-11", "ingester-0", "ingester-10"}, podNames(input))
+}
+
+func TestIsPodRunningAndReady(t *testing.T) {
+	tests := map[string]struct {
+		pod      *corev1.Pod
+		expected bool
+	}{
+		"should return true on a ready pod with 1 ready and running container": {
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+				},
+			}},
+			expected: true,
+		},
+		"should return true on a ready pod with multiple ready and running containers": {
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+				},
+			}},
+			expected: true,
+		},
+		"should return false if a container is not ready": {
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					{Ready: false, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+				},
+			}},
+			expected: false,
+		},
+		"should return false if a container is terminated": {
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					{Ready: true, State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}}},
+				},
+			}},
+			expected: false,
+		},
+		"should return false if the pod is not in the running phase": {
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+				},
+			}},
+			expected: false,
+		},
+		"should return false if the pod is terminating": {
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: now(),
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+						{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+						{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, testData.expected, isPodRunningAndReady(testData.pod))
+		})
+	}
+}
+
 func TestMoveStatefulSetToFront(t *testing.T) {
 	input := []*v1.StatefulSet{
 		{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-a"}},
@@ -98,4 +191,9 @@ func TestMax(t *testing.T) {
 func TestMin(t *testing.T) {
 	assert.Equal(t, 1, min(1))
 	assert.Equal(t, 3, min(4, 3, 5))
+}
+
+func now() *metav1.Time {
+	ts := metav1.Now()
+	return &ts
 }


### PR DESCRIPTION
The rollout-operator checks the non-ready pods looking at the StatefulSet status. Non-ready pods are the ones failing the readiness probe. Mimir ingesters pod readiness probe is configured with `period=10s #success=1 #failure=3`. Given the ingester takes a while to shutdown, the readiness probe doesn't fail immediately but after about 30s (10s x 3 times). Until then, the terminating pod is not reported as non-ready in the StatefulSet status, and so the StatefulSet is not reported has having not ready pods.

This PR improved the logic used to check if a StatefulSet has not ready pods, checking all actual pods status too.