### PR TITLE
Fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pracucci @aknuds1 @bboreham
+* @grafana/mimir-maintainers


### PR DESCRIPTION
Most code here has been written by me so far ([stats](https://github.com/grafana/rollout-operator/graphs/contributors)), but I think it's fair saying that all Mimir maintainers have a strong interest into this project and care a lot about it, so I propose to make all of them owners.