### PR TITLE
Build statically linked binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ rollout-operator:
 
 .PHONY: build-linux-amd64
 build-linux-amd64:
-	GOOS=linux GOARCH=amd64 go build ./cmd/rollout-operator
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
 .PHONY: build-image
 build-image: build-linux-amd64


### PR DESCRIPTION
Ensure we build statically linked binaries on the host so that we don't have issues with missing dynamic libraries when running in Alpine. An alternative would be build the binary in Docker, using an Alpine-based image, but would take longer.