### PR TITLE
Cut v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+## v0.2.0
+
 * [ENHANCEMENT] Update Docker base image to `alpine:3.16`. #23
 * [ENHANCEMENT] Update the minimum go version to `1.18`. #23
 * [ENHANCEMENT] Update dependencies to address CVEs, including: #23


### PR DESCRIPTION
Separates out a CHANGELOG section as a last step before tagging the new minor version.