### PR TITLE
Increase integration test timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test:
 
 .PHONY: integration
 integration: integration/mock-service/.uptodate
-	go test -v -tags requires_docker -count 1 ./integration/...
+	go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
 
 integration/mock-service/.uptodate:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' -o ./integration/mock-service/mock-service ./integration/mock-service


### PR DESCRIPTION
Tests got flaky as we're hitting the default 10m timeout in them.

Increase the timeout to handle CI properly.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
