### PR TITLE
Update github action versions due to deprecation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: '^1.20.1'
       - run: make rollout-operator
@@ -16,8 +16,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: '^1.20.1'
       - run: make test
@@ -25,8 +25,8 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: '^1.20.1'
       - run: make build-image
@@ -35,10 +35,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: '^1.20.1'
-      - uses: golangci/golangci-lint-action@v2
+      - uses: golangci/golangci-lint-action@v3
         with:
           args: --timeout=5m


### PR DESCRIPTION
Currently the logs of the `lint` Github action shows a deprecation notice:

> 
> Warning: The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. 
> For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
> 

We are using `https://github.com/golangci/golangci-lint-action` in this stage, and in v3 it has in its dependencies `"@actions/core": "^1.10.0",` which fixes this.

I updated `actions/checkout` and `actions/setup-go` as well for consistency between the jobs.