### PR TITLE
Makefile: Set dependencies for binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ IMAGE_TAG ?= $(GIT_BRANCH)-$(GIT_REVISION)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
-rollout-operator:
+DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune -o
+GO_FILES := $(shell find . $(DONT_FIND) -name cmd -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print)
+
+rollout-operator: $(GO_FILES)
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
 .PHONY: build-image

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ IMAGE_TAG ?= $(GIT_BRANCH)-$(GIT_REVISION)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
-DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune -o
-GO_FILES := $(shell find . $(DONT_FIND) -type f -name '*.go' -print)
+DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune
+GO_FILES := $(shell find . $(DONT_FIND) -o -type f -name '*.go' -print)
 
 rollout-operator: $(GO_FILES)
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
 DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune -o
-GO_FILES := $(shell find . $(DONT_FIND) -name cmd -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print)
+GO_FILES := $(shell find . $(DONT_FIND) -type f -name '*.go' -print)
 
 rollout-operator: $(GO_FILES)
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator


### PR DESCRIPTION
In Makefile, set the dependencies for the rollout-operator binary so it gets re-built when Go files change.

I've copied and adapted the logic from the Mimir Makefile for finding Go source files. Please review whether this logic makes sence, since it's a bit hairy :)