### PR TITLE
Update Go to 1.20.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20.1'
+          go-version: '^1.20.3'
       - run: make rollout-operator
 
   test:
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20.1'
+          go-version: '^1.20.3'
       - run: make test
 
   integration:
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20.1'
+          go-version: '^1.20.3'
       - run: make build-image
       - run: make integration
 
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20.1'
+          go-version: '^1.20.3'
       - uses: golangci/golangci-lint-action@v3
         with:
           args: --timeout=5m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [ENHANCEMENT] Update Go to `1.20.3`. #48
+
 ## v0.4.0
 
 * [ENHANCEMENT] Update Go to `1.20.1`. #39

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.20.1-bullseye AS build
+FROM --platform=$BUILDPLATFORM golang:1.20.3-bullseye AS build
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Updates the Go version used to build the image and in CI to 1.20.3.