### PR TITLE
Reinstate /ingester/ prefix

### DIFF
--- a/pkg/admission/prep_downscale.go
+++ b/pkg/admission/prep_downscale.go
@@ -163,7 +163,7 @@ func prepareDownscale(ctx context.Context, logger log.Logger, ar v1.AdmissionRev
 	// https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id
 	for i := 0; i < int(diff); i++ {
 		index := int(*oldReplicas) - i - 1 // nr in statefulset
-		eps[i].url = fmt.Sprintf("%v-%v.%v.%v.svc.cluster.local:%s/%s",
+		eps[i].url = fmt.Sprintf("%v-%v.%v.%v.svc.cluster.local:%s/ingester/%s",
 			ar.Request.Name, // pod name
 			index,
 			ar.Request.Name, // svc name


### PR DESCRIPTION
Labels in Kubernetes do not allow the `/` character. Therefore the `/ingester/` prefix needs to be added.
Found this while working on an integration test for the downscale webhook.