### PR TITLE
Update Go to 1.20.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20.3'
+          go-version: '^1.20.4'
       - run: make rollout-operator
 
   test:
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20.3'
+          go-version: '^1.20.4'
       - run: make test
 
   integration:
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20.3'
+          go-version: '^1.20.4'
       - run: make build-image
       - run: make integration
 
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20.3'
+          go-version: '^1.20.4'
       - uses: golangci/golangci-lint-action@v3
         with:
           args: --timeout=5m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [ENHANCEMENT] Update Go to `1.20.4`. #55
+
 ## v0.5.0
 
 * [ENHANCEMENT] Add an `/admission/prepare-downscale` mutating admission webhook that prepares pods for shutdown before downscaling. #47 #52

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.20.3-bullseye AS build
+FROM --platform=$BUILDPLATFORM golang:1.20.4-bullseye AS build
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
`0.5.0` was cut recently so this may end up being unnecessary due to another Go release happening before we release another image, but I'm updating just in case.