### PR TITLE
Drop specifying go patch version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,27 +8,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '^1.20.4'
+          go-version: '1.20'
+          check-latest: true
       - run: make rollout-operator
 
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '^1.20.4'
+          go-version: '1.20'
+          check-latest: true
       - run: make test
 
   integration:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '^1.20.4'
+          go-version: '1.20'
+          check-latest: true
       - run: make build-image
       - run: make integration
 
@@ -36,9 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '^1.20.4'
+          go-version: '1.20'
+          check-latest: true
       - uses: golangci/golangci-lint-action@v3
         with:
           args: --timeout=5m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.20.4-bullseye AS build
+FROM --platform=$BUILDPLATFORM golang:1.20-bullseye AS build
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Removes the patch version being specified for Go from both the Dockerfile and CI.

The aim of this is to only require intervention on Go minor version upgrades. Currently this effectively upgrades to go 1.20.5.

The CI workflow was changed according to [node semver](https://github.com/npm/node-semver#x-ranges-12x-1x-12-). The current specification `^1.20.4` actually meant `>=1.20.4 < 2.0.0`. Given the dependencies of this project, minor version changes actually cause breakage like in https://github.com/grafana/rollout-operator/pull/39. `1.20` means `>=1.20.0 < 1.21.0`, where the `check-latest: true` ensures we're on the latest patch version, effectively matching the Docker tag behavior.

I also updated to `actions/setup-go@v4`, which isn't really necessary for these changes, but I noticed there was a new version while doing this.