### PR TITLE
Add boringcrypto image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.20.5' # temporary pin to get a passing CI because of a bug in docker
           check-latest: true
       - run: make build-image
       - run: make integration
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.20.5' # temporary pin to get a passing CI because of a bug in docker
           check-latest: true
       - run: make build-image-boringcrypto
       - run: make integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,6 @@ jobs:
       - run: make build-image
       - run: make integration
 
-
   integration-boringcrypto:
     runs-on: ubuntu-latest
     steps:
@@ -47,7 +46,6 @@ jobs:
           check-latest: true
       - run: make build-image-boringcrypto
       - run: make integration
-
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.5' # temporary pin to get a passing CI because of a bug in docker
+          go-version: '1.20'
           check-latest: true
       - run: make build-image
       - run: make integration
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.5' # temporary pin to get a passing CI because of a bug in docker
+          go-version: '1.20'
           check-latest: true
       - run: make build-image-boringcrypto
       - run: make integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,19 @@ jobs:
       - run: make build-image
       - run: make integration
 
+
+  integration-boringcrypto:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+          check-latest: true
+      - run: make build-image-boringcrypto
+      - run: make integration
+
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
           go-version: '1.20'
           check-latest: true
       - run: make test
+      - run: make test-boringcrypto
 
   integration:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main / unreleased
 
+* [FEATURE] Publish boringcrypto image for amd64. #71
 * [ENHANCEMENT] Update the intermediate build container for the Docker image to `golang:1.20-bookworm`. #66 #67
 
 ## v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## main / unreleased
 
-* [FEATURE] Publish boringcrypto image for amd64. #71
-* [ENHANCEMENT] Update the intermediate build container for the Docker image to `golang:1.20-bookworm`. #66 #67
+* [FEATURE] Publish an additional boringcrypto image for linux/amd64,linux/arm64. #71
+* [ENHANCEMENT] Update the intermediate build container for the Docker image to `golang:1.20-alpine3.18`. #66 #67 #71
 
 ## v0.6.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@ FROM --platform=$BUILDPLATFORM golang:1.20-bookworm AS build
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG BUILDTARGET=rollout-operator
 
 COPY . /src/rollout-operator
 WORKDIR /src/rollout-operator
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make ${BUILDTARGET}
 
 FROM alpine:3.18
 RUN apk add --no-cache ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ WORKDIR /src/rollout-operator
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make ${BUILDTARGET}
 
 FROM alpine:3.18
-# need gcompat for glibc compatibility of the boringcrypto image
-RUN apk add --no-cache ca-certificates gcompat
+RUN apk add --no-cache ca-certificates
 
 COPY --from=build /src/rollout-operator/rollout-operator /bin/rollout-operator
 ENTRYPOINT [ "/bin/rollout-operator" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.20-bookworm AS build
+FROM golang:1.20-alpine AS build
 
 ARG TARGETOS
 ARG TARGETARCH
 ARG BUILDTARGET=rollout-operator
+
+RUN apk add --no-cache build-base git
 
 COPY . /src/rollout-operator
 WORKDIR /src/rollout-operator

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.20-bookworm AS build
+FROM golang:1.20.5-bullseye as build
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -8,7 +8,7 @@ COPY . /src/rollout-operator
 WORKDIR /src/rollout-operator
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make ${BUILDTARGET}
 
-FROM alpine:3.18
+FROM alpine:3.18.2
 RUN apk add --no-cache ca-certificates
 
 COPY --from=build /src/rollout-operator/rollout-operator /bin/rollout-operator

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.20-bookworm AS build
+FROM golang:1.20-bookworm AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ WORKDIR /src/rollout-operator
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make ${BUILDTARGET}
 
 FROM alpine:3.18
-RUN apk add --no-cache ca-certificates libc6-compat gcompat
+# need gcompat for glibc compatibility of the boringcrypto image
+RUN apk add --no-cache ca-certificates gcompat
 
 COPY --from=build /src/rollout-operator/rollout-operator /bin/rollout-operator
 ENTRYPOINT [ "/bin/rollout-operator" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5-bullseye as build
+FROM --platform=$BUILDPLATFORM golang:1.20-bookworm AS build
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -8,7 +8,7 @@ COPY . /src/rollout-operator
 WORKDIR /src/rollout-operator
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make ${BUILDTARGET}
 
-FROM alpine:3.18.2
+FROM alpine:3.18
 RUN apk add --no-cache ca-certificates libc6-compat gcompat
 
 COPY --from=build /src/rollout-operator/rollout-operator /bin/rollout-operator

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine AS build
+FROM golang:1.20-alpine3.18 AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /src/rollout-operator
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make ${BUILDTARGET}
 
 FROM alpine:3.18.2
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates libc6-compat gcompat
 
 COPY --from=build /src/rollout-operator/rollout-operator /bin/rollout-operator
 ENTRYPOINT [ "/bin/rollout-operator" ]

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ rollout-operator: $(GO_FILES)
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
 rollout-operator-boringcrypto: $(GO_FILES)
-	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -tags netgo ./cmd/rollout-operator
+	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -tags netgo -ldflags '-extldflags "-static" -linkmode=external' ./cmd/rollout-operator
 
 .PHONY: build-image
 build-image: clean

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ rollout-operator: $(GO_FILES)
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
 rollout-operator-boringcrypto: $(GO_FILES)
-	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -tags netgo -ldflags '-extldflags "-static"' ./cmd/rollout-operator
+	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -tags netgo ./cmd/rollout-operator
 
 .PHONY: build-image
 build-image: clean

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ rollout-operator: $(GO_FILES)
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
 rollout-operator-boringcrypto: $(GO_FILES)
-	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -tags netgo -ldflags '-extldflags "-static" -linkmode=external' ./cmd/rollout-operator
+	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -tags netgo ./cmd/rollout-operator
 
 .PHONY: build-image
 build-image: clean

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-image-boringcrypto: clean ## Build the rollout-operator image with boringc
 .PHONY: publish-images
 publish-images: publish-standard-image publish-boringcrypto-image
 
-.PHONY: publish-standard image
+.PHONY: publish-standard-image
 publish-standard-image: clean
 	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
 

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,12 @@ rollout-operator-boringcrypto: $(GO_FILES)
 
 .PHONY: build-image
 build-image: clean
-	$(SUDO) docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
+	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 
 .PHONY: publish-images
 publish-images: clean
-	$(SUDO) docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) .
-	$(SUDO) docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
+	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
+	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) .
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ publish-images: clean
 test:
 	go test ./...
 
+test-boringcrypto:
+	GOEXPERIMENT=boringcrypto go test ./...
+
+
 .PHONY: integration
 integration: integration/mock-service/.uptodate
 	go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build-image: clean
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 
 .PHONY: build-image
-build-image-boringcrypto: clean
+build-image-boringcrypto: clean ## Build the rollout-operator image with boringcrypto and tag with the regular image repo, so that it can be used in integration tests.
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 
 .PHONY: publish-images

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ rollout-operator-boringcrypto: $(GO_FILES)
 build-image: clean
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 
-.PHONY: build-image
 build-image-boringcrypto: clean ## Build the rollout-operator image with boringcrypto and tag with the regular image repo, so that it can be used in integration tests.
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Generate the default image tag based on the git branch and revision.
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 GIT_REVISION := $(shell git rev-parse --short HEAD)
-IMAGE_PREFIX ?= us.gcr.io/kubernetes-dev
+IMAGE_PREFIX ?= grafana
 IMAGE_TAG ?= $(subst /,-,$(GIT_BRANCH))-$(GIT_REVISION)
 
 GOOS ?= $(shell go env GOOS)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Generate the default image tag based on the git branch and revision.
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 GIT_REVISION := $(shell git rev-parse --short HEAD)
-IMAGE_PREFIX ?= grafana
+IMAGE_PREFIX ?= us.gcr.io/kubernetes-dev
 IMAGE_TAG ?= $(GIT_BRANCH)-$(GIT_REVISION)
 
 GOOS ?= $(shell go env GOOS)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Generate the default image tag based on the git branch and revision.
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 GIT_REVISION := $(shell git rev-parse --short HEAD)
-IMAGE_PREFIX ?= us.gcr.io/kubernetes-dev
+IMAGE_PREFIX ?= grafana
 IMAGE_TAG ?= $(GIT_BRANCH)-$(GIT_REVISION)
 
 GOOS ?= $(shell go env GOOS)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ GOARCH ?= $(shell go env GOARCH)
 DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune
 GO_FILES := $(shell find . $(DONT_FIND) -o -type f -name '*.go' -print)
 
-.PHONY: rollout-operator
 rollout-operator: $(GO_FILES)
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test-boringcrypto:
 integration: integration/mock-service/.uptodate
 	go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
 
-.PHONY: integration
+.PHONY: integration-boringcrypto
 integration-boringcrypto: integration/mock-service/.uptodate
 	GOEXPERIMENT=boringcrypto go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build-image: clean
 
 .PHONY: publish-images
 publish-images: clean
-	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
+	docker buildx build --push --platform linux/amd64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
 	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) .
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,6 @@ test-boringcrypto:
 integration: integration/mock-service/.uptodate
 	go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
 
-.PHONY: integration-boringcrypto
-integration-boringcrypto: integration/mock-service/.uptodate
-	GOEXPERIMENT=boringcrypto go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
-
 integration/mock-service/.uptodate:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' -o ./integration/mock-service/mock-service ./integration/mock-service
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t mock-service:latest -f ./integration/mock-service/Dockerfile ./integration/mock-service

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,11 @@ test-boringcrypto:
 
 .PHONY: integration
 integration: integration/mock-service/.uptodate
-	go test -v -tags requires_docker -count 1 -timeout 1m ./integration/...
+	go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
+
+.PHONY: integration-boringcrypto
+integration-boringcrypto: integration/mock-service/.uptodate
+	GOEXPERIMENT=boringcrypto go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
 
 integration/mock-service/.uptodate:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' -o ./integration/mock-service/mock-service ./integration/mock-service

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,7 @@ integration: integration/mock-service/.uptodate
 
 .PHONY: integration
 integration-boringcrypto: integration/mock-service/.uptodate
-	go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
-
+	GOEXPERIMENT=boringcrypto go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
 
 integration/mock-service/.uptodate:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' -o ./integration/mock-service/mock-service ./integration/mock-service

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,11 @@ GOARCH ?= $(shell go env GOARCH)
 DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune
 GO_FILES := $(shell find . $(DONT_FIND) -o -type f -name '*.go' -print)
 
+.PHONY: rollout-operator
 rollout-operator: $(GO_FILES)
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
+.PHONY: rollout-operator-boringcrypto
 rollout-operator-boringcrypto: $(GO_FILES)
 	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -tags netgo ./cmd/rollout-operator
 
@@ -20,6 +22,7 @@ rollout-operator-boringcrypto: $(GO_FILES)
 build-image: clean
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 
+.PHONY: build-image-boringcrypto
 build-image-boringcrypto: clean ## Build the rollout-operator image with boringcrypto and tag with the regular image repo, so that it can be used in integration tests.
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 
@@ -38,6 +41,7 @@ publish-boringcrypto-image: clean
 test:
 	go test ./...
 
+.PHONY: test-boringcrypto
 test-boringcrypto:
 	GOEXPERIMENT=boringcrypto go test ./...
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ rollout-operator-boringcrypto: $(GO_FILES)
 build-image: clean
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 
+.PHONY: build-image
+build-image-boringcrypto: clean
+	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
+
 .PHONY: publish-images
 publish-images: clean
 	docker buildx build --push --platform linux/amd64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
@@ -32,10 +36,14 @@ test:
 test-boringcrypto:
 	GOEXPERIMENT=boringcrypto go test ./...
 
-
 .PHONY: integration
 integration: integration/mock-service/.uptodate
 	go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
+
+.PHONY: integration
+integration-boringcrypto: integration/mock-service/.uptodate
+	go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
+
 
 integration/mock-service/.uptodate:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' -o ./integration/mock-service/mock-service ./integration/mock-service

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ rollout-operator: $(GO_FILES)
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
 rollout-operator-boringcrypto: $(GO_FILES)
-	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
+	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -ldflags '-extldflags "-static"' -trimpath -gcflags="all=-trimpath=/go" -asmflags="all=-trimpath=/go" ./cmd/rollout-operator
 
 .PHONY: build-image
 build-image: clean

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,14 @@ build-image-boringcrypto: clean ## Build the rollout-operator image with boringc
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 
 .PHONY: publish-images
-publish-images: clean
+publish-images: publish-standard-image publish-boringcrypto-image
+
+.PHONY: publish-standard image
+publish-standard-image: clean
 	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
+
+.PHONY: publish-boringcrypto-image
+publish-boringcrypto-image: clean
 	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) .
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Generate the default image tag based on the git branch and revision.
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 GIT_REVISION := $(shell git rev-parse --short HEAD)
-IMAGE_PREFIX ?= grafana
-IMAGE_TAG ?= $(GIT_BRANCH)-$(GIT_REVISION)
+IMAGE_PREFIX ?= us.gcr.io/kubernetes-dev
+IMAGE_TAG ?= $(subst /,-,$(GIT_BRANCH))-$(GIT_REVISION)
 
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
@@ -26,7 +26,7 @@ build-image-boringcrypto: clean ## Build the rollout-operator image with boringc
 .PHONY: publish-images
 publish-images: clean
 	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
-	docker buildx build --push --platform linux/amd64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) .
+	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) .
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,12 @@ rollout-operator-boringcrypto: $(GO_FILES)
 
 .PHONY: build-image
 build-image: clean
-	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
+	$(SUDO) docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 
 .PHONY: publish-images
 publish-images: clean
-	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
-	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) .
+	$(SUDO) docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) .
+	$(SUDO) docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ rollout-operator: $(GO_FILES)
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
 rollout-operator-boringcrypto: $(GO_FILES)
-	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
+	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -tags netgo -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
 .PHONY: build-image
 build-image: clean
@@ -37,11 +37,7 @@ test-boringcrypto:
 
 .PHONY: integration
 integration: integration/mock-service/.uptodate
-	go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
-
-.PHONY: integration-boringcrypto
-integration-boringcrypto: integration/mock-service/.uptodate
-	GOEXPERIMENT=boringcrypto go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
+	go test -v -tags requires_docker -count 1 -timeout 1m ./integration/...
 
 integration/mock-service/.uptodate:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' -o ./integration/mock-service/mock-service ./integration/mock-service

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ rollout-operator: $(GO_FILES)
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
 rollout-operator-boringcrypto: $(GO_FILES)
-	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -ldflags '-extldflags "-static"' -trimpath -gcflags="all=-trimpath=/go" -asmflags="all=-trimpath=/go" ./cmd/rollout-operator
+	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
 .PHONY: build-image
 build-image: clean

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ build-image-boringcrypto: clean ## Build the rollout-operator image with boringc
 
 .PHONY: publish-images
 publish-images: clean
-	docker buildx build --push --platform linux/amd64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
-	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) .
+	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
+	docker buildx build --push --platform linux/amd64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) .
 
 .PHONY: test
 test:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,5 +10,5 @@
     ```
 1. Publish the updated Docker image
     ```bash
-    $ IMAGE_TAG="${tag}" make publish-image
+    $ IMAGE_TAG="${tag}" make publish-images
     ```

--- a/cmd/rollout-operator/boringcrypto.go
+++ b/cmd/rollout-operator/boringcrypto.go
@@ -1,0 +1,6 @@
+//go:build boringcrypto
+// +build boringcrypto
+
+package main
+
+import _ "crypto/tls/fipsonly"

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -30,8 +30,6 @@ func requireEventuallyPod(t *testing.T, api *kubernetes.Clientset, ctx context.C
 		}
 		for _, test := range tests[ok:] {
 			if !test(t, pod) {
-				logsB, err := api.CoreV1().Pods(corev1.NamespaceDefault).GetLogs(podName, &corev1.PodLogOptions{}).Do(ctx).Raw()
-				t.Log("pod logs", podName, err, string(logsB))
 				return false
 			}
 			ok++
@@ -47,7 +45,7 @@ func expectPodPhase(expectedPhase corev1.PodPhase) func(t *testing.T, pod *corev
 			t.Logf("Pod %q phase is the expected %q", pod.Name, phase)
 			return true
 		}
-		t.Logf("Pod %q phase %q is not the expected %q. %s", pod.Name, phase, expectedPhase, pod.Status.String())
+		t.Logf("Pod %q phase %q is not the expected %q.", pod.Name, phase, expectedPhase)
 		return false
 	}
 }
@@ -90,7 +88,7 @@ func expectedPodReadyState(expectedReady bool) func(t *testing.T, pod *corev1.Po
 			t.Logf("Pod %s container %s is ready=%t as expected.", pod.Name, s.Name, s.Ready)
 			return true
 		}
-		t.Logf("Pod %s container %s is ready=%t, but expected %t. %s", pod.Name, s.Name, s.Ready, expectedReady, pod.Status.String())
+		t.Logf("Pod %s container %s is ready=%t, but expected %t.", pod.Name, s.Name, s.Ready, expectedReady)
 		return false
 	}
 }

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -30,6 +30,8 @@ func requireEventuallyPod(t *testing.T, api *kubernetes.Clientset, ctx context.C
 		}
 		for _, test := range tests[ok:] {
 			if !test(t, pod) {
+				logsB, err := api.CoreV1().Pods(corev1.NamespaceDefault).GetLogs(podName, &corev1.PodLogOptions{}).Do(ctx).Raw()
+				t.Log("pod logs", podName, err, string(logsB))
 				return false
 			}
 			ok++
@@ -45,7 +47,7 @@ func expectPodPhase(expectedPhase corev1.PodPhase) func(t *testing.T, pod *corev
 			t.Logf("Pod %q phase is the expected %q", pod.Name, phase)
 			return true
 		}
-		t.Logf("Pod %q phase %q is not the expected %q.", pod.Name, phase, expectedPhase)
+		t.Logf("Pod %q phase %q is not the expected %q. %s", pod.Name, phase, expectedPhase, pod.Status.String())
 		return false
 	}
 }
@@ -88,7 +90,7 @@ func expectedPodReadyState(expectedReady bool) func(t *testing.T, pod *corev1.Po
 			t.Logf("Pod %s container %s is ready=%t as expected.", pod.Name, s.Name, s.Ready)
 			return true
 		}
-		t.Logf("Pod %s container %s is ready=%t, but expected %t.", pod.Name, s.Name, s.Ready, expectedReady)
+		t.Logf("Pod %s container %s is ready=%t, but expected %t. %s", pod.Name, s.Name, s.Ready, expectedReady, pod.Status.String())
 		return false
 	}
 }


### PR DESCRIPTION
This adds a boringcrypto image 

* builds and pushes amd64/arm64 boringcrypto image upon `make publish-images`
	* images are pushed to `grafana/rollout-operator-boringcrypto` 
	* also build the binary in an alpine container as opposed to a Debian. This means that the binary is linked against musl instead of glibc and running alpine with glibc may come with problems
* runs unit and integration tests with boringcrypto
