### PR TITLE
release-0.6: Add boringcrypto image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20.4'
+          go-version: '1.20.5'
       - run: make rollout-operator
 
   test:
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20.4'
+          go-version: '1.20.5'
       - run: make test
       - run: make test-boringcrypto
 
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20.4'
+          go-version: '1.20.5'
       - run: make build-image
       - run: make integration
 
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.20.5'
           check-latest: true
       - run: make build-image-boringcrypto
       - run: make integration
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20.4'
+          go-version: '1.20.5'
       - uses: golangci/golangci-lint-action@v3
         with:
           args: --timeout=5m

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           go-version: '^1.20.4'
       - run: make test
+      - run: make test-boringcrypto
 
   integration:
     runs-on: ubuntu-latest
@@ -30,6 +31,17 @@ jobs:
         with:
           go-version: '^1.20.4'
       - run: make build-image
+      - run: make integration
+
+  integration-boringcrypto:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+          check-latest: true
+      - run: make build-image-boringcrypto
       - run: make integration
 
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+## v0.6.1
+
 * [FEATURE] Publish an additional boringcrypto image for linux/amd64,linux/arm64. #71
 
 ## v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [FEATURE] Publish an additional boringcrypto image for linux/amd64,linux/arm64. #71
+
 ## v0.6.0
 
 * [ENHANCEMENT] Update Go to `1.20.4`. #55

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM --platform=$BUILDPLATFORM golang:1.20.4-bullseye AS build
+FROM golang:1.20-alpine3.18 AS build
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG BUILDTARGET=rollout-operator
+
+RUN apk add --no-cache build-base git
 
 COPY . /src/rollout-operator
 WORKDIR /src/rollout-operator
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make ${BUILDTARGET}
 
 FROM alpine:3.18
 RUN apk add --no-cache ca-certificates

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,5 +10,5 @@
     ```
 1. Publish the updated Docker image
     ```bash
-    $ IMAGE_TAG="${tag}" make publish-image
+    $ IMAGE_TAG="${tag}" make publish-images
     ```

--- a/cmd/rollout-operator/boringcrypto.go
+++ b/cmd/rollout-operator/boringcrypto.go
@@ -1,0 +1,6 @@
+//go:build boringcrypto
+// +build boringcrypto
+
+package main
+
+import _ "crypto/tls/fipsonly"


### PR DESCRIPTION
This PR cherry-picks #71 onto 0.6.0

This also pins the go version so that CI can pass

After merging my plan is to
* open a PR against main to update the changelog for 0.6.1 https://github.com/grafana/rollout-operator/pull/74
* follow the release procedure on the `release-0.6` branch to release v0.6.1
