### PR TITLE
Update changelog for v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+## v0.7.0
+
 * [ENHANCEMENT] Updated dependencies, including: #70
   * `github.com/k3d-io/k3d/v5` from `v5.5.1` to `v5.5.2` 
   * `github.com/prometheus/client_golang` from `v1.15.1` to `v1.16.0`


### PR DESCRIPTION
Cuts v0.7.0.

Tested some rollouts locally and soaked a release candidate in a dev cell for a few days and nothing looks amiss.