### PR TITLE
Update Go to 1.21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - run: make rollout-operator
 
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - run: make test
       - run: make test-boringcrypto
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - run: make build-image
       - run: make integration
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - run: make build-image-boringcrypto
       - run: make integration
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: golangci/golangci-lint-action@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [ENHANCEMENT] Update Go to `1.21`. #77
+
 ## v0.7.0
 
 * [ENHANCEMENT] Updated dependencies, including: #70

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.18 AS build
+FROM golang:1.21-alpine3.18 AS build
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Updates the intermediate build container and CI to run on [Go 1.21](https://go.dev/doc/go1.21)