### PR TITLE
Update changelog for v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+## v0.8.0
+
 * [ENHANCEMENT] Update Go to `1.21`. #77
 * [ENHANCEMENT] Updated dependencies, including: #78
   * `github.com/k3d-io/k3d/v5` from `v5.5.2` to `v5.6.0` 


### PR DESCRIPTION
Marking the release of v0.8.0 in the changelog. The release candidate that was soaking looked good and testing rollouts locally also looked good.