### PR TITLE
prepare-downscale webhook should check for rollouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [ENHANCEMENT] Update the prepare-downscale webhook to check that a rollout is not in progress in the rollout-group, else deny.
+
 ## v0.8.0
 
 * [ENHANCEMENT] Update Go to `1.21`. #77

--- a/pkg/admission/prep_downscale.go
+++ b/pkg/admission/prep_downscale.go
@@ -164,20 +164,18 @@ func prepareDownscale(ctx context.Context, logger log.Logger, ar v1.AdmissionRev
 			)
 		}
 		if foundSts != nil {
-			level.Warn(logger).Log("msg", "downscale not allowed because another statefulset was downscaled recently", "err", err)
-			return deny(
-				"downscale of %s/%s in %s from %d to %d replicas is not allowed because statefulset %v was downscaled at %v and is labelled to wait %s between zone downscales",
-				ar.Request.Resource.Resource, ar.Request.Name, ar.Request.Namespace, *oldReplicas, *newReplicas, foundSts.name, foundSts.lastDownscaleTime, foundSts.waitTime,
-			)
+			msg := fmt.Sprintf("downscale of %s/%s in %s from %d to %d replicas is not allowed because statefulset %v was downscaled at %v and is labelled to wait %s between zone downscales",
+				ar.Request.Resource.Resource, ar.Request.Name, ar.Request.Namespace, *oldReplicas, *newReplicas, foundSts.name, foundSts.lastDownscaleTime, foundSts.waitTime)
+			level.Warn(logger).Log("msg", msg, "err", err)
+			return deny(msg)
 		}
 
 		foundSts = findStatefulSetWithNonUpdatedReplicas(ctx, api, ar.Request.Namespace, stsList)
 		if foundSts != nil {
-			level.Warn(logger).Log("msg", "downscale not allowed because another statefulset with non-updated replicas")
-			return deny(
-				"downscale of %s/%s in %s from %d to %d replicas is not allowed because statefulset %v has %d non-updated replicas and %d non-ready replicas",
-				ar.Request.Resource.Resource, ar.Request.Name, ar.Request.Namespace, *oldReplicas, *newReplicas, foundSts.name, foundSts.nonUpdatedReplicas, foundSts.nonReadyReplicas,
-			)
+			msg := fmt.Sprintf("downscale of %s/%s in %s from %d to %d replicas is not allowed because statefulset %v has %d non-updated replicas and %d non-ready replicas",
+				ar.Request.Resource.Resource, ar.Request.Name, ar.Request.Namespace, *oldReplicas, *newReplicas, foundSts.name, foundSts.nonUpdatedReplicas, foundSts.nonReadyReplicas)
+			level.Warn(logger).Log("msg", msg)
+			return deny(msg)
 		}
 	}
 

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -291,9 +291,10 @@ func TestFindStatefulSetWithNonUpdatedReplicas(t *testing.T) {
 	}
 	api := fake.NewSimpleClientset(objects...)
 
-	sts, err := findStatefulSetWithNonUpdatedReplicas(context.Background(), api, namespace, rolloutGroup)
+	stsList, err := findStatefulSetsForRolloutGroup(context.Background(), api, namespace, rolloutGroup)
+	sts := findStatefulSetWithNonUpdatedReplicas(stsList)
 	assert.Nil(t, err)
-	assert.NotNil(t, sts)
+	require.NotNil(t, sts)
 	assert.Equal(t, uint(4), sts.nonUpdatedReplicas)
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -23,6 +23,7 @@ import (
 	ktesting "k8s.io/client-go/testing"
 
 	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/util"
 )
 
 const (
@@ -71,14 +72,14 @@ func TestRolloutController_Reconcile(t *testing.T) {
 			},
 			pods: []runtime.Object{
 				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash, func(pod *corev1.Pod) {
-					pod.DeletionTimestamp = now()
+					pod.DeletionTimestamp = util.Now()
 				}),
 				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash, func(pod *corev1.Pod) {
-					pod.DeletionTimestamp = now()
+					pod.DeletionTimestamp = util.Now()
 				}),
 			},
 		},
@@ -94,7 +95,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 				mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash, func(pod *corev1.Pod) {
-					pod.DeletionTimestamp = now()
+					pod.DeletionTimestamp = util.Now()
 				}),
 			},
 		},
@@ -182,7 +183,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 			},
 			pods: []runtime.Object{
 				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash, func(pod *corev1.Pod) {
-					pod.DeletionTimestamp = now()
+					pod.DeletionTimestamp = util.Now()
 				}),
 				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
@@ -233,7 +234,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 				mockStatefulSetPod("ingester-zone-a-0", testLastRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-1", testLastRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-2", testLastRevisionHash, func(pod *corev1.Pod) {
-					pod.DeletionTimestamp = now()
+					pod.DeletionTimestamp = util.Now()
 				}),
 				mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,4 +1,4 @@
-package controller
+package util
 
 import (
 	"sort"
@@ -6,27 +6,28 @@ import (
 	"github.com/facette/natsort"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 )
 
-// sortStatefulSets sorts in-place the provided slice of StatefulSet.
-func sortStatefulSets(sets []*v1.StatefulSet) {
+// SortStatefulSets sorts in-place the provided slice of StatefulSet.
+func SortStatefulSets(sets []*v1.StatefulSet) {
 	sort.Slice(sets, func(i, j int) bool {
 		return sets[i].Name < sets[j].Name
 	})
 }
 
-// sortPods sorts in-place the provided slice of Pod. Pod names are sorted
+// SortPods sorts in-place the provided slice of Pod. Pod names are sorted
 // in natural order in order to play nicely with StatefulSet naming schema.
-func sortPods(pods []*corev1.Pod) {
+func SortPods(pods []*corev1.Pod) {
 	sort.Slice(pods, func(i, j int) bool {
 		return natsort.Compare(pods[i].Name, pods[j].Name)
 	})
 }
 
-// podNames returns the names of input pods.
-func podNames(pods []*corev1.Pod) []string {
+// PodNames returns the names of input pods.
+func PodNames(pods []*corev1.Pod) []string {
 	names := make([]string, 0, len(pods))
 	for _, pod := range pods {
 		names = append(names, pod.Name)
@@ -34,8 +35,8 @@ func podNames(pods []*corev1.Pod) []string {
 	return names
 }
 
-// isPodRunningAndReady returns whether the input pod is running and ready.
-func isPodRunningAndReady(pod *corev1.Pod) bool {
+// IsPodRunningAndReady returns whether the input pod is running and ready.
+func IsPodRunningAndReady(pod *corev1.Pod) bool {
 	// The pod phase must be "running".
 	if pod.Status.Phase != corev1.PodRunning {
 		return false
@@ -58,9 +59,9 @@ func isPodRunningAndReady(pod *corev1.Pod) bool {
 	return true
 }
 
-// moveStatefulSetToFront returns a new slice where the input StatefulSet toMove is moved
+// MoveStatefulSetToFront returns a new slice where the input StatefulSet toMove is moved
 // at the beginning. Comparison is done via pointer equality.
-func moveStatefulSetToFront(sets []*v1.StatefulSet, toMove *v1.StatefulSet) []*v1.StatefulSet {
+func MoveStatefulSetToFront(sets []*v1.StatefulSet, toMove *v1.StatefulSet) []*v1.StatefulSet {
 	out := make([]*v1.StatefulSet, 0, len(sets)+1)
 	out = append(out, toMove)
 
@@ -73,9 +74,9 @@ func moveStatefulSetToFront(sets []*v1.StatefulSet, toMove *v1.StatefulSet) []*v
 	return out
 }
 
-// groupStatefulSetsByLabel returns a map containing the input StatefulSets grouped by
+// GroupStatefulSetsByLabel returns a map containing the input StatefulSets grouped by
 // the input label's value.
-func groupStatefulSetsByLabel(sets []*v1.StatefulSet, label string) map[string][]*v1.StatefulSet {
+func GroupStatefulSetsByLabel(sets []*v1.StatefulSet, label string) map[string][]*v1.StatefulSet {
 	groups := make(map[string][]*v1.StatefulSet)
 
 	for _, sts := range sets {
@@ -86,10 +87,10 @@ func groupStatefulSetsByLabel(sets []*v1.StatefulSet, label string) map[string][
 	return groups
 }
 
-// mustNewLabelsRequirement wraps labels.NewRequirement() and panics on error.
+// MustNewLabelsRequirement wraps labels.NewRequirement() and panics on error.
 // This utility function can be safely used whenever the input is deterministic
 // (eg. based on hard-coded config).
-func mustNewLabelsRequirement(key string, op selection.Operator, vals []string) labels.Requirement {
+func MustNewLabelsRequirement(key string, op selection.Operator, vals []string) labels.Requirement {
 	req, err := labels.NewRequirement(key, op, vals)
 	if err != nil {
 		panic(err)
@@ -97,22 +98,7 @@ func mustNewLabelsRequirement(key string, op selection.Operator, vals []string) 
 	return *req
 }
 
-func max(value int, others ...int) int {
-	for _, other := range others {
-		if other > value {
-			value = other
-		}
-	}
-
-	return value
-}
-
-func min(value int, others ...int) int {
-	for _, other := range others {
-		if other < value {
-			value = other
-		}
-	}
-
-	return value
+func Now() *metav1.Time {
+	ts := metav1.Now()
+	return &ts
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,4 +1,4 @@
-package controller
+package util
 
 import (
 	"testing"
@@ -24,7 +24,7 @@ func TestSortStatefulSets(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-c"}},
 	}
 
-	sortStatefulSets(input)
+	SortStatefulSets(input)
 	assert.Equal(t, expected, input)
 }
 
@@ -45,7 +45,7 @@ func TestSortPods(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "ingester-20"}},
 	}
 
-	sortPods(input)
+	SortPods(input)
 	assert.Equal(t, expected, input)
 }
 
@@ -56,7 +56,7 @@ func TestPodNames(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "ingester-10"}},
 	}
 
-	assert.Equal(t, []string{"ingester-11", "ingester-0", "ingester-10"}, podNames(input))
+	assert.Equal(t, []string{"ingester-11", "ingester-0", "ingester-10"}, PodNames(input))
 }
 
 func TestIsPodRunningAndReady(t *testing.T) {
@@ -120,7 +120,7 @@ func TestIsPodRunningAndReady(t *testing.T) {
 		"should return false if the pod is terminating": {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					DeletionTimestamp: now(),
+					DeletionTimestamp: Now(),
 				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
@@ -137,7 +137,7 @@ func TestIsPodRunningAndReady(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			assert.Equal(t, testData.expected, isPodRunningAndReady(testData.pod))
+			assert.Equal(t, testData.expected, IsPodRunningAndReady(testData.pod))
 		})
 	}
 }
@@ -155,7 +155,7 @@ func TestMoveStatefulSetToFront(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-c"}},
 	}
 
-	actual := moveStatefulSetToFront(input, input[1])
+	actual := MoveStatefulSetToFront(input, input[1])
 	assert.Equal(t, expected, actual)
 }
 
@@ -182,7 +182,7 @@ func TestGroupStatefulSetsByLabel(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, expected, groupStatefulSetsByLabel(input, config.RolloutGroupLabelKey))
+	assert.Equal(t, expected, GroupStatefulSetsByLabel(input, config.RolloutGroupLabelKey))
 }
 
 func TestMax(t *testing.T) {
@@ -193,9 +193,4 @@ func TestMax(t *testing.T) {
 func TestMin(t *testing.T) {
 	assert.Equal(t, 1, min(1))
 	assert.Equal(t, 3, min(4, 3, 5))
-}
-
-func now() *metav1.Time {
-	ts := metav1.Now()
-	return &ts
 }


### PR DESCRIPTION
This PR updates the prepare-downscale webhook to check for rollouts that are in progress in the rollout-group, by comparing the statefulset's Status.UpdatedReplicas to the number of ready and running pods in the group.

This PR also:
- Moves some of the util functions that were in the controller package to a separate util package for access by webhooks.
- Removes the unused min/max functions, since these are built-ins in go 1.21

Fixes #79