### PR TITLE
WIP: use the downscale time stored in ingester/prepare_shutdown

### DIFF
--- a/pkg/admission/prep_downscale.go
+++ b/pkg/admission/prep_downscale.go
@@ -298,8 +298,12 @@ func findDownscalesDoneMinTimeAgo(ctx context.Context, logger log.Logger, api ku
 			return nil, err
 		}
 
+		// The ingester will return either `unset` or `set <timestamp>`
 		splits := strings.SplitN(string(bts), " ", 2)
 		if len(splits) != 2 {
+			if len(splits) == 1 && splits[0] == "unset" {
+				return nil, nil
+			}
 			level.Error(logger).Log("msg", "error splitting body of HTTP get request", "err", err, "body", string(bts))
 			return nil, fmt.Errorf("error splitting body (%v) of HTTP get request: %w", string(bts), err)
 		}

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -261,7 +261,7 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 	}
 	timestamp := time.Now()
 	if params.downscaleInProgress {
-		timestamp = timestamp.Add(-15 * time.Hour)
+		timestamp = timestamp.Add(-5 * time.Hour)
 	}
 	api := fake.NewSimpleClientset(objects...)
 	f := &fakeHttpClient{

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -63,7 +63,6 @@ func newDebugLogger() log.Logger {
 
 type testParams struct {
 	statusCode          int
-	stsAnnotated        bool
 	downscaleInProgress bool
 	allowed             bool
 	dryRun              bool
@@ -76,7 +75,6 @@ func withStatusCode(statusCode int) optionFunc {
 		tp.statusCode = statusCode
 		if tp.statusCode/100 != 2 {
 			tp.allowed = false
-			tp.stsAnnotated = false
 		}
 	}
 }
@@ -84,16 +82,13 @@ func withStatusCode(statusCode int) optionFunc {
 func withDryRun() optionFunc {
 	return func(tp *testParams) {
 		tp.dryRun = true
-		tp.stsAnnotated = false
 	}
 }
 
 func withDownscaleInProgress(inProgress bool) optionFunc {
 	return func(tp *testParams) {
-		tp.stsAnnotated = true
 		tp.allowed = true
 		if inProgress {
-			tp.stsAnnotated = false
 			tp.allowed = false
 		}
 		tp.downscaleInProgress = inProgress
@@ -117,7 +112,7 @@ type fakeHttpClient struct {
 func (f *fakeHttpClient) Post(url, contentType string, body io.Reader) (resp *http.Response, err error) {
 	return &http.Response{
 		StatusCode: f.statusCode,
-		Body:       io.NopCloser(bytes.NewBuffer([]byte("set "))),
+		Body:       io.NopCloser(bytes.NewBuffer([]byte("set"))),
 	}, nil
 }
 
@@ -131,7 +126,6 @@ func (f *fakeHttpClient) Get(url string) (resp *http.Response, err error) {
 func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, options ...optionFunc) {
 	params := testParams{
 		statusCode:          http.StatusOK,
-		stsAnnotated:        false,
 		downscaleInProgress: false,
 		allowed:             true,
 		dryRun:              false,

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -378,4 +378,18 @@ func TestChangedEndpoints(t *testing.T) {
 		require.Equal(t, endpoints[1].url, "ingester-zone-a-1.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown")
 		require.Equal(t, endpoints[2].url, "ingester-zone-a-0.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown?unset=true")
 	})
+
+	t.Run("", func(t *testing.T) {
+		endpoints := changedEndpoints(2, 2, 3, ar, stsName, port, path)
+		require.Len(t, endpoints, 2)
+		require.Equal(t, endpoints[0].url, "ingester-zone-a-1.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown")
+		require.Equal(t, endpoints[1].url, "ingester-zone-a-0.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown")
+	})
+
+	t.Run("", func(t *testing.T) {
+		endpoints := changedEndpoints(2, 3, 3, ar, stsName, port, path)
+		require.Len(t, endpoints, 2)
+		require.Equal(t, endpoints[0].url, "ingester-zone-a-1.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown")
+		require.Equal(t, endpoints[1].url, "ingester-zone-a-0.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown")
+	})
 }

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -356,18 +356,26 @@ func TestChangedEndpoints(t *testing.T) {
 	t.Run("", func(t *testing.T) {
 		endpoints := changedEndpoints(5, 3, 2, ar, stsName, port, path)
 		require.Len(t, endpoints, 5)
-		require.NotContains(t, endpoints[0].url, "?unset=true")
-		require.NotContains(t, endpoints[1].url, "?unset=true")
-		require.NotContains(t, endpoints[2].url, "?unset=true")
-		require.Contains(t, endpoints[3].url, "?unset=true")
-		require.Contains(t, endpoints[4].url, "?unset=true")
+		require.Equal(t, endpoints[0].url, "ingester-zone-a-4.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown")
+		require.Equal(t, endpoints[1].url, "ingester-zone-a-3.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown")
+		require.Equal(t, endpoints[2].url, "ingester-zone-a-2.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown")
+		require.Equal(t, endpoints[3].url, "ingester-zone-a-1.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown?unset=true")
+		require.Equal(t, endpoints[4].url, "ingester-zone-a-0.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown?unset=true")
 	})
 
 	t.Run("", func(t *testing.T) {
 		endpoints := changedEndpoints(3, 1, 3, ar, stsName, port, path)
 		require.Len(t, endpoints, 3)
-		require.NotContains(t, endpoints[0].url, "?unset=true")
-		require.Contains(t, endpoints[1].url, "?unset=true")
-		require.Contains(t, endpoints[2].url, "?unset=true")
+		require.Equal(t, endpoints[0].url, "ingester-zone-a-2.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown")
+		require.Equal(t, endpoints[1].url, "ingester-zone-a-1.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown?unset=true")
+		require.Equal(t, endpoints[2].url, "ingester-zone-a-0.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown?unset=true")
+	})
+
+	t.Run("", func(t *testing.T) {
+		endpoints := changedEndpoints(3, 2, 3, ar, stsName, port, path)
+		require.Len(t, endpoints, 3)
+		require.Equal(t, endpoints[0].url, "ingester-zone-a-2.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown")
+		require.Equal(t, endpoints[1].url, "ingester-zone-a-1.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown")
+		require.Equal(t, endpoints[2].url, "ingester-zone-a-0.ingester-zone-a.loki-prod.svc.cluster.local:8080//ingester/prepare_shutdown?unset=true")
 	})
 }


### PR DESCRIPTION
Read the last downscale time from the `ingester/prepare_shutdown` endpoint and use that to determine if a rollout should go ahead.