### PR TITLE
Do not exit reconciliation if scaling errors

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -242,7 +242,7 @@ func (c *RolloutController) reconcileStatefulSetsGroup(ctx context.Context, grou
 	// up-to-date.
 	if updated, err := c.adjustStatefulSetsGroupReplicas(ctx, groupName, sets); updated || err != nil {
 		if err != nil {
-			return fmt.Errorf("unable to adjust desired replicas of StatefulSet in group %s: %w", groupName, err)
+			level.Warn(c.logger).Log("msg", "unable to adjust desired replicas of StatefulSet", "group", groupName, "err", err)
 		}
 
 		return nil

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -240,11 +240,11 @@ func (c *RolloutController) reconcileStatefulSetsGroup(ctx context.Context, grou
 	// Adjust the number of replicas for each StatefulSet in the group if desired. If the number of
 	// replicas of any StatefulSet was adjusted, return early in order to guarantee each STS model is
 	// up-to-date.
-	if updated, err := c.adjustStatefulSetsGroupReplicas(ctx, groupName, sets); updated || err != nil {
-		if err != nil {
-			level.Warn(c.logger).Log("msg", "unable to adjust desired replicas of StatefulSet", "group", groupName, "err", err)
-		}
-
+	updated, err := c.adjustStatefulSetsGroupReplicas(ctx, groupName, sets)
+	if err != nil {
+		level.Warn(c.logger).Log("msg", "unable to adjust desired replicas of StatefulSet", "group", groupName, "err", err)
+	}
+	if updated {
 		return nil
 	}
 


### PR DESCRIPTION
Following #82, downscaling attempts are prevented in a zone if some other zone has non-ready pods. One situation where this could happen is if zone-C is rolling around the same time that zone-A starts experiencing evictions. In this case, zone C may also want to downscale some nodes, but is unable to because zone A has non-ready nodes, and since reconciliation exits when downscaling fails, zone C can't finish rolling its pods either.

This change allows reconciliation to continue even if scaling fails, so that updates may proceed.