### PR TITLE
Don't end reconciliation early if the StatefulSet patch failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main / unreleased
 
+## v0.8.3
+
+* [BUGFIX] Do not exit reconciliation early if there are errors while trying to adjust the number of replicas. #92
+
 ## v0.8.2
 
 * [BUGFIX] Do not exit reconciliation early if there are errors while trying to adjust the number of replicas. #90

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -244,7 +244,7 @@ func (c *RolloutController) reconcileStatefulSetsGroup(ctx context.Context, grou
 	if err != nil {
 		level.Warn(c.logger).Log("msg", "unable to adjust desired replicas of StatefulSet", "group", groupName, "err", err)
 	}
-	if updated {
+	if err == nil && updated {
 		level.Debug(c.logger).Log("msg", "ending reconcile early due to updated StatefulSet replicas", "group", groupName)
 		return nil
 	}
@@ -327,7 +327,12 @@ func (c *RolloutController) adjustStatefulSetsGroupReplicas(ctx context.Context,
 
 			patch := fmt.Sprintf(`{"spec":{"replicas":%d}}`, desiredReplicas)
 			_, err = c.kubeClient.AppsV1().StatefulSets(c.namespace).Patch(ctx, sts.GetName(), types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
-			return true, err
+			if err != nil {
+				// If the patch failed, don't consider the statefulsets changed
+				return false, err
+			}
+
+			return true, nil
 		} else if desiredReplicas < currentReplicas {
 			level.Info(c.logger).Log(
 				"msg", "scaling down statefulset to match leader",

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -37,6 +38,9 @@ func TestRolloutController_Reconcile(t *testing.T) {
 	tests := map[string]struct {
 		statefulSets        []runtime.Object
 		pods                []runtime.Object
+		kubePatchErr        error
+		kubeDeleteErr       error
+		kubeUpdateErr       error
 		expectedDeletedPods []string
 		expectedUpdatedSets []string
 		expectedPatchedSets []string
@@ -311,15 +315,43 @@ func TestRolloutController_Reconcile(t *testing.T) {
 			},
 			expectedPatchedSets: []string{"ingester-zone-b"},
 		},
+		"should not return early and should delete pods if StatefulSet replicas cannot be adjusted": {
+			statefulSets: []runtime.Object{
+				mockStatefulSet("ingester-zone-a", withReplicas(2, 2), withLabels(map[string]string{
+					"grafana.com/min-time-between-zones-downscale": "12h",
+				})),
+				mockStatefulSet("ingester-zone-b", withReplicas(3, 3), withPrevRevision(),
+					withLabels(map[string]string{
+						"grafana.com/min-time-between-zones-downscale": "12h",
+					}),
+					withAnnotations(map[string]string{
+						"grafana.com/rollout-downscale-leader": "ingester-zone-a",
+					}),
+				),
+			},
+			pods: []runtime.Object{
+				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-b-0", testLastRevisionHash),
+				mockStatefulSetPod("ingester-zone-b-1", testLastRevisionHash),
+				mockStatefulSetPod("ingester-zone-b-2", testLastRevisionHash),
+			},
+			kubePatchErr:        errors.New("cannot patch StatefulSet right now"),
+			expectedDeletedPods: []string{"ingester-zone-a-0", "ingester-zone-a-1"},
+		},
 	}
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			kubeClient := fake.NewSimpleClientset(append(testData.statefulSets, testData.pods...)...)
 
-			// Inject an hook to track all deleted pods.
+			// Inject an hook to track all deleted pods or return mocked errors.
 			var deletedPods []string
 			kubeClient.PrependReactor("delete", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				if testData.kubeDeleteErr != nil {
+					return true, nil, testData.kubeDeleteErr
+				}
+
 				switch action.GetResource().Resource {
 				case "pods":
 					deletedPods = append(deletedPods, action.(ktesting.DeleteAction).GetName())
@@ -328,11 +360,15 @@ func TestRolloutController_Reconcile(t *testing.T) {
 				return false, nil, nil
 			})
 
-			// Inject a hook to track all updated StatefulSets.
+			// Inject a hook to track all updated StatefulSets or return mocked errors.
 			var updatedSets []*v1.StatefulSet
 			var updatedStsNames []string
 
 			kubeClient.PrependReactor("update", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				if testData.kubeUpdateErr != nil {
+					return true, nil, testData.kubeUpdateErr
+				}
+
 				switch action.GetResource().Resource {
 				case "statefulsets":
 					sts := action.(ktesting.UpdateAction).GetObject().(*v1.StatefulSet)
@@ -344,10 +380,14 @@ func TestRolloutController_Reconcile(t *testing.T) {
 				return false, nil, nil
 			})
 
-			// Inject a hook to track all patched StatefulSets.
+			// Inject a hook to track all patched StatefulSets or return mocked errors.
 			var patchedStsNames []string
 
 			kubeClient.PrependReactor("patch", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				if testData.kubePatchErr != nil {
+					return true, nil, testData.kubePatchErr
+				}
+
 				switch action.GetResource().Resource {
 				case "statefulsets":
 					name := action.(ktesting.PatchAction).GetName()


### PR DESCRIPTION
Fixes an issue where reconciliation aborted even if the scale down of an STS was denied.