### PR TITLE
Change default make target and expand make help documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ build-image: clean ## Build the rollout-operator image
 
 .PHONY: build-image-boringcrypto
 build-image-boringcrypto: clean ## Build the rollout-operator image with boringcrypto 
-  # Tags with the regular image repo for integration testing
+	# Tags with the regular image repo for integration testing
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 
 .PHONY: publish-images

--- a/Makefile
+++ b/Makefile
@@ -10,37 +10,38 @@ GOARCH ?= $(shell go env GOARCH)
 DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune
 GO_FILES := $(shell find . $(DONT_FIND) -o -type f -name '*.go' -print)
 
-.DEFAULT_GOAL := help
+.DEFAULT_GOAL := rollout-operator
 
 # Adapted from https://www.thapaliya.com/en/writings/well-documented-makefiles/
 .PHONY: help
 help: ## Display this help and any documented user-facing targets
-	@awk 'BEGIN {FS = ": ##"; printf "Usage:\n  make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\.\-\/%]+: ##/ { printf "  %-45s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\.\-\/%]+:.*?##/ { printf "  %-45s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-rollout-operator: $(GO_FILES)
+rollout-operator: $(GO_FILES) ## Build the rollout-operator binary
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
 .PHONY: rollout-operator-boringcrypto
-rollout-operator-boringcrypto: $(GO_FILES)
+rollout-operator-boringcrypto: $(GO_FILES) ## Build the rollout-operator binary with boringcrypto
 	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -tags netgo ./cmd/rollout-operator
 
-.PHONY: build-image ## Build a rollout-operator image
-build-image: clean
+.PHONY: build-image 
+build-image: clean ## Build the rollout-operator image
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 
 .PHONY: build-image-boringcrypto
-build-image-boringcrypto: clean ## Build the rollout-operator image with boringcrypto and tag with the regular image repo, so that it can be used in integration tests.
+build-image-boringcrypto: clean ## Build the rollout-operator image with boringcrypto 
+  # Tags with the regular image repo for integration testing
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 
 .PHONY: publish-images
-publish-images: publish-standard-image publish-boringcrypto-image
+publish-images: publish-standard-image publish-boringcrypto-image ## Build and publish both the standard and boringcrypto images
 
 .PHONY: publish-standard-image
-publish-standard-image: clean
+publish-standard-image: clean ## Build and publish only the standard rollout-operator image
 	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
 
 .PHONY: publish-boringcrypto-image
-publish-boringcrypto-image: clean
+publish-boringcrypto-image: clean ## Build and publish only the boring-crypto rollout-operator image
 	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) .
 
 .PHONY: test
@@ -48,7 +49,7 @@ test: ## Run tests
 	go test ./...
 
 .PHONY: test-boringcrypto
-test-boringcrypto:
+test-boringcrypto: ## Run tests with GOEXPERIMENT=boringcrypto
 	GOEXPERIMENT=boringcrypto go test ./...
 
 .PHONY: integration
@@ -65,6 +66,6 @@ lint: ## Run golangci-lint
 	golangci-lint run --timeout=5m
 
 .PHONY: clean
-clean: ## Run go clean and remove the rollout-operator
+clean: ## Run go clean and remove the rollout-operator binary
 	rm -f rollout-operator
 	go clean ./...

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Generate the default image tag based on the git branch and revision.
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 GIT_REVISION := $(shell git rev-parse --short HEAD)
+
 IMAGE_PREFIX ?= grafana
 IMAGE_TAG ?= $(subst /,-,$(GIT_BRANCH))-$(GIT_REVISION)
 


### PR DESCRIPTION
Builds off of the changes made in #86.
 
This changes the default goal (only running `make`) back to building the binary. It was changed to help before, but having to type `make rollout-operator` is a bit rough. I kept the `help` target at the top of the Makefile to keep the discoverability of the option since it is nice.

I also modified the `awk` command used in the help target to allow documenting the options with dependencies and then documented them. `make help` now prints:
```
Usage:
  make <target>

Targets:
  help                                           Display this help and any documented user-facing targets
  rollout-operator                               Build the rollout-operator binary
  rollout-operator-boringcrypto                  Build the rollout-operator binary with boringcrypto
  build-image                                    Build the rollout-operator image
  build-image-boringcrypto                       Build the rollout-operator image with boringcrypto
  publish-images                                 Build and publish both the standard and boringcrypto images
  publish-standard-image                         Build and publish only the standard rollout-operator image
  publish-boringcrypto-image                     Build and publish only the boring-crypto rollout-operator image
  test                                           Run tests
  test-boringcrypto                              Run tests with GOEXPERIMENT=boringcrypto
  integration                                    Run integration tests
  lint                                           Run golangci-lint
  clean                                          Run go clean and remove the rollout-operator binary
  ```