### PR TITLE
prepare-downscale: exclude pods in the same zone when finding unavailable pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [ENHANCEMENT] Proceed with prepare-downscale operation even when pods from zone being downscaled are not ready or not up to date. #99
+
 ## v0.9.0
 
 * [ENHANCEMENT] Updated dependencies, including: #93

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -313,10 +313,41 @@ func TestFindStatefulSetWithNonUpdatedReplicas(t *testing.T) {
 	api := fake.NewSimpleClientset(objects...)
 
 	stsList, err := findStatefulSetsForRolloutGroup(context.Background(), api, namespace, rolloutGroup)
-	sts := findStatefulSetWithNonUpdatedReplicas(context.Background(), api, namespace, stsList)
+	sts := findStatefulSetWithNonUpdatedReplicas(context.Background(), api, namespace, stsList, stsMeta.Name)
 	assert.Nil(t, err)
 	require.NotNil(t, sts)
 	assert.Equal(t, sts.name, "zone-b")
+}
+
+func TestFindStatefulSetWithNonUpdatedReplicas_UnavailableReplicasSameZone(t *testing.T) {
+	namespace := "test"
+	rolloutGroup := "ingester"
+	labels := map[string]string{config.RolloutGroupLabelKey: rolloutGroup, "name": "zone-a"}
+	stsMeta := metav1.ObjectMeta{
+		Name:      "zone-a",
+		Namespace: namespace,
+		Labels:    labels,
+	}
+	objects := []runtime.Object{
+		&apps.StatefulSet{
+			ObjectMeta: stsMeta,
+			Spec: apps.StatefulSetSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: stsMeta,
+				},
+			},
+			Status: apps.StatefulSetStatus{
+				Replicas:        1,
+				UpdatedReplicas: 0,
+			},
+		},
+	}
+	api := fake.NewSimpleClientset(objects...)
+
+	stsList, err := findStatefulSetsForRolloutGroup(context.Background(), api, namespace, rolloutGroup)
+	sts := findStatefulSetWithNonUpdatedReplicas(context.Background(), api, namespace, stsList, stsMeta.Name)
+	assert.Nil(t, err)
+	require.Nil(t, sts)
 }
 
 func TestFindPodsForStatefulSet(t *testing.T) {


### PR DESCRIPTION
Having unavailable or not up to date pods in the same zone we're trying to scale down shouldn't really stop us from downscaling the zone.