### PR TITLE
Fix: do not allow downscale if the operator failed to check whether there are StatefulSets with non-updated replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [BUGFIX] Do not allow downscale if the operator failed to check whether there are StatefulSets with non-updated replicas. #105
+
 ## v0.10.0
 
 * [ENHANCEMENT] Proceed with prepare-downscale operation even when pods from zone being downscaled are not ready or not up to date. #99

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -313,8 +313,10 @@ func TestFindStatefulSetWithNonUpdatedReplicas(t *testing.T) {
 	api := fake.NewSimpleClientset(objects...)
 
 	stsList, err := findStatefulSetsForRolloutGroup(context.Background(), api, namespace, rolloutGroup)
-	sts := findStatefulSetWithNonUpdatedReplicas(context.Background(), api, namespace, stsList, stsMeta.Name)
-	assert.Nil(t, err)
+	require.NoError(t, err)
+
+	sts, err := findStatefulSetWithNonUpdatedReplicas(context.Background(), api, namespace, stsList, stsMeta.Name)
+	require.NoError(t, err)
 	require.NotNil(t, sts)
 	assert.Equal(t, sts.name, "zone-b")
 }
@@ -345,8 +347,10 @@ func TestFindStatefulSetWithNonUpdatedReplicas_UnavailableReplicasSameZone(t *te
 	api := fake.NewSimpleClientset(objects...)
 
 	stsList, err := findStatefulSetsForRolloutGroup(context.Background(), api, namespace, rolloutGroup)
-	sts := findStatefulSetWithNonUpdatedReplicas(context.Background(), api, namespace, stsList, stsMeta.Name)
-	assert.Nil(t, err)
+	require.NoError(t, err)
+
+	sts, err := findStatefulSetWithNonUpdatedReplicas(context.Background(), api, namespace, stsList, stsMeta.Name)
+	require.NoError(t, err)
 	require.Nil(t, sts)
 }
 


### PR DESCRIPTION
The error returned by `countRunningAndReadyPods()` is swallowed but shouldn't.