### PR TITLE
Cut v0.10.1 in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+## v0.10.1
+
 * [BUGFIX] Do not allow downscale if the operator failed to check whether there are StatefulSets with non-updated replicas. #105
 
 ## v0.10.0


### PR DESCRIPTION
Cutting the 2nd release of the day, to include https://github.com/grafana/rollout-operator/pull/105