### PR TITLE
Add build target which creates debug image

### DIFF
--- a/Dockerfile.delve
+++ b/Dockerfile.delve
@@ -8,7 +8,7 @@ RUN apk add --no-cache build-base git
 
 COPY . /src/rollout-operator
 WORKDIR /src/rollout-operator
-RUN go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@v1.21.2
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.2
 RUN /go/bin/dlv -h
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make ${BUILDTARGET}
 

--- a/Dockerfile.delve
+++ b/Dockerfile.delve
@@ -1,0 +1,30 @@
+FROM golang:1.21-alpine3.18 AS build
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG BUILDTARGET=rollout-operator-debug
+
+RUN apk add --no-cache build-base git
+
+COPY . /src/rollout-operator
+WORKDIR /src/rollout-operator
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.2
+RUN /go/bin/dlv -h
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make ${BUILDTARGET}
+
+FROM alpine:3.18
+RUN apk add --no-cache ca-certificates
+
+COPY --from=build /go/bin/dlv /bin/dlv
+COPY --from=build /src/rollout-operator/rollout-operator /bin/rollout-operator
+ENTRYPOINT [ "/usr/bin/dlv", "--headless=true", "--listen=:49988", "--api-version=2", "--accept-multiclient", "exec", "/bin/rollout-operator" ]
+
+# Create rollout-operator user to run as non-root.
+RUN addgroup -g 10000 -S rollout-operator && \
+    adduser  -u 10000 -S rollout-operator -G rollout-operator
+USER rollout-operator:rollout-operator
+
+ARG revision
+LABEL org.opencontainers.image.title="rollout-operator" \
+    org.opencontainers.image.source="https://github.com/grafana/rollout-operator" \
+    org.opencontainers.image.revision="${revision}"

--- a/Dockerfile.delve
+++ b/Dockerfile.delve
@@ -25,6 +25,6 @@ RUN addgroup -g 10000 -S rollout-operator && \
 USER rollout-operator:rollout-operator
 
 ARG revision
-LABEL org.opencontainers.image.title="rollout-operator" \
+LABEL org.opencontainers.image.title="rollout-operator-debug" \
     org.opencontainers.image.source="https://github.com/grafana/rollout-operator" \
     org.opencontainers.image.revision="${revision}"

--- a/Dockerfile.delve
+++ b/Dockerfile.delve
@@ -17,7 +17,7 @@ RUN apk add --no-cache ca-certificates
 
 COPY --from=build /go/bin/dlv /bin/dlv
 COPY --from=build /src/rollout-operator/rollout-operator /bin/rollout-operator
-ENTRYPOINT [ "/usr/bin/dlv", "--headless=true", "--listen=:49988", "--api-version=2", "--accept-multiclient", "exec", "/bin/rollout-operator" ]
+ENTRYPOINT [ "/bin/dlv", "--headless=true", "--listen=:49988", "--api-version=2", "--accept-multiclient", "exec", "/bin/rollout-operator" ]
 
 # Create rollout-operator user to run as non-root.
 RUN addgroup -g 10000 -S rollout-operator && \

--- a/Dockerfile.delve
+++ b/Dockerfile.delve
@@ -17,7 +17,7 @@ RUN apk add --no-cache ca-certificates
 
 COPY --from=build /go/bin/dlv /bin/dlv
 COPY --from=build /src/rollout-operator/rollout-operator /bin/rollout-operator
-ENTRYPOINT [ "/bin/dlv", "--headless=true", "--listen=:49988", "--api-version=2", "--accept-multiclient", "exec", "/bin/rollout-operator" ]
+ENTRYPOINT [ "/bin/dlv", "--headless=true", "--listen=:49988", "--api-version=2", "--accept-multiclient", "exec", "/bin/rollout-operator" , "--continue", "--"]
 
 # Create rollout-operator user to run as non-root.
 RUN addgroup -g 10000 -S rollout-operator && \

--- a/Dockerfile.delve
+++ b/Dockerfile.delve
@@ -8,7 +8,7 @@ RUN apk add --no-cache build-base git
 
 COPY . /src/rollout-operator
 WORKDIR /src/rollout-operator
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.2
+RUN go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@v1.21.2
 RUN /go/bin/dlv -h
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make ${BUILDTARGET}
 

--- a/Dockerfile.delve
+++ b/Dockerfile.delve
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine3.18 AS build
+FROM golang:1.21-alpine3.19 AS build
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -12,7 +12,7 @@ RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.2
 RUN /go/bin/dlv -h
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make ${BUILDTARGET}
 
-FROM alpine:3.18
+FROM alpine:3.19
 RUN apk add --no-cache ca-certificates
 
 COPY --from=build /go/bin/dlv /bin/dlv

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ publish-images: publish-standard-image publish-boringcrypto-image ## Build and p
 publish-standard-image: clean ## Build and publish only the standard rollout-operator image
 	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
 
+.PHONY: publish-debug-image
+publish-debug-image: clean
+	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-debug -t rollout-operator-debug:latest -t rollout-operator-debug:$(IMAGE_TAG) -f Dockerfile.delve .
+
 .PHONY: publish-boringcrypto-image
 publish-boringcrypto-image: clean ## Build and publish only the boring-crypto rollout-operator image
 	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) .

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ publish-standard-image: clean ## Build and publish only the standard rollout-ope
 
 .PHONY: publish-debug-image
 publish-debug-image: clean
-	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-debug -t $(IMAGE_PREFIX)/rollout-operator-debug:latest -t $(IMAGE_PREFIX)/rollout-operator-debug:$(IMAGE_TAG) -f Dockerfile.delve .
+	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-debug -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG)-debug -f Dockerfile.delve .
 
 .PHONY: publish-boringcrypto-image
 publish-boringcrypto-image: clean ## Build and publish only the boring-crypto rollout-operator image

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ help: ## Display this help and any documented user-facing targets
 rollout-operator: $(GO_FILES) ## Build the rollout-operator binary
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
+rollout-operator-debug: $(GO_FILES)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
+
 .PHONY: rollout-operator-boringcrypto
 rollout-operator-boringcrypto: $(GO_FILES) ## Build the rollout-operator binary with boringcrypto
 	GOEXPERIMENT=boringcrypto GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -tags netgo ./cmd/rollout-operator
@@ -28,6 +31,10 @@ rollout-operator-boringcrypto: $(GO_FILES) ## Build the rollout-operator binary 
 .PHONY: build-image 
 build-image: clean ## Build the rollout-operator image
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
+
+.PHONY: build-debug-image ## Build a rollout-operator image running in delve
+build-debug-image: clean
+	docker buildx build --load --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) -f Dockerfile.delve .
 
 .PHONY: build-image-boringcrypto
 build-image-boringcrypto: clean ## Build the rollout-operator image with boringcrypto 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ rollout-operator: $(GO_FILES) ## Build the rollout-operator binary
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
 rollout-operator-debug: $(GO_FILES)
-	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build  -gcflags "all=-N -l" -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
 .PHONY: rollout-operator-boringcrypto
 rollout-operator-boringcrypto: $(GO_FILES) ## Build the rollout-operator binary with boringcrypto

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ publish-standard-image: clean ## Build and publish only the standard rollout-ope
 
 .PHONY: publish-debug-image
 publish-debug-image: clean
-	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-debug -t rollout-operator-debug:latest -t rollout-operator-debug:$(IMAGE_TAG) -f Dockerfile.delve .
+	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BUILDTARGET=rollout-operator-debug -t $(IMAGE_PREFIX)/rollout-operator-debug:latest -t $(IMAGE_PREFIX)/rollout-operator-debug:$(IMAGE_TAG) -f Dockerfile.delve .
 
 .PHONY: publish-boringcrypto-image
 publish-boringcrypto-image: clean ## Build and publish only the boring-crypto rollout-operator image

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ help: ## Display this help and any documented user-facing targets
 rollout-operator: $(GO_FILES) ## Build the rollout-operator binary
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
-rollout-operator-debug: $(GO_FILES)
+rollout-operator-debug: $(GO_FILES) ## Build the rollout-operator binary without optimizations
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build  -gcflags "all=-N -l" -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
 .PHONY: rollout-operator-boringcrypto
@@ -32,7 +32,7 @@ rollout-operator-boringcrypto: $(GO_FILES) ## Build the rollout-operator binary 
 build-image: clean ## Build the rollout-operator image
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 
-.PHONY: build-debug-image ## Build a rollout-operator image running in delve
+.PHONY: build-debug-image ## Build a rollout-operator debug image running in delve
 build-debug-image: clean
 	docker buildx build --load --platform linux/arm64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) -f Dockerfile.delve .
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build-image: clean ## Build the rollout-operator image
 
 .PHONY: build-debug-image ## Build a rollout-operator image running in delve
 build-debug-image: clean
-	docker buildx build --load --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) -f Dockerfile.delve .
+	docker buildx build --load --platform linux/arm64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) -f Dockerfile.delve .
 
 .PHONY: build-image-boringcrypto
 build-image-boringcrypto: clean ## Build the rollout-operator image with boringcrypto 


### PR DESCRIPTION
To build the debug image the binary gets compiled without optimizations and with debug symbols, the binary gets started in Delve. This allows a user to attach a remote debugger to the running process.