### PR TITLE
Improve tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [FEATURE] Coordinate downscaling between zones with a ConfigMap instead of annotation, optionally, via the new zoneTracker for the prepare-downscale admission webhook. #107
 * [ENHANCEMENT] Expose pprof endpoint for profiling. #109
 * [ENHANCEMENT] Change Docker build image to `golang:1.21-bookworm` and update base image to `alpine:3.19`. #97
-* [ENHANCEMENT] Add basic tracing support. #101 #114
+* [ENHANCEMENT] Add basic tracing support. #101 #114 #115
 * [ENHANCEMENT] Updated dependencies, including: #111
   * `github.com/gorilla/mux` from `v1.8.0` to `v1.8.1`
   * `github.com/prometheus/client_golang` from `v1.17.0` to `v1.18.0`

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
 	github.com/go-kit/log v0.2.1
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20240108174153-a150e79e4581
+	github.com/grafana/dskit v0.0.0-20240112005349-f30e65d9dee2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/k3d-io/k3d/v5 v5.6.0
 	github.com/opentracing-contrib/go-stdlib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/grafana/dskit v0.0.0-20240108174153-a150e79e4581 h1:m8XnBonHhjenIYLI4cJmTxTAuVlmt0xeiKz6p39sl6Q=
-github.com/grafana/dskit v0.0.0-20240108174153-a150e79e4581/go.mod h1:kkWM4WUV230bNG3urVRWPBnSJHs64y/0RmWjftnnn0c=
+github.com/grafana/dskit v0.0.0-20240112005349-f30e65d9dee2 h1:ozlFUa4X7SzBwvQqnUXIqF991P2afWR2G221y75vJyc=
+github.com/grafana/dskit v0.0.0-20240112005349-f30e65d9dee2/go.mod h1:kkWM4WUV230bNG3urVRWPBnSJHs64y/0RmWjftnnn0c=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/vendor/github.com/grafana/dskit/spanlogger/spanlogger.go
+++ b/vendor/github.com/grafana/dskit/spanlogger/spanlogger.go
@@ -167,3 +167,17 @@ func (s *SpanLogger) getLogger() log.Logger {
 	}
 	return logger
 }
+
+// SetSpanAndLogTag sets a tag on the span used by this SpanLogger, and appends a key/value pair to the logger used for
+// future log lines emitted by this SpanLogger.
+//
+// It is not safe to call this method from multiple goroutines simultaneously.
+// It is safe to call this method at the same time as calling other SpanLogger methods, however, this may produce
+// inconsistent results (eg. some log lines may be emitted with the provided key/value pair, and others may not).
+func (s *SpanLogger) SetSpanAndLogTag(key string, value interface{}) {
+	s.Span.SetTag(key, value)
+
+	logger := s.getLogger()
+	wrappedLogger := log.With(logger, key, value)
+	s.logger.Store(&wrappedLogger)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -243,7 +243,7 @@ github.com/google/uuid
 # github.com/gorilla/mux v1.8.1
 ## explicit; go 1.20
 github.com/gorilla/mux
-# github.com/grafana/dskit v0.0.0-20240108174153-a150e79e4581
+# github.com/grafana/dskit v0.0.0-20240112005349-f30e65d9dee2
 ## explicit; go 1.20
 github.com/grafana/dskit/grpcutil
 github.com/grafana/dskit/httpgrpc


### PR DESCRIPTION
This PR improves on the tracing introduced in #114.

In particular:

* it uses the `SetSpanAndLogTag` method introduced in https://github.com/grafana/dskit/pull/467 to simplify the code (see https://github.com/grafana/rollout-operator/pull/114#discussion_r1448257480 for discussion)
* it adds tracing to `zoneTracker`, which was introduced in #107 