### PR TITLE
Support for delay between call to prepare-downscale and actual downscale.

### DIFF
--- a/pkg/admission/prep_downscale.go
+++ b/pkg/admission/prep_downscale.go
@@ -81,8 +81,7 @@ func prepareDownscale(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 	logger.SetSpanAndLogTag("object.new_replicas", int32PtrStr(newInfo.replicas))
 
 	// Continue if it's a downscale
-	_, response := checkReplicasChange(logger, oldInfo, newInfo)
-	if response != nil {
+	if _, response := checkReplicasChange(logger, oldInfo, newInfo); response != nil {
 		// TODO: if newReplicas (first returned value from checkReplicasChange) >= 0, and some pods in replica set (up to newReplicas) have "prepared-for-downscale" annotation set, we will call DELETE on prepare-for-downscale URL.
 		return response
 	}
@@ -188,7 +187,7 @@ func prepareDownscale(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 		// or delay since the maximum hasn't been reached yet, we deny the downscale.
 		resp := checkPrepareDownscaleMinDelayBeforeShutdown(ctx, logger, eps, api, prepareDownscaleMinDelayBeforeShutdown, ar.Request.Resource.Resource, ar.Request.Name, ar.Request.Namespace)
 		if resp != nil {
-			return response
+			return resp
 		}
 	}
 
@@ -210,7 +209,7 @@ func prepareDownscale(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 	}
 }
 
-func checkPrepareDownscaleMinDelayBeforeShutdown(ctx context.Context, logger log.Logger, eps []endpoint, api kubernetes.Interface, minDelay time.Duration, resourceType, resourceName, namespace string) interface{} {
+func checkPrepareDownscaleMinDelayBeforeShutdown(ctx context.Context, logger log.Logger, eps []endpoint, api kubernetes.Interface, minDelay time.Duration, resourceType, resourceName, namespace string) *v1.AdmissionResponse {
 	if len(eps) == 0 {
 		return nil
 	}

--- a/pkg/admission/prep_downscale.go
+++ b/pkg/admission/prep_downscale.go
@@ -124,11 +124,11 @@ func prepareDownscale(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 
 	prepareDownscaleMinDelayBeforeShutdown := time.Duration(0)
 	{
-		delayStr := annotations[config.PrepareDownscaleMinDelayBeforeShutdown]
+		delayStr := annotations[config.PrepareDownscaleMinDelayBeforeShutdownAnnotationKey]
 		if delayStr != "" {
 			parsedDelay, err := model.ParseDuration(delayStr)
 			if err != nil {
-				level.Warn(logger).Log("msg", fmt.Sprintf("ignoring misconfigured %v annotation that cannot be parsed as duration", config.PrepareDownscaleMinDelayBeforeShutdown), "err", err)
+				level.Warn(logger).Log("msg", fmt.Sprintf("ignoring misconfigured %v annotation that cannot be parsed as duration", config.PrepareDownscaleMinDelayBeforeShutdownAnnotationKey), "err", err)
 				// TODO: shall we abort downscale in this case?
 			} else {
 				prepareDownscaleMinDelayBeforeShutdown = time.Duration(parsedDelay)
@@ -326,7 +326,7 @@ func checkPrepareDownscaleMinDelayBeforeShutdown(ctx context.Context, logger log
 		t, err := getLastPrepareDownscaleAnnotationOnPod(ctx, api, ep.namespace, ep.podName)
 		if err != nil {
 			level.Error(logger).Log("msg", fmt.Sprintf("failed to check %s annotation on pod", config.LastPrepareDownscaleAnnotationKey), "pod", ep.podName, "err", err)
-			return deny(fmt.Sprintf("downscale of %s/%s in %s not allowed, as %s cannot be verified for pod %s", resourceType, resourceName, namespace, config.PrepareDownscaleMinDelayBeforeShutdown, ep.podName))
+			return deny(fmt.Sprintf("downscale of %s/%s in %s not allowed, as %s cannot be verified for pod %s", resourceType, resourceName, namespace, config.PrepareDownscaleMinDelayBeforeShutdownAnnotationKey, ep.podName))
 		}
 
 		if t.IsZero() {
@@ -341,11 +341,11 @@ func checkPrepareDownscaleMinDelayBeforeShutdown(ctx context.Context, logger log
 
 	elapsedSinceMaxTime := time.Since(maxTime)
 	if elapsedSinceMaxTime < minDelay {
-		level.Warn(logger).Log("msg", fmt.Sprintf("%s has not been reached for all pods yet, rejecting downscale", config.PrepareDownscaleMinDelayBeforeShutdown), "minDelay", minDelay, "elapsed", elapsedSinceMaxTime)
+		level.Warn(logger).Log("msg", fmt.Sprintf("%s has not been reached for all pods yet, rejecting downscale", config.PrepareDownscaleMinDelayBeforeShutdownAnnotationKey), "minDelay", minDelay, "elapsed", elapsedSinceMaxTime)
 		return deny(fmt.Sprintf("downscale of %s/%s in %s not allowed, as %s has not been reached for all pods. elapsed time: %v", resourceType, resourceName, namespace, config.MinTimeBetweenZonesDownscaleLabelKey, elapsedSinceMaxTime))
 	}
 
-	level.Info(logger).Log("msg", fmt.Sprintf("%s has been reached for all pods, allowing downscale", config.PrepareDownscaleMinDelayBeforeShutdown), "minDelay", minDelay, "elapsed", elapsedSinceMaxTime)
+	level.Info(logger).Log("msg", fmt.Sprintf("%s has been reached for all pods, allowing downscale", config.PrepareDownscaleMinDelayBeforeShutdownAnnotationKey), "minDelay", minDelay, "elapsed", elapsedSinceMaxTime)
 	return nil
 }
 

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -101,6 +101,13 @@ func TestUpscaleWithLastPreparedPodsTimeWithDeletionEnabled(t *testing.T) {
 	testPrepDownscaleWebhookWithZoneTracker(t, 2, 5) // TODO: feature not implemented for zone-tracker.
 }
 
+func TestUpscaleWithLastPreparedPodsTimeWithDeletionDisabled(t *testing.T) {
+	ts := time.Now().Add(-1 * time.Hour).UTC()
+
+	testPrepDownscaleWebhook(t, 2, 5, withLastPreparedPodsTime(ts.Format(time.RFC3339)), withDeletePrepareDownscaleEnabled("false"), withCheckLastPreparedPodsTimeIsCleared(ts.Format(time.RFC3339)))
+	testPrepDownscaleWebhookWithZoneTracker(t, 2, 5) // TODO: feature not implemented for zone-tracker.
+}
+
 func newDebugLogger() log.Logger {
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	var options []level.Option
@@ -262,9 +269,9 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 	}
 
 	if params.deletePrepareDownscaleEnabled != "" {
-		oldParams.DeleteDownscaleEndpointKey = config.PrepareDownscaleDeleteEnabledLabelKey
+		oldParams.DeleteDownscaleEndpointKey = config.PrepareDownscaleDeleteEnabledAnnotationKey
 		oldParams.DeleteDownscaleEndpointValue = params.deletePrepareDownscaleEnabled
-		newParams.DeleteDownscaleEndpointKey = config.PrepareDownscaleDeleteEnabledLabelKey
+		newParams.DeleteDownscaleEndpointKey = config.PrepareDownscaleDeleteEnabledAnnotationKey
 		newParams.DeleteDownscaleEndpointValue = params.deletePrepareDownscaleEnabled
 	}
 

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -262,9 +262,9 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 	}
 
 	if params.minDelayBeforeShutdown != "" {
-		oldParams.MinDelayBeforeShutdownKey = config.PrepareDownscaleMinDelayBeforeShutdown
+		oldParams.MinDelayBeforeShutdownKey = config.PrepareDownscaleMinDelayBeforeShutdownAnnotationKey
 		oldParams.MinDelayBeforeShutdownValue = params.minDelayBeforeShutdown
-		newParams.MinDelayBeforeShutdownKey = config.PrepareDownscaleMinDelayBeforeShutdown
+		newParams.MinDelayBeforeShutdownKey = config.PrepareDownscaleMinDelayBeforeShutdownAnnotationKey
 		newParams.MinDelayBeforeShutdownValue = params.minDelayBeforeShutdown
 	}
 

--- a/pkg/admission/zone_tracker.go
+++ b/pkg/admission/zone_tracker.go
@@ -132,7 +132,7 @@ func (zt *zoneTracker) prepareDownscale(ctx context.Context, l log.Logger, ar v1
 
 	// Since it's a downscale, check if the resource has the label that indicates it needs to be prepared to be downscaled.
 	// Create a slice of endpoint addresses for pods to send HTTP post requests to and to fail if any don't return 200
-	eps := createEndpoints(ar, oldInfo, newInfo, port, path)
+	eps := createPrepareDownscaleEndpointsFromAdmissionReview(ar, oldInfo, newInfo, port, path)
 
 	err = sendPrepareShutdownRequests(ctx, logger, client, eps, false, api)
 	if err != nil {

--- a/pkg/admission/zone_tracker.go
+++ b/pkg/admission/zone_tracker.go
@@ -134,7 +134,7 @@ func (zt *zoneTracker) prepareDownscale(ctx context.Context, l log.Logger, ar v1
 	// Create a slice of endpoint addresses for pods to send HTTP post requests to and to fail if any don't return 200
 	eps := createEndpoints(ar, oldInfo, newInfo, port, path)
 
-	err = sendPrepareShutdownRequests(ctx, logger, client, eps)
+	err = sendPrepareShutdownRequests(ctx, logger, client, eps, false, api)
 	if err != nil {
 		// Down-scale operation is disallowed because a pod failed to prepare for shutdown and cannot be deleted
 		level.Error(logger).Log("msg", "downscale not allowed due to error", "err", err)

--- a/pkg/admission/zone_tracker.go
+++ b/pkg/admission/zone_tracker.go
@@ -14,11 +14,12 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/grafana/rollout-operator/pkg/config"
 	v1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/rollout-operator/pkg/config"
 )
 
 type zoneTracker struct {
@@ -61,7 +62,7 @@ func (zt *zoneTracker) prepareDownscale(ctx context.Context, l log.Logger, ar v1
 	logger.SetSpanAndLogTag("object.new_replicas", int32PtrStr(newInfo.replicas))
 
 	// Continue if it's a downscale
-	response := checkReplicasChange(logger, oldInfo, newInfo)
+	_, response := checkReplicasChange(logger, oldInfo, newInfo)
 	if response != nil {
 		return response
 	}

--- a/pkg/admission/zone_tracker_test.go
+++ b/pkg/admission/zone_tracker_test.go
@@ -3,16 +3,16 @@ package admission
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/grafana/rollout-operator/pkg/config"
 	apps "k8s.io/api/apps/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/grafana/rollout-operator/pkg/config"
 )
 
 func TestZoneTracker(t *testing.T) {
@@ -281,7 +281,6 @@ func TestLastDownscaledNonExistentZone(t *testing.T) {
 	zt := newZoneTracker(client, "testnamespace", "testconfigmap")
 
 	time, _ := zt.lastDownscaled("nonexistentzone")
-	fmt.Printf("time: %v\n", time)
 	if time != "" {
 		t.Errorf("lastDownscaled did not handle non-existent zone correctly")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,9 +20,9 @@ const (
 	PrepareDownscaleLabelKey   = "grafana.com/prepare-downscale"
 	PrepareDownscaleLabelValue = "true"
 
-	// PrepareDownscaleMinDelayBeforeShutdown is minimum duration between call to prepare-downscale endpoint, and when downscale is actually
+	// PrepareDownscaleMinDelayBeforeShutdownAnnotationKey is minimum duration between call to prepare-downscale endpoint, and when downscale is actually
 	// performed.
-	PrepareDownscaleMinDelayBeforeShutdown = "grafana.com/prepare-downscale-min-delay-before-shutdown"
+	PrepareDownscaleMinDelayBeforeShutdownAnnotationKey = "grafana.com/prepare-downscale-min-delay-before-shutdown"
 	// LastPrepareDownscaleAnnotationKey is a timestamp when prepare-downscale was called last time on the pod. (UTC, time.RFC3339 format)
 	LastPrepareDownscaleAnnotationKey = "grafana.com/last-prepare-downscale"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,11 @@ const (
 	// LastPrepareDownscaleAnnotationKey is a timestamp when prepare-downscale was called last time on the pod. (UTC, time.RFC3339 format)
 	LastPrepareDownscaleAnnotationKey = "grafana.com/last-prepare-downscale"
 
+	// PrepareDownscaleDeleteEnabledLabelKey is boolean option that enables calling "DELETE /prepare-downscale"
+	// when dowscale is canceled during "min delay" period.
+	PrepareDownscaleDeleteEnabledLabelKey   = "grafana.com/delete-prepare-downscale-enabled"
+	PrepareDownscaleDeleteEnabledLabelValue = "true"
+
 	// RolloutGroupLabelKey is the group to which multiple statefulsets belong and must be operated on together.
 	RolloutGroupLabelKey = "rollout-group"
 	// RolloutMaxUnavailableAnnotationKey is the max number of pods in each statefulset that may be stopped at

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,10 +26,10 @@ const (
 	// LastPrepareDownscaleAnnotationKey is a timestamp when prepare-downscale was called last time on the pod. (UTC, time.RFC3339 format)
 	LastPrepareDownscaleAnnotationKey = "grafana.com/last-prepare-downscale"
 
-	// PrepareDownscaleDeleteEnabledLabelKey is boolean option that enables calling "DELETE /prepare-downscale"
+	// PrepareDownscaleDeleteEnabledAnnotationKey is boolean option that enables calling "DELETE /prepare-downscale"
 	// when dowscale is canceled during "min delay" period.
-	PrepareDownscaleDeleteEnabledLabelKey   = "grafana.com/delete-prepare-downscale-enabled"
-	PrepareDownscaleDeleteEnabledLabelValue = "true"
+	PrepareDownscaleDeleteEnabledAnnotationKey   = "grafana.com/delete-prepare-downscale-enabled"
+	PrepareDownscaleDeleteEnabledAnnotationValue = "true"
 
 	// RolloutGroupLabelKey is the group to which multiple statefulsets belong and must be operated on together.
 	RolloutGroupLabelKey = "rollout-group"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,12 @@ const (
 	PrepareDownscaleLabelKey   = "grafana.com/prepare-downscale"
 	PrepareDownscaleLabelValue = "true"
 
+	// PrepareDownscaleMinDelayBeforeShutdown is minimum duration between call to prepare-downscale endpoint, and when downscale is actually
+	// performed.
+	PrepareDownscaleMinDelayBeforeShutdown = "grafana.com/prepare-downscale-min-delay-before-shutdown"
+	// LastPrepareDownscaleAnnotationKey is a timestamp when prepare-downscale was called last time on the pod. (UTC, time.RFC3339 format)
+	LastPrepareDownscaleAnnotationKey = "grafana.com/last-prepare-downscale"
+
 	// RolloutGroupLabelKey is the group to which multiple statefulsets belong and must be operated on together.
 	RolloutGroupLabelKey = "rollout-group"
 	// RolloutMaxUnavailableAnnotationKey is the max number of pods in each statefulset that may be stopped at


### PR DESCRIPTION
We plan to run new ingesters with delay between prepare-downscale and actual downscale. During this delay, ingesters will keep running, but will not receive any new data.

Timestamp of prepare-downscale call is recorded as Pod annotation.

After delay elapses (checked as max recorded timestamp in pod annotations), rollout operator's admission controller allows final downscale.

User can cancel the downscale during this delay, and scale up again. In that case rollout operator can be configured to call `DELETE` on prepare-downscale endpoint.

(draft, doing manual testing)