### PR TITLE
Reduce cardinality of metrics emitted for requests to the Kubernetes control plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main / unreleased
 
-* [ENHANCEMENT] Add metrics for Kubernetes control plane calls. #118
+* [ENHANCEMENT] Add metrics for Kubernetes control plane calls. #118 #123
 
 ## v0.11.0
 

--- a/pkg/instrumentation/kubernetes_api_client_test.go
+++ b/pkg/instrumentation/kubernetes_api_client_test.go
@@ -1,0 +1,49 @@
+package instrumentation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestURLExtraction(t *testing.T) {
+	testCases := map[string]string{
+		// Cluster-wide core objects
+		"/api/v1/nodes":                    "core/v1/nodes collection",
+		"/api/v1/nodes/the-node":           "core/v1/nodes object",
+		"/api/v1/nodes/the-node/status":    "core/v1/nodes object status subresource",
+		"/api/v1/namespaces":               "core/v1/namespaces collection",
+		"/api/v1/namespaces/the-namespace": "core/v1/namespaces object",
+		// Namespaced core objects
+		"/api/v1/namespaces/the-namespace/pods":                "core/v1/pods collection",
+		"/api/v1/namespaces/the-namespace/pods/the-pod":        "core/v1/pods object",
+		"/api/v1/namespaces/the-namespace/pods/the-pod/status": "core/v1/pods object status subresource",
+		// Cluster-wide non-core objects
+		"/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations":                   "admissionregistration.k8s.io/v1/validatingwebhookconfigurations collection",
+		"/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations/the-config":        "admissionregistration.k8s.io/v1/validatingwebhookconfigurations object",
+		"/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations/the-config/status": "admissionregistration.k8s.io/v1/validatingwebhookconfigurations object status subresource",
+		// Namespaced non-core objects
+		"/apis/apps/v1/namespaces/the-namespace/statefulsets":                        "apps/v1/statefulsets collection",
+		"/apis/apps/v1/namespaces/the-namespace/statefulsets/the-statefulset":        "apps/v1/statefulsets object",
+		"/apis/apps/v1/namespaces/the-namespace/statefulsets/the-statefulset/status": "apps/v1/statefulsets object status subresource",
+
+		// Invalid paths
+		// These cases should never happen given we're using the official client library and it always uses the expected format, but we
+		// should still do something sensible if these do happen.
+		"":                "",
+		"/":               "/",
+		"/something-else": "/something-else",
+		"/api":            "/api",
+		"/api/v1":         "/api/v1",
+		"/apis":           "/apis",
+		"/apis/apps":      "/apis/apps",
+		"/apis/apps/v1":   "/apis/apps/v1",
+	}
+
+	for input, expectedDescription := range testCases {
+		t.Run(input, func(t *testing.T) {
+			actualDescription := urlToResourceDescription(input)
+			require.Equal(t, expectedDescription, actualDescription)
+		})
+	}
+}


### PR DESCRIPTION
The metrics added in #118 turned out to produce many more series than expected (see [discussion here](https://github.com/grafana/rollout-operator/pull/118#discussion_r1451928924) - I missed the pod deletion behaviour in my testing).

For example, in a very small Mimir development cluster with 2 compactors, 9 store-gateways and 21 ingesters, the rollout-operator was emitting 44 unique `method` / `path` combinations after a rollout:

```
DELETE /api/v1/namespaces/the-namespace/pods/compactor-0
DELETE /api/v1/namespaces/the-namespace/pods/compactor-1
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-a-0
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-a-1
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-a-2
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-a-3
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-a-4
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-a-5
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-a-6
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-b-0
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-b-1
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-b-2
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-b-3
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-b-4
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-b-5
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-b-6
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-c-0
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-c-1
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-c-2
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-c-3
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-c-4
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-c-5
DELETE /api/v1/namespaces/the-namespace/pods/ingester-zone-c-6
DELETE /api/v1/namespaces/the-namespace/pods/store-gateway-zone-a-0
DELETE /api/v1/namespaces/the-namespace/pods/store-gateway-zone-a-1
DELETE /api/v1/namespaces/the-namespace/pods/store-gateway-zone-a-2
DELETE /api/v1/namespaces/the-namespace/pods/store-gateway-zone-b-0
DELETE /api/v1/namespaces/the-namespace/pods/store-gateway-zone-b-1
DELETE /api/v1/namespaces/the-namespace/pods/store-gateway-zone-b-2
DELETE /api/v1/namespaces/the-namespace/pods/store-gateway-zone-c-0
DELETE /api/v1/namespaces/the-namespace/pods/store-gateway-zone-c-1
DELETE /api/v1/namespaces/the-namespace/pods/store-gateway-zone-c-2
GET /api/v1/namespaces/the-namespace/pods
GET /api/v1/namespaces/the-namespace/secrets/rollout-operator-self-signed-certificate
GET /apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations
GET /apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations
GET /apis/apps/v1/namespaces/the-namespace/statefulsets
PUT /apis/apps/v1/namespaces/the-namespace/statefulsets/compactor/status
PUT /apis/apps/v1/namespaces/the-namespace/statefulsets/ingester-zone-a/status
PUT /apis/apps/v1/namespaces/the-namespace/statefulsets/ingester-zone-b/status
PUT /apis/apps/v1/namespaces/the-namespace/statefulsets/ingester-zone-c/status
PUT /apis/apps/v1/namespaces/the-namespace/statefulsets/store-gateway-zone-a/status
PUT /apis/apps/v1/namespaces/the-namespace/statefulsets/store-gateway-zone-b/status
PUT /apis/apps/v1/namespaces/the-namespace/statefulsets/store-gateway-zone-c/status
```

Each of these combinations emits a classic histogram with 17 series each, for a total of 748 series.

It's not uncommon to run clusters with hundreds of ingesters and store-gateways, so this is not sustainable, and it's not necessary either - we're most interested in understanding the performance of a particular kind of request, not the performance of requests for a single specific object.

This PR reduces the cardinality of metrics emitted by grouping equivalent requests together. For example, all pod delete requests would be emitted with `path="core/v1/pods object"`.

The Kubernetes API follows a fairly rigid pattern for URLs, documented [here](https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-uris), so the changes in this PR use that pattern to parse the URL and format it for the metric label.