### PR TITLE
Cut changelog for v0.12 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+## v0.12.0
+
 * [ENHANCEMENT] Add metrics for Kubernetes control plane calls. #118 #123
 
 ## v0.11.0


### PR DESCRIPTION
This is the first step to creating a new release, according to the instructions in https://github.com/grafana/rollout-operator/blob/main/RELEASE.md.