### PR TITLE
Prepare delayed downscale

### DIFF
--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -171,7 +171,7 @@ func main() {
 	maybeStartTLSServer(cfg, logger, kubeClient, restart, metrics)
 
 	// Init the controller.
-	c := controller.NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, cfg.kubeNamespace, cfg.reconcileInterval, reg, logger)
+	c := controller.NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, cfg.kubeNamespace, httpClient, cfg.reconcileInterval, reg, logger)
 	check(errors.Wrap(c.Init(), "failed to init controller"))
 
 	// Listen to sigterm, as well as for restart (like for certificate renewal).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,4 +35,10 @@ const (
 	RolloutMirrorReplicasFromResourceNameAnnotationKey       = rolloutMirrorReplicasFromResourceAnnotationKeyPrefix + "-name"
 	RolloutMirrorReplicasFromResourceKindAnnotationKey       = rolloutMirrorReplicasFromResourceAnnotationKeyPrefix + "-kind"
 	RolloutMirrorReplicasFromResourceAPIVersionAnnotationKey = rolloutMirrorReplicasFromResourceAnnotationKeyPrefix + "-api-version" // optional
+
+	// RolloutDelayedDownscaleAnnotationKey configures delay for downscaling. Prepare-url must be configured as well, and must support GET, POST and DELETE methods.
+	RolloutDelayedDownscaleAnnotationKey = "grafana.com/rollout-delayed-downscale"
+
+	// RolloutDelayedDownscalePrepareUrlAnnotationKey is a full URL to prepare-downscale endpoint. Hostname will be replaced with pod's fully qualified domain name.
+	RolloutDelayedDownscalePrepareUrlAnnotationKey = "grafana.com/rollout-prepare-delayed-downscale-url"
 )

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -535,7 +535,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 			})
 
 			patchedStatefulSets := addPatchStatefulsetReactor(kubeClient, testData.kubePatchErr)
-			scaleClient := createScaleClient(testData.customResourceScaleSpecReplicas, testData.customResourceScaleStatusReplicas, testData.getScaleErr)
+			scaleClient := createFakeScaleClient(testData.customResourceScaleSpecReplicas, testData.customResourceScaleStatusReplicas, testData.getScaleErr)
 			dynamicClient, patchedStatuses := createFakeDynamicClient()
 
 			// Create the controller and start informers.
@@ -617,18 +617,18 @@ func TestRolloutController_ReconcileStatefulsetWithDownscaleDelay(t *testing.T) 
 					withDelayedDownscaleAnnotations(time.Hour, "http://pod/prepare-delayed-downscale")),
 			},
 			httpResponses: map[string]httpResponse{
-				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
-				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
+				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
+				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
 			},
 			customResourceScaleSpecReplicas:   3, // We want to downscale to 3 replicas only.
 			customResourceScaleStatusReplicas: 5,
 
 			expectedHttpRequests: []string{
-				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
 			},
 
 			expectedPatchedSets: map[string][]string{"ingester-zone-b": {`{"spec":{"replicas":3}}`}}, // This is the downscale!
@@ -641,17 +641,17 @@ func TestRolloutController_ReconcileStatefulsetWithDownscaleDelay(t *testing.T) 
 					withDelayedDownscaleAnnotations(time.Hour, "http://pod/prepare-delayed-downscale")),
 			},
 			httpResponses: map[string]httpResponse{
-				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-30*time.Minute).Unix())},
-				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Unix())},
+				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-30*time.Minute).Unix())},
+				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Unix())},
 			},
 			customResourceScaleSpecReplicas:   3, // We want to downscale to 3 replicas only.
 			customResourceScaleStatusReplicas: 5,
 			expectedHttpRequests: []string{
-				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
 			},
 		},
 
@@ -662,17 +662,17 @@ func TestRolloutController_ReconcileStatefulsetWithDownscaleDelay(t *testing.T) 
 					withDelayedDownscaleAnnotations(time.Hour, "http://pod/prepare-delayed-downscale")),
 			},
 			httpResponses: map[string]httpResponse{
-				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
-				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Unix())},
+				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
+				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Unix())},
 			},
 			customResourceScaleSpecReplicas:   3, // We want to downscale to 3 replicas only.
 			customResourceScaleStatusReplicas: 5,
 			expectedHttpRequests: []string{
-				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
 			},
 		},
 
@@ -683,17 +683,17 @@ func TestRolloutController_ReconcileStatefulsetWithDownscaleDelay(t *testing.T) 
 					withDelayedDownscaleAnnotations(time.Hour, "http://pod/prepare-delayed-downscale")),
 			},
 			httpResponses: map[string]httpResponse{
-				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 500, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
-				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 500, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
+				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 500, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
+				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 500, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
 			},
 			customResourceScaleSpecReplicas:   3, // We want to downscale to 3 replicas only.
 			customResourceScaleStatusReplicas: 5,
 			expectedHttpRequests: []string{
-				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
 			},
 		},
 
@@ -704,17 +704,17 @@ func TestRolloutController_ReconcileStatefulsetWithDownscaleDelay(t *testing.T) 
 					withDelayedDownscaleAnnotations(time.Hour, "http://pod/prepare-delayed-downscale")),
 			},
 			httpResponses: map[string]httpResponse{
-				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {err: fmt.Errorf("network is down"), body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
-				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
+				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {err: fmt.Errorf("network is down"), body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
+				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
 			},
 			customResourceScaleSpecReplicas:   3, // We want to downscale to 3 replicas only.
 			customResourceScaleStatusReplicas: 5,
 			expectedHttpRequests: []string{
-				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
 			},
 		},
 
@@ -725,21 +725,21 @@ func TestRolloutController_ReconcileStatefulsetWithDownscaleDelay(t *testing.T) 
 					withDelayedDownscaleAnnotations(time.Hour, "http://pod/prepare-delayed-downscale")),
 			},
 			httpResponses: map[string]httpResponse{
-				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 200, body: "this should be JSON, but isn't"},
-				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
+				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 200, body: "this should be JSON, but isn't"},
+				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
 			},
 			customResourceScaleSpecReplicas:   3, // We want to downscale to 3 replicas only.
 			customResourceScaleStatusReplicas: 5,
 			expectedHttpRequests: []string{
-				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
 			},
 		},
 
-		"scale down is not allowed for zone-a, but is IS allowed for zone-b": {
+		"scale down is not allowed for zone-a, but IS allowed for zone-b": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-a", withReplicas(5, 5),
 					withMirrorReplicasAnnotations("test", customResourceGVK),
@@ -750,25 +750,25 @@ func TestRolloutController_ReconcileStatefulsetWithDownscaleDelay(t *testing.T) 
 					withDelayedDownscaleAnnotations(time.Hour, "http://pod/prepare-delayed-downscale")),
 			},
 			httpResponses: map[string]httpResponse{
-				"POST http://ingester-zone-a-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Unix())},
-				"POST http://ingester-zone-a-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Unix())},
-				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
-				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
+				"POST http://ingester-zone-a-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Unix())},
+				"POST http://ingester-zone-a-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Unix())},
+				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
+				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale": {statusCode: 200, body: fmt.Sprintf(`{"timestamp": %d}`, now.Add(-70*time.Minute).Unix())},
 			},
 			customResourceScaleSpecReplicas:   3, // We want to downscale to 3 replicas only.
 			customResourceScaleStatusReplicas: 5,
 			expectedHttpRequests: []string{
-				"DELETE http://ingester-zone-a-0.ingester-zone-a.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-a-1.ingester-zone-a.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-a-2.ingester-zone-a.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-a-3.ingester-zone-a.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-a-4.ingester-zone-a.test.svc.cluster.local/prepare-delayed-downscale",
+				"DELETE http://ingester-zone-a-0.ingester-zone-a.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-a-1.ingester-zone-a.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-a-2.ingester-zone-a.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-a-3.ingester-zone-a.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-a-4.ingester-zone-a.test.svc.cluster.local./prepare-delayed-downscale",
 
-				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-b-3.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"POST http://ingester-zone-b-4.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
 			},
 
 			expectedPatchedSets: map[string][]string{"ingester-zone-b": {`{"spec":{"replicas":3}}`}}, // This is the downscale!
@@ -784,8 +784,8 @@ func TestRolloutController_ReconcileStatefulsetWithDownscaleDelay(t *testing.T) 
 			customResourceScaleStatusReplicas: 2,
 			expectedPatchedSets:               map[string][]string{"ingester-zone-b": {`{"spec":{"replicas":5}}`}},
 			expectedHttpRequests: []string{
-				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
 			},
 		},
 
@@ -798,9 +798,9 @@ func TestRolloutController_ReconcileStatefulsetWithDownscaleDelay(t *testing.T) 
 			customResourceScaleSpecReplicas:   3,
 			customResourceScaleStatusReplicas: 3,
 			expectedHttpRequests: []string{
-				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
-				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local/prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-0.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-1.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
+				"DELETE http://ingester-zone-b-2.ingester-zone-b.test.svc.cluster.local./prepare-delayed-downscale",
 			},
 		},
 	}
@@ -815,7 +815,7 @@ func TestRolloutController_ReconcileStatefulsetWithDownscaleDelay(t *testing.T) 
 
 			// Inject a hook to track all patched StatefulSets or return mocked errors.
 			patchedStsNames := addPatchStatefulsetReactor(kubeClient, testData.kubePatchErr)
-			scaleClient := createScaleClient(testData.customResourceScaleSpecReplicas, testData.customResourceScaleStatusReplicas, testData.getScaleErr)
+			scaleClient := createFakeScaleClient(testData.customResourceScaleSpecReplicas, testData.customResourceScaleStatusReplicas, testData.getScaleErr)
 
 			dynamicClient, _ := createFakeDynamicClient()
 			httpClient := &fakeHttpClient{
@@ -874,7 +874,7 @@ func addPatchStatefulsetReactor(fakeKubeClient *fake.Clientset, kubePatchErr err
 	return patchedStsNames
 }
 
-func createScaleClient(customResourceScaleSpecReplicas int, customResourceScaleStatusReplicas int, getScaleErr error) *fakescale.FakeScaleClient {
+func createFakeScaleClient(customResourceScaleSpecReplicas int, customResourceScaleStatusReplicas int, getScaleErr error) *fakescale.FakeScaleClient {
 	scaleClient := &fakescale.FakeScaleClient{}
 	scaleClient.AddReactor("get", "*", func(rawAction ktesting.Action) (handled bool, ret runtime.Object, err error) {
 		if getScaleErr != nil {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -585,7 +585,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 
 			// Create the controller and start informers.
 			reg := prometheus.NewPedanticRegistry()
-			c := NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, testNamespace, 5*time.Second, reg, log.NewNopLogger())
+			c := NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger())
 			require.NoError(t, c.Init())
 			defer c.Stop()
 
@@ -658,7 +658,7 @@ func TestRolloutController_ReconcileShouldDeleteMetricsForDecommissionedRolloutG
 
 	// Create the controller and start informers.
 	reg := prometheus.NewPedanticRegistry()
-	c := NewRolloutController(kubeClient, nil, nil, nil, testNamespace, 5*time.Second, reg, log.NewNopLogger())
+	c := NewRolloutController(kubeClient, nil, nil, nil, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger())
 	require.NoError(t, c.Init())
 	defer c.Stop()
 

--- a/pkg/controller/custom_resource_replicas.go
+++ b/pkg/controller/custom_resource_replicas.go
@@ -48,7 +48,7 @@ func (c *RolloutController) adjustStatefulSetsGroupReplicasToMirrorResource(ctx 
 		if err := checkScalingDelay(ctx, c.logger, sts, client, currentReplicas, desiredReplicas); err != nil {
 			level.Warn(c.logger).Log("msg", "not scaling statefulset due to failed scaling delay check", "group", groupName, "name", sts.GetName(), "currentReplicas", currentReplicas, "desiredReplicas", desiredReplicas, "err", err)
 
-			// We can continue with next statefulset in this case -- if delay has not been reached, we can still prepare other statefulsets for downscale.
+			// If delay has not been reached, we can check next statefulset.
 			updateStatusReplicasOnReferenceResourceIfNeeded(ctx, c.logger, c.dynamicClient, sts, scaleObj, referenceGVR, referenceName, currentReplicas)
 			continue
 		}

--- a/pkg/controller/custom_resource_replicas.go
+++ b/pkg/controller/custom_resource_replicas.go
@@ -37,7 +37,7 @@ func (c *RolloutController) adjustStatefulSetsGroupReplicasToMirrorResource(ctx 
 		desiredReplicas := scaleObj.Spec.Replicas
 		if currentReplicas == desiredReplicas {
 			updateStatusReplicasOnReferenceResourceIfNeeded(ctx, c.logger, c.dynamicClient, sts, scaleObj, referenceGVR, referenceName, desiredReplicas)
-			cancelPossibleDelayedDownscale(ctx, c.logger, sts, client, desiredReplicas)
+			cancelDelayedDownscaleIfConfigured(ctx, c.logger, sts, client, desiredReplicas)
 			// No change in the number of replicas: don't log because this will be the result most of the time.
 			continue
 		}

--- a/pkg/controller/custom_resource_replicas.go
+++ b/pkg/controller/custom_resource_replicas.go
@@ -37,6 +37,7 @@ func (c *RolloutController) adjustStatefulSetsGroupReplicasToMirrorResource(ctx 
 		desiredReplicas := scaleObj.Spec.Replicas
 		if currentReplicas == desiredReplicas {
 			updateStatusReplicasOnReferenceResourceIfNeeded(ctx, c.logger, c.dynamicClient, sts, scaleObj, referenceGVR, referenceName, desiredReplicas)
+			cancelPossibleDelayedDownscale(ctx, c.logger, sts, client, desiredReplicas)
 			// No change in the number of replicas: don't log because this will be the result most of the time.
 			continue
 		}

--- a/pkg/controller/custom_resource_replicas.go
+++ b/pkg/controller/custom_resource_replicas.go
@@ -48,8 +48,8 @@ func (c *RolloutController) adjustStatefulSetsGroupReplicasToMirrorResource(ctx 
 		if err := checkScalingDelay(ctx, c.logger, sts, client, currentReplicas, desiredReplicas); err != nil {
 			level.Warn(c.logger).Log("msg", "not scaling statefulset due to failed scaling delay check", "group", groupName, "name", sts.GetName(), "currentReplicas", currentReplicas, "desiredReplicas", desiredReplicas, "err", err)
 
-			// If delay has not been reached, we can check next statefulset.
 			updateStatusReplicasOnReferenceResourceIfNeeded(ctx, c.logger, c.dynamicClient, sts, scaleObj, referenceGVR, referenceName, currentReplicas)
+			// If delay has not been reached, we can check next statefulset.
 			continue
 		}
 

--- a/pkg/controller/custom_resource_replicas.go
+++ b/pkg/controller/custom_resource_replicas.go
@@ -18,7 +18,7 @@ import (
 	"github.com/grafana/rollout-operator/pkg/config"
 )
 
-func (c *RolloutController) adjustStatefulSetsGroupReplicasToMirrorResource(ctx context.Context, groupName string, sets []*appsv1.StatefulSet) (bool, error) {
+func (c *RolloutController) adjustStatefulSetsGroupReplicasToMirrorResource(ctx context.Context, groupName string, sets []*appsv1.StatefulSet, client httpClient) (bool, error) {
 	// Return early no matter what after scaling up or down a single StatefulSet to make sure that rollout-operator
 	// works with up-to-date models.
 	for _, sts := range sets {
@@ -38,6 +38,17 @@ func (c *RolloutController) adjustStatefulSetsGroupReplicasToMirrorResource(ctx 
 		if currentReplicas == desiredReplicas {
 			updateStatusReplicasOnReferenceResourceIfNeeded(ctx, c.logger, c.dynamicClient, sts, scaleObj, referenceGVR, referenceName, desiredReplicas)
 			// No change in the number of replicas: don't log because this will be the result most of the time.
+			continue
+		}
+
+		// We're going to change number of replicas on the statefulset.
+		// If there is delayed downscale configured on the statefulset, we will first handle delay part, and only if that succeeds,
+		// continue with downscaling or upscaling.
+		if err := checkScalingDelay(ctx, c.logger, sts, client, currentReplicas, desiredReplicas); err != nil {
+			level.Warn(c.logger).Log("msg", "not scaling statefulset due to failed scaling delay check", "group", groupName, "name", sts.GetName(), "currentReplicas", currentReplicas, "desiredReplicas", desiredReplicas, "err", err)
+
+			// We can continue with next statefulset in this case -- if delay has not been reached, we can still prepare other statefulsets for downscale.
+			updateStatusReplicasOnReferenceResourceIfNeeded(ctx, c.logger, c.dynamicClient, sts, scaleObj, referenceGVR, referenceName, currentReplicas)
 			continue
 		}
 

--- a/pkg/controller/delay.go
+++ b/pkg/controller/delay.go
@@ -49,7 +49,7 @@ func checkScalingDelay(ctx context.Context, logger log.Logger, sts *v1.StatefulS
 
 	if desiredReplicas > currentReplicas {
 		callCancelDelayedDownscale(ctx, logger, httpClient, createEndpoints(sts.Namespace, sts.GetName(), 0, int(currentReplicas), prepareURL))
-		// Proceed even if calling cancel of delayed downscale fails. We call it repeatedly.
+		// Proceed even if calling cancel of delayed downscale fails. We call cancellation repeatedly, so it will happen during next reconcile.
 		return nil
 	}
 
@@ -72,6 +72,7 @@ func checkScalingDelay(ctx context.Context, logger log.Logger, sts *v1.StatefulS
 	}
 
 	// We can proceed with downscale!
+	level.Info(logger).Log("msg", "downscale delay has been reached on all downscaled pods, proceeding with downscale", "name", sts.GetName(), "delay", delay, "elapsed", elapsedSinceMaxTime)
 	return nil
 }
 

--- a/pkg/controller/delay.go
+++ b/pkg/controller/delay.go
@@ -67,7 +67,7 @@ func checkScalingDelay(ctx context.Context, logger log.Logger, sts *v1.StatefulS
 
 	elapsedSinceMaxTime := time.Since(maxPrepareTime)
 	if elapsedSinceMaxTime < delay {
-		return fmt.Errorf("downscale delay configured in %s annotation (%v) has not been reached for all pods. elapsed time: %v", config.RolloutDelayedDownscaleAnnotationKey, delay, elapsedSinceMaxTime)
+		return fmt.Errorf("configured downscale delay %v has not been reached for all pods. elapsed time: %v", delay, elapsedSinceMaxTime)
 	}
 
 	// We can proceed with downscale!
@@ -223,13 +223,13 @@ func callCancelDownscale(ctx context.Context, logger log.Logger, client httpClie
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodDelete, target, nil)
 			if err != nil {
-				level.Error(epLogger).Log("msg", fmt.Sprintf("error creating HTTP DELETE request to endpoint from %s annotation", config.RolloutDelayedDownscalePrepareUrlAnnotationKey), "err", err)
+				level.Error(epLogger).Log("msg", "error creating HTTP DELETE request to endpoint", "err", err)
 				return err
 			}
 
 			resp, err := client.Do(req)
 			if err != nil {
-				level.Error(epLogger).Log("msg", fmt.Sprintf("error sending HTTP DELETE request to endpoint from %s annotation", config.RolloutDelayedDownscalePrepareUrlAnnotationKey), "err", err)
+				level.Error(epLogger).Log("msg", "error sending HTTP DELETE request to endpoint", "err", err)
 				return err
 			}
 
@@ -238,10 +238,10 @@ func callCancelDownscale(ctx context.Context, logger log.Logger, client httpClie
 			if resp.StatusCode/100 != 2 {
 				err := errors.New("HTTP DELETE request returned non-2xx status code")
 				body, readError := io.ReadAll(resp.Body)
-				level.Error(epLogger).Log("msg", fmt.Sprintf("unexpected status code returned when calling DELETE on endpoint from %s annotation", config.RolloutDelayedDownscalePrepareUrlAnnotationKey), "status", resp.StatusCode, "response_body", string(body))
+				level.Error(epLogger).Log("msg", "unexpected status code returned when calling DELETE on endpoint", "status", resp.StatusCode, "response_body", string(body))
 				return errors.Join(err, readError)
 			}
-			level.Debug(epLogger).Log("msg", fmt.Sprintf("HTTP DELETE request to endpoint from %s annotation succeded", config.RolloutDelayedDownscalePrepareUrlAnnotationKey))
+			level.Debug(epLogger).Log("msg", "HTTP DELETE request to endpoint succeeded")
 			return nil
 		})
 	}

--- a/pkg/controller/delay.go
+++ b/pkg/controller/delay.go
@@ -1,0 +1,240 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/model"
+	"golang.org/x/sync/errgroup"
+	v1 "k8s.io/api/apps/v1"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+func checkScalingDelay(ctx context.Context, logger log.Logger, sts *v1.StatefulSet, httpClient httpClient, currentReplicas, desiredReplicas int32) error {
+	if currentReplicas == desiredReplicas {
+		// should not happen
+		return nil
+	}
+
+	delay, prepareURL, err := parseDelayedDownscaleAnnotations(sts.GetAnnotations())
+	if delay == 0 || prepareURL == nil || err != nil {
+		return err
+	}
+
+	// If we're dealing with upscaling, we will cancel preparation of delayed downscale on all pods.
+	// If we fail for any pod, we have few options:
+	//  * we can block upscaling and retry later
+	//  * we allow upscaling, and call cancel of preparation later.
+	//  * we ignore the problem.
+	//
+	// TODO: For now, we ignore the problem, but this needs fixing.
+
+	if desiredReplicas > currentReplicas {
+		endpoints := createEndpoints(sts.Namespace, sts.GetName(), 0, int(currentReplicas), prepareURL)
+
+		err := callCancelDownscale(ctx, logger, httpClient, endpoints)
+		if err != nil {
+			level.Warn(logger).Log("msg", "failed to cancel delayed downscale", "err", err)
+		}
+		return nil
+	}
+
+	// desiredReplicas < currentReplicas.
+	endpoints := createEndpoints(sts.Namespace, sts.GetName(), int(desiredReplicas), int(currentReplicas), prepareURL)
+	maxPrepareTime, err := callPrepareDownscaleAndReturnMaxPrepareTimestamp(ctx, logger, httpClient, endpoints)
+	if err != nil {
+		return fmt.Errorf("failed prepare pods for delayed downscale: %v", err)
+	}
+
+	elapsedSinceMaxTime := time.Since(maxPrepareTime)
+	if elapsedSinceMaxTime < delay {
+		return fmt.Errorf("downscale delay configured in %s annotation (%v) has not been reached for all pods. elapsed time: %v", config.RolloutDelayedDownscaleAnnotationKey, delay, elapsedSinceMaxTime)
+	}
+
+	// We can proceed with downscale!
+	return nil
+}
+
+func parseDelayedDownscaleAnnotations(annotations map[string]string) (time.Duration, *url.URL, error) {
+	delayStr := annotations[config.RolloutDelayedDownscaleAnnotationKey]
+	urlStr := annotations[config.RolloutDelayedDownscalePrepareUrlAnnotationKey]
+
+	if delayStr == "" || urlStr == "" {
+		return 0, nil, nil
+	}
+
+	d, err := model.ParseDuration(delayStr)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to parse %s annotation value as duration: %v", config.RolloutDelayedDownscaleAnnotationKey, err)
+	}
+	if d < 0 {
+		return 0, nil, fmt.Errorf("negative value of %s annotation: %v", config.RolloutDelayedDownscaleAnnotationKey, delayStr)
+	}
+
+	delay := time.Duration(d)
+
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to parse %s annotation value as URL: %v", config.RolloutDelayedDownscalePrepareUrlAnnotationKey, err)
+	}
+
+	return delay, u, nil
+}
+
+type endpoint struct {
+	namespace string
+	podName   string
+	url       url.URL
+	index     int
+}
+
+// Create prepare-downscale endpoints for pods with index in [from, to) range.
+func createEndpoints(namespace, serviceName string, from, to int, url *url.URL) []endpoint {
+	eps := make([]endpoint, 0, to-from)
+
+	// The DNS entry for a pod of a stateful set is
+	// ingester-zone-a-0.$(servicename).$(namespace).svc.cluster.local
+	// The service in this case is ingester-zone-a as well.
+	// https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id
+
+	for index := from; index < to; index++ {
+		ep := endpoint{
+			namespace: namespace,
+			podName:   fmt.Sprintf("%v-%v", serviceName, index),
+			index:     index,
+		}
+
+		ep.url = *url
+		ep.url.Host = fmt.Sprintf("%s.%v.%v.svc.cluster.local", ep.podName, serviceName, ep.namespace)
+
+		eps = append(eps, ep)
+	}
+
+	return eps
+}
+
+func callPrepareDownscaleAndReturnMaxPrepareTimestamp(ctx context.Context, logger log.Logger, client httpClient, endpoints []endpoint) (time.Time, error) {
+	if len(endpoints) == 0 {
+		return time.Now(), nil
+	}
+
+	var (
+		maxTimeMu sync.Mutex
+		maxTime   time.Time
+	)
+
+	type expectedResponse struct {
+		Timestamp int64 `json:"timestamp"`
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	for ix := range endpoints {
+		ep := endpoints[ix]
+		g.Go(func() error {
+			target := ep.url.String()
+
+			epLogger := log.With(logger, "pod", ep.podName, "url", target)
+
+			// POST -- prepare for delayed downscale, if not yet prepared, and return timestamp when prepare was called.
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, nil)
+			if err != nil {
+				level.Error(epLogger).Log("msg", "error creating HTTP POST request to endpoint", "err", err)
+				return err
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				level.Error(epLogger).Log("error sending HTTP POST request to endpoint", "err", err)
+				return err
+			}
+
+			defer resp.Body.Close()
+
+			body, readError := io.ReadAll(resp.Body)
+			if readError != nil {
+				level.Error(epLogger).Log("msg", "error reading response from HTTP POST request to endpoint", "err", err)
+				return err
+			}
+
+			if resp.StatusCode/100 != 2 {
+				err := errors.New("HTTP DELETE request returned non-2xx status code")
+				level.Error(epLogger).Log("msg", "unexpected status code returned when calling DELETE on endpoint", "status", resp.StatusCode, "response_body", string(body))
+				return errors.Join(err, readError)
+			}
+
+			r := expectedResponse{}
+			if err := json.Unmarshal(body, &r); err != nil {
+				level.Error(epLogger).Log("msg", "error decoding response from HTTP POST request to endpoint", "err", err)
+				return err
+			}
+
+			if r.Timestamp == 0 {
+				level.Error(epLogger).Log("msg", "invalid response from HTTP POST request to endpoint: no timestamp")
+				return fmt.Errorf("no timestamp in response")
+			}
+
+			t := time.Unix(r.Timestamp, 0)
+
+			maxTimeMu.Lock()
+			if t.After(maxTime) {
+				maxTime = t
+			}
+			maxTimeMu.Unlock()
+
+			level.Debug(epLogger).Log("msg", "HTTP POST request to endpoint succeded", "timestamp", t.UTC().Format(time.RFC3339))
+			return nil
+		})
+	}
+	err := g.Wait()
+	return maxTime, err
+}
+
+func callCancelDownscale(ctx context.Context, logger log.Logger, client httpClient, endpoints []endpoint) error {
+	if len(endpoints) == 0 {
+		return nil
+	}
+
+	g, _ := errgroup.WithContext(ctx)
+	for ix := range endpoints {
+		ep := endpoints[ix]
+		g.Go(func() error {
+			target := ep.url.String()
+
+			epLogger := log.With(logger, "pod", ep.podName, "url", target)
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodDelete, target, nil)
+			if err != nil {
+				level.Error(epLogger).Log("msg", fmt.Sprintf("error creating HTTP DELETE request to endpoint from %s annotation", config.RolloutDelayedDownscalePrepareUrlAnnotationKey), "err", err)
+				return err
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				level.Error(epLogger).Log("msg", fmt.Sprintf("error sending HTTP DELETE request to endpoint from %s annotation", config.RolloutDelayedDownscalePrepareUrlAnnotationKey), "err", err)
+				return err
+			}
+
+			defer resp.Body.Close()
+
+			if resp.StatusCode/100 != 2 {
+				err := errors.New("HTTP DELETE request returned non-2xx status code")
+				body, readError := io.ReadAll(resp.Body)
+				level.Error(epLogger).Log("msg", fmt.Sprintf("unexpected status code returned when calling DELETE on endpoint from %s annotation", config.RolloutDelayedDownscalePrepareUrlAnnotationKey), "status", resp.StatusCode, "response_body", string(body))
+				return errors.Join(err, readError)
+			}
+			level.Debug(epLogger).Log("msg", fmt.Sprintf("HTTP DELETE request to endpoint from %s annotation succeded", config.RolloutDelayedDownscalePrepareUrlAnnotationKey))
+			return nil
+		})
+	}
+	return g.Wait()
+}

--- a/pkg/instrumentation/kubernetes_api_client.go
+++ b/pkg/instrumentation/kubernetes_api_client.go
@@ -46,7 +46,11 @@ func (k *kubernetesAPIClientInstrumentation) RoundTrip(req *http.Request) (*http
 
 	resp, err := k.next.RoundTrip(req)
 	duration := time.Since(start)
-	instrument.ObserveWithExemplar(req.Context(), k.hist.WithLabelValues(urlToResourceDescription(req.URL.EscapedPath()), req.Method, strconv.Itoa(resp.StatusCode)), duration.Seconds())
+	statusCode := 0
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
+	instrument.ObserveWithExemplar(req.Context(), k.hist.WithLabelValues(urlToResourceDescription(req.URL.EscapedPath()), req.Method, strconv.Itoa(statusCode)), duration.Seconds())
 
 	return resp, err
 }

--- a/pkg/instrumentation/kubernetes_api_client.go
+++ b/pkg/instrumentation/kubernetes_api_client.go
@@ -31,11 +31,15 @@ func InstrumentKubernetesAPIClient(cfg *rest.Config, reg prometheus.Registerer) 
 	)
 
 	cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-		return &kubernetesAPIClientInstrumentation{
-			next: &nethttp.Transport{RoundTripper: rt},
-			hist: hist,
-		}
+		return newInstrumentation(rt, hist)
 	})
+}
+
+func newInstrumentation(rt http.RoundTripper, hist *prometheus.HistogramVec) *kubernetesAPIClientInstrumentation {
+	return &kubernetesAPIClientInstrumentation{
+		next: &nethttp.Transport{RoundTripper: rt},
+		hist: hist,
+	}
 }
 
 func (k *kubernetesAPIClientInstrumentation) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/pkg/instrumentation/kubernetes_api_client.go
+++ b/pkg/instrumentation/kubernetes_api_client.go
@@ -50,11 +50,11 @@ func (k *kubernetesAPIClientInstrumentation) RoundTrip(req *http.Request) (*http
 
 	resp, err := k.next.RoundTrip(req)
 	duration := time.Since(start)
-	statusCode := 0
+	statusCode := "error"
 	if resp != nil {
-		statusCode = resp.StatusCode
+		statusCode = strconv.Itoa(resp.StatusCode)
 	}
-	instrument.ObserveWithExemplar(req.Context(), k.hist.WithLabelValues(urlToResourceDescription(req.URL.EscapedPath()), req.Method, strconv.Itoa(statusCode)), duration.Seconds())
+	instrument.ObserveWithExemplar(req.Context(), k.hist.WithLabelValues(urlToResourceDescription(req.URL.EscapedPath()), req.Method, statusCode), duration.Seconds())
 
 	return resp, err
 }


### PR DESCRIPTION
This PR adds support for downscale delay when using [reference resource as a source of number of replicas.](https://github.com/grafana/rollout-operator/pull/129)

Two annotations are used for configuration:
* Delay duration: `grafana.com/rollout-delayed-downscale`
* URL: `grafana.com/rollout-prepare-delayed-downscale-url`.

How it works: When rollout-operator detects that statefulset configured with these annotations should be scaled down, it first calls `POST <URL>`  on all pods that should be scaled down. Pods are expected to prepare for scaledown and return timestamp when such preparation happened (possibly in the past). Any errors from these calls (networking, non-200 status code, invalid JSON object) will cause that downscale is aborted (and retried later, if scaledown condition is still true).

Operator then computes Maximum of returned timestamps. If this maximum is in the past for more than "delay duration", scaledown proceeds. Otherwise, scaledown is not allowed at this point, and will be retried later.

All other pods that are NOT going to be scaled down also receive HTTP request to given URL, however with `DELETE` method. This tells pod to "cancel" any possible preparation for scaledown in the past.

For example, if statefulset has 100 pods, and 30 of them are going to be scaled down, then pods from 0 to 69 receive `DELETE <url>` call, while pods 70 .. 99 receive `POST <url>` call.

If rollout operator detects no change of replicas, or scale up, it will still perform `DELETE <url>` calls, to make sure that any possible previous preparations are cancelled. Since these DELETE calls are repeated all the time, errors from them are ignored.

JSON response expected by rollout-operator is simply `{"timestamp": <unix-seconds as number>}`.

Format of the URL annotation is full URL like `http://pod/prepare-delayed-downscale`, in which the "host" part of the URL will be replaced with pod's fully-qualified domain name, eg. `ingester-zone-b-0.ingester-zone-b.namespace.svc.cluster.local.`.

**How is this different from `grafana.com/min-time-between-zones-downscale`?**

`grafana.com/min-time-between-zones-downscale` is applied to delay downscaling of zones based on downscale timestamp of another zone.

**How is this different from `grafana.com/prepare-downscale-http-path`?**

`grafana.com/prepare-downscale-http-path` together with `grafana.com/prepare-downscale-http-port` annotation are used to signal pod that is being scaled down. Ie. after call to `grafana.com/prepare-downscale-http-path+port`, pod will be downscaled right after.

`grafana.com/rollout-prepare-delayed-downscale-url` tells pod about downscale in the future, which can be minutes or hours later.