### PR TITLE
Add required RBAC verbs, add scaling diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ This is similar to using `grafana.com/rollout-downscale-leader`, but reference r
 
 This can be used in combination with HorizontalPodAutoscaler, when it is undesireable to set number of replicas directly on target statefulset, because we want to add custom logic to the scaledown (see next point). In that case, HPA can update different "reference resource", and rollout-operator can "mirror" number of replicas from reference resource to target statefulset.
 
+To support scaling based on reference resource, rollout-operator needs to be allowed to execute `get` and `patch` verbs on `status` and `scale` subresources of the custom resource. For example when using custom resource `replica-templates` from API group `rollout-operator.grafana.com`, you can add following to the RBAC:
+
+```yaml
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - replica-templates/scale
+  - replica-templates/status
+  verbs:
+  - get
+  - patch
+```
+
 ## Delayed scaledown
 
 When using "Scaling based on reference resource", rollout-operator can be configured to delay the actual scaledown, and ask individual pods to prepare for delayed-scaledown.

--- a/scaling.md
+++ b/scaling.md
@@ -31,6 +31,7 @@ sequenceDiagram
         RO->>CS: Reads "scale" subresource for replicas
         alt is downscale
             RO->>Pods: calls POST prepare-delayed-downscale-url on all downscaled pods
+            RO->>Pods: calls DELETE prepare-delayed-downscale-url on all non-downscaled pods
             RO->>SS: If delay has elapsed, updates spec.replicas
         else is upscale, or no change in replicas.
             RO->>Pods: calls DELETE prepare-delayed-downscale-url on all pods

--- a/scaling.md
+++ b/scaling.md
@@ -1,0 +1,41 @@
+# Diagram of how rollout-operator performs scaling based on custom resource.
+
+Scaling based on reference resource, without delayed downscale:
+
+```mermaid
+sequenceDiagram
+    participant HPA as HorizontalPodAutoscaler
+    participant CS as Custom Resource
+    participant RO as rollout-operator
+    participant SS as StatefulSet
+    HPA->>CS: Updates "scale" subresource with desired number of replicas
+    loop Rollout-Operator Reconciliation Loop
+        RO->>CS: Reads "scale" subresource for replicas
+        RO->>SS: If scale replicas and StatefulSet spec.replicas differ, updates spec.replicas
+        RO->>CS: Updates replicas in "status" subresource with current number of replicas
+    end
+```
+
+Scaling based on reference resource, with delayed downscale:
+
+```mermaid
+sequenceDiagram
+    participant HPA as HorizontalPodAutoscaler
+    participant CS as Custom Resource
+    participant RO as rollout-operator
+    participant SS as StatefulSet
+    participant Pods
+    
+    HPA->>CS: Updates "scale" subresource with desired number of replicas
+    loop Rollout-Operator Reconciliation Loop
+        RO->>CS: Reads "scale" subresource for replicas
+        alt is downscale
+            RO->>Pods: calls POST prepare-delayed-downscale-url on all downscaled pods
+            RO->>SS: If delay has elapsed, updates spec.replicas
+        else is upscale, or no change in replicas.
+            RO->>Pods: calls DELETE prepare-delayed-downscale-url on all pods
+            RO->>SS: If scale replicas and StatefulSet spec.replicas differ,<br />updates spec.replicas
+        end
+        RO->>CS: Updates replicas in "status" subresource with current number of replicas
+    end
+```


### PR DESCRIPTION
This PR mentions verbs required for scaling based on reference resource. It also adds a diagram showing how rollout operator works.