### PR TITLE
Update SPDX header after license change

### DIFF
--- a/pkg/admission/convert.go
+++ b/pkg/admission/convert.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-License-Identifier: Apache-2.0
 // Provenance-includes-location: https://github.com/kubernetes/kubernetes/blob/5539a5b80fe45cc04df4f53bd1047cd6d998bcf1/test/images/agnhost/webhook/convert.go
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Kubernetes Authors.

--- a/pkg/admission/scheme.go
+++ b/pkg/admission/scheme.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-License-Identifier: Apache-2.0
 // Provenance-includes-location: https://github.com/kubernetes/kubernetes/blob/5539a5b80fe45cc04df4f53bd1047cd6d998bcf1/test/images/agnhost/webhook/scheme.go
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Kubernetes Authors.

--- a/pkg/admission/serve.go
+++ b/pkg/admission/serve.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-License-Identifier: Apache-2.0
 // Provenance-includes-location: https://github.com/kubernetes/kubernetes/blob/5539a5b80fe45cc04df4f53bd1047cd6d998bcf1/test/images/agnhost/webhook/main.go
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Kubernetes Authors.


### PR DESCRIPTION
In https://github.com/grafana/rollout-operator/pull/139 the license was updated to Apache 2.0, but there were still SPDX headers mentioning AGPLv3.