### PR TITLE
 Invoke DELETE on pod prepare-downscale path if any POSTs failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This operator coordinates the rollout of pods between different StatefulSets wit
 
 ## How updates work
 
-The operator coordinates the rollout of pods belonging to `StatefulSets` with the `rollout-group` label and updates strategy set to `OnDelete`. The label value should identify the group of StatefulSets to which the StatefulSet belongs to. Make sure the statefulset has a label `name` in its `spec.template`, the operator uses it to find pods belonging to it.
+The operator coordinates the rollout of pods belonging to `StatefulSets` with the `rollout-group` label and updates strategy set to `OnDelete`. The label value should identify the group of StatefulSets to which the StatefulSet belongs to. Make sure the StatefulSet has a label `name` in its `spec.template`, as the operator uses it to find pods belonging to it.
 
 For example, given the following StatefulSets in a namespace:
 - `ingester-zone-a` with `rollout-group: ingester`
@@ -25,9 +25,9 @@ For each **rollout group**, the operator **guarantees**:
 1. Pods in a StatefulSet are rolled out if and only if all pods in all other StatefulSets of the same group are `Ready` (otherwise it will start or continue the rollout once this check is satisfied)
 1. Pods are rolled out if and only if all StatefulSets in the same group have `OnDelete` update strategy (otherwise the operator will skip the group and log an error)
 1. The maximum number of not-Ready pods in a StatefulSet doesn't exceed the value configured in the `rollout-max-unavailable` annotation (if not set, it defaults to `1`). Values:
-  - `<= 0`: invalid (will default to `1` and log a warning)
-  - `1`: pods are rolled out sequentially
-  - `> 1`: pods are rolled out in parallel (honoring the configured number of max unavailable pods)
+   - `<= 0`: invalid (will default to `1` and log a warning)
+   - `1`: pods are rolled out sequentially
+   - `> 1`: pods are rolled out in parallel (honoring the configured number of max unavailable pods)
 
 ## How scaling up and down works
 

--- a/pkg/controller/replicas.go
+++ b/pkg/controller/replicas.go
@@ -106,7 +106,6 @@ func minimumTimeHasElapsed(follower *v1.StatefulSet, all []*v1.StatefulSet, logg
 	)
 
 	return timeSinceDownscale > minTimeSinceDownscale, nil
-
 }
 
 // getMostRecentDownscale gets the time of the most recent downscale of any statefulset besides


### PR DESCRIPTION
This addresses a bug in rollout-operator where:

1. Kubernetes receives a request to downscale a statefulset by `X` hosts.
2. The prepare-downscale admission webhook approves the downscale and attempts to prepare `X` pods for shutdown by calling invoking their handler identified by the `grafana.com/prepare-downscale-http-path` and `-port` annotations.
3. At least one of these invocations fails. The admission webhook returns an error to Kubernetes, so the downscale is not approved.
4. 💥 But some hosts may have been prepared for downscale. 💥 

This PR adds cleanup logic to issue `DELETE` requests on all pods if any of the `POST`s failed. Notes:
* `DELETE` calls are attempted once.
* `DELETE` failures are logged but otherwise ignored.
* For simplicity, we'll invoke `DELETE` on all of the pods involved in the scaledown operation, not just ones that received a POST.

This doesn't fix the similar issue where replica count changing from 10->9->10 leaves that one pod prepared for shutdown. (But that's in the works.)