### PR TITLE
Swap base image from alpine to distroless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## main / unreleased
 
+* [CHANGE] The docker base images are now based off distroless images rather than Alpine. #149
+  * The standard base image is now `gcr.io/distroless/static-debian12:nonroot`.
+  * The boringcrypto base image is now `gcr.io/distroless/base-nossl-debian12:nonroot` (for glibc).
+
 ## v0.16.0
+
 * [ENHANCEMENT] If the POST to prepare-shutdown fails for any replica, attempt to undo the operation by issuing an HTTP DELETE to prepare-shutdown for all target replicas. #146
 
 ## v0.15.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,6 @@ FROM gcr.io/distroless/static-debian12
 COPY --from=build /src/rollout-operator/rollout-operator /bin/rollout-operator
 ENTRYPOINT [ "/bin/rollout-operator" ]
 
-# Create rollout-operator user to run as non-root.
-RUN addgroup -g 10000 -S rollout-operator && \
-    adduser  -u 10000 -S rollout-operator -G rollout-operator
-USER rollout-operator:rollout-operator
-
 ARG revision
 LABEL org.opencontainers.image.title="rollout-operator" \
       org.opencontainers.image.source="https://github.com/grafana/rollout-operator" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ COPY . /src/rollout-operator
 WORKDIR /src/rollout-operator
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make ${BUILDTARGET}
 
-FROM alpine:3.19
-RUN apk add --no-cache ca-certificates gcompat
+FROM gcr.io/distroless/static-debian12
 
 COPY --from=build /src/rollout-operator/rollout-operator /bin/rollout-operator
 ENTRYPOINT [ "/bin/rollout-operator" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASEIMAGE
+
 FROM golang:1.22-bookworm AS build
 
 ARG TARGETOS
@@ -8,7 +10,7 @@ COPY . /src/rollout-operator
 WORKDIR /src/rollout-operator
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make ${BUILDTARGET}
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM ${BASEIMAGE}
 
 COPY --from=build /src/rollout-operator/rollout-operator /bin/rollout-operator
 ENTRYPOINT [ "/bin/rollout-operator" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . /src/rollout-operator
 WORKDIR /src/rollout-operator
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make ${BUILDTARGET}
 
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY --from=build /src/rollout-operator/rollout-operator /bin/rollout-operator
 ENTRYPOINT [ "/bin/rollout-operator" ]

--- a/integration/mock-service/Dockerfile
+++ b/integration/mock-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY       mock-service /bin/mock-service
 ENTRYPOINT [ "/bin/mock-service" ]

--- a/integration/mock-service/Dockerfile
+++ b/integration/mock-service/Dockerfile
@@ -3,11 +3,6 @@ FROM gcr.io/distroless/static-debian12
 COPY       mock-service /bin/mock-service
 ENTRYPOINT [ "/bin/mock-service" ]
 
-# Create mock-service user to run as non-root.
-RUN addgroup -g 10000 -S mock-service && \
-    adduser  -u 10000 -S mock-service -G mock-service
-USER mock-service:mock-service
-
 ARG revision
 LABEL org.opencontainers.image.title="mock-service" \
       org.opencontainers.image.source="https://github.com/grafana/rollout-operator/integration/mock-service" \

--- a/integration/mock-service/Dockerfile
+++ b/integration/mock-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM gcr.io/distroless/static-debian12
 
 COPY       mock-service /bin/mock-service
 ENTRYPOINT [ "/bin/mock-service" ]


### PR DESCRIPTION
Mimir is moving to a distroless image so it would be nice if rollout-operator did too. The primary motivation is to lessen CVE noise even further.

~Opening this as a draft at first to experiment.~ Tests look good!