### PR TITLE
Add request UID to webhook logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [CHANGE] The docker base images are now based off distroless images rather than Alpine. #149
   * The standard base image is now `gcr.io/distroless/static-debian12:nonroot`.
   * The boringcrypto base image is now `gcr.io/distroless/base-nossl-debian12:nonroot` (for glibc).
+* [ENHANCEMENT] Include unique IDs of webhook requests in logs for easier debugging. #150
 
 ## v0.16.0
 

--- a/pkg/admission/prep_downscale.go
+++ b/pkg/admission/prep_downscale.go
@@ -60,6 +60,7 @@ func prepareDownscale(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 	logger.SetSpanAndLogTag("object.resource", ar.Request.Resource.Resource)
 	logger.SetSpanAndLogTag("object.namespace", ar.Request.Namespace)
 	logger.SetSpanAndLogTag("request.dry_run", *ar.Request.DryRun)
+	logger.SetSpanAndLogTag("request.uid", ar.Request.UID)
 
 	if *ar.Request.DryRun {
 		return &v1.AdmissionResponse{Allowed: true}

--- a/pkg/admission/serve.go
+++ b/pkg/admission/serve.go
@@ -17,6 +17,7 @@ import (
 	v1 "k8s.io/api/admission/v1"
 	"k8s.io/api/admission/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -61,6 +62,8 @@ func Serve(admit AdmitV1Func, logger log.Logger, api *kubernetes.Clientset) http
 			return
 		}
 
+		var requestUid types.UID
+
 		var responseObj runtime.Object
 		switch *gvk {
 		case v1beta1.SchemeGroupVersion.WithKind("AdmissionReview"):
@@ -69,24 +72,38 @@ func Serve(admit AdmitV1Func, logger log.Logger, api *kubernetes.Clientset) http
 				level.Error(logger).Log("msg", "unexpected type", "type", fmt.Sprintf("%T", obj), "expected", "*v1beta1.AdmissionReview")
 				return
 			}
-			level.Debug(logger).Log("msg", "handling request", "kind", requestedAdmissionReview.Request.Kind, "namespace", requestedAdmissionReview.Request.Namespace, "name", requestedAdmissionReview.Request.Name)
+			level.Debug(logger).Log(
+				"msg", "handling request",
+				"kind", requestedAdmissionReview.Request.Kind,
+				"namespace", requestedAdmissionReview.Request.Namespace,
+				"name", requestedAdmissionReview.Request.Name,
+				"request.uid", requestedAdmissionReview.Request.UID,
+			)
 			responseAdmissionReview := &v1beta1.AdmissionReview{}
 			responseAdmissionReview.SetGroupVersionKind(*gvk)
 			responseAdmissionReview.Response = delegateV1beta1AdmitToV1(admit)(r.Context(), logger, *requestedAdmissionReview, api)
 			responseAdmissionReview.Response.UID = requestedAdmissionReview.Request.UID
 			responseObj = responseAdmissionReview
+			requestUid = requestedAdmissionReview.Request.UID
 		case v1.SchemeGroupVersion.WithKind("AdmissionReview"):
 			requestedAdmissionReview, ok := obj.(*v1.AdmissionReview)
 			if !ok {
 				level.Error(logger).Log("msg", "unexpected type", "type", fmt.Sprintf("%T", obj), "expected", "*v1.AdmissionReview")
 				return
 			}
-			level.Debug(logger).Log("msg", "handling request", "kind", requestedAdmissionReview.Request.Kind, "namespace", requestedAdmissionReview.Request.Namespace, "name", requestedAdmissionReview.Request.Name)
+			level.Debug(logger).Log(
+				"msg", "handling request",
+				"kind", requestedAdmissionReview.Request.Kind,
+				"namespace", requestedAdmissionReview.Request.Namespace,
+				"name", requestedAdmissionReview.Request.Name,
+				"request.uid", requestedAdmissionReview.Request.UID,
+			)
 			responseAdmissionReview := &v1.AdmissionReview{}
 			responseAdmissionReview.SetGroupVersionKind(*gvk)
 			responseAdmissionReview.Response = admit(r.Context(), logger, *requestedAdmissionReview, api)
 			responseAdmissionReview.Response.UID = requestedAdmissionReview.Request.UID
 			responseObj = responseAdmissionReview
+			requestUid = requestedAdmissionReview.Request.UID
 		default:
 			msg := fmt.Sprintf("Unsupported group version kind: %v", gvk)
 			level.Error(logger).Log("msg", "unsupported group version kind", "gvk", gvk)
@@ -94,7 +111,7 @@ func Serve(admit AdmitV1Func, logger log.Logger, api *kubernetes.Clientset) http
 			return
 		}
 
-		level.Debug(logger).Log("msg", "sending response", "response", responseObj)
+		level.Debug(logger).Log("msg", "sending response", "request.uid", requestUid, "response", responseObj)
 		respBytes, err := json.Marshal(responseObj)
 		if err != nil {
 			level.Error(logger).Log("msg", "error marshaling response", "err", err)

--- a/pkg/admission/zone_tracker.go
+++ b/pkg/admission/zone_tracker.go
@@ -42,6 +42,7 @@ func (zt *zoneTracker) prepareDownscale(ctx context.Context, l log.Logger, ar v1
 	logger.SetSpanAndLogTag("object.resource", ar.Request.Resource.Resource)
 	logger.SetSpanAndLogTag("object.namespace", ar.Request.Namespace)
 	logger.SetSpanAndLogTag("request.dry_run", *ar.Request.DryRun)
+	logger.SetSpanAndLogTag("request.uid", ar.Request.UID)
 
 	if *ar.Request.DryRun {
 		return &v1.AdmissionResponse{Allowed: true}


### PR DESCRIPTION
For better debuggability when there are concurrent webhook calls.