### PR TITLE
Admission webhook: Undo prepare-shutdown calls if last-downscale fails to store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * The standard base image is now `gcr.io/distroless/static-debian12:nonroot`.
   * The boringcrypto base image is now `gcr.io/distroless/base-nossl-debian12:nonroot` (for glibc).
 * [ENHANCEMENT] Include unique IDs of webhook requests in logs for easier debugging. #150
+* [ENHANCEMENT] prepare-downscale admission webhook: undo prepare-shutdown calls if adding the `last-downscale` annotation fails. #151
 
 ## v0.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [ENHANCEMENT] Include unique IDs of webhook requests in logs for easier debugging. #150
 * [ENHANCEMENT] Include k8s operation username in request debug logs. #152
 * [ENHANCEMENT] `rollout-max-unavailable` annotation can now be specified as percentage, e.g.: `rollout-max-unavailable: 25%`. Resulting value is computed as `floor(replicas * percentage)`, but is never less than 1. #153
+* [ENHANCEMENT] Delayed downscale of statefulset can now reduce replicas earlier, if subset of pods at the end of statefulset have already reached their delay. #156
 * [BUGFIX] Fix a mangled error log in controller's delayed downscale code. #154
 
 ## v0.16.0

--- a/pkg/admission/prep_downscale.go
+++ b/pkg/admission/prep_downscale.go
@@ -554,7 +554,7 @@ func undoPrepareShutdownRequests(ctx context.Context, logger log.Logger, client 
 		})
 	}
 
-	undoGroup.Wait()
+	_ = undoGroup.Wait()
 }
 
 var tenantResolver spanlogger.TenantResolver = noTenantResolver{}

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -61,8 +61,8 @@ func TestValidDownscaleWithAnotherInProgress(t *testing.T) {
 }
 
 func TestInvalidDownscale(t *testing.T) {
-	testPrepDownscaleWebhook(t, 5, 3, withStatusCode(http.StatusInternalServerError), expectDeletes())
-	testPrepDownscaleWebhookWithZoneTracker(t, 5, 3, withStatusCode(http.StatusInternalServerError), expectDeletes())
+	testPrepDownscaleWebhook(t, 5, 3, withStatusCode(http.StatusInternalServerError), expectDeletes(), expectDeny())
+	testPrepDownscaleWebhookWithZoneTracker(t, 5, 3, withStatusCode(http.StatusInternalServerError), expectDeletes(), expectDeny())
 }
 
 func TestFailLastDownscaleAttr(t *testing.T) {
@@ -361,11 +361,6 @@ func TestSendPrepareShutdown(t *testing.T) {
 		"last post fails": {
 			numEndpoints:  64,
 			lastPostsFail: 1,
-			expectErr:     true,
-		},
-		"delete failures should still call all deletes": {
-			numEndpoints:  64,
-			lastPostsFail: 64,
 			expectErr:     true,
 		},
 	}

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -766,6 +766,10 @@ func testPrepDownscaleWebhookWithZoneTracker(t *testing.T, oldReplicas, newRepli
 
 	admissionResponse := zt.prepareDownscale(ctx, logger, ar, api, f)
 	require.Equal(t, params.allowed, admissionResponse.Allowed, "Unexpected result for allowed: got %v, expected %v", admissionResponse.Allowed, params.allowed)
+
+	if params.expectDeletes {
+		require.Greater(t, f.calls(http.MethodDelete), 0)
+	}
 }
 
 func TestDecodeAndReplicas(t *testing.T) {

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
-	fakeappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1/fake"
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/grafana/rollout-operator/pkg/config"
@@ -309,8 +308,7 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 	api := fake.NewSimpleClientset(objects...)
 
 	if params.failSetLastDownscale {
-		f := api.AppsV1().(*fakeappsv1.FakeAppsV1)
-		f.PrependReactor("patch", "statefulsets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		api.PrependReactor("patch", "statefulsets", func(action k8stesting.Action) (bool, runtime.Object, error) {
 			return true, nil, errors.New("something terrible happened")
 		})
 	}
@@ -785,8 +783,7 @@ func testPrepDownscaleWebhookWithZoneTracker(t *testing.T, oldReplicas, newRepli
 	api := fake.NewSimpleClientset(objects...)
 
 	if params.failSetLastDownscale {
-		f := api.AppsV1().(*fakeappsv1.FakeAppsV1)
-		f.PrependReactor("update", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		api.PrependReactor("update", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
 			return true, nil, errors.New("something terrible happened")
 		})
 	}

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"text/template"
@@ -58,8 +59,13 @@ func TestValidDownscaleWithAnotherInProgress(t *testing.T) {
 }
 
 func TestInvalidDownscale(t *testing.T) {
-	testPrepDownscaleWebhook(t, 5, 3, withStatusCode(http.StatusInternalServerError))
-	testPrepDownscaleWebhookWithZoneTracker(t, 5, 3, withStatusCode(http.StatusInternalServerError))
+	testPrepDownscaleWebhook(t, 5, 3, withStatusCode(http.StatusInternalServerError), expectDeletes())
+	testPrepDownscaleWebhookWithZoneTracker(t, 5, 3, withStatusCode(http.StatusInternalServerError), expectDeletes())
+}
+
+func TestFailStoreAnnotation(t *testing.T) {
+	testPrepDownscaleWebhook(t, 5, 3, expectDeletes())
+	testPrepDownscaleWebhookWithZoneTracker(t, 5, 3, expectDeletes())
 }
 
 func TestDownscaleDryRun(t *testing.T) {
@@ -82,6 +88,7 @@ type testParams struct {
 	downscaleInProgress bool
 	allowed             bool
 	dryRun              bool
+	expectDeletes       bool
 }
 
 type optionFunc func(*testParams)
@@ -93,6 +100,12 @@ func withStatusCode(statusCode int) optionFunc {
 			tp.allowed = false
 			tp.stsAnnotated = false
 		}
+	}
+}
+
+func expectDeletes() optionFunc {
+	return func(tp *testParams) {
+		tp.expectDeletes = true
 	}
 }
 
@@ -125,19 +138,34 @@ type templateParams struct {
 }
 
 type fakeHttpClient struct {
-	statusCode int
-	mockDo     func(*http.Request) (*http.Response, error)
+	mockDo func(*http.Request) (*http.Response, error)
+
+	mu            sync.Mutex
+	callsByMethod map[string]int
+}
+
+func newFakeHttpClient(mockDo func(*http.Request) (*http.Response, error)) *fakeHttpClient {
+	if mockDo == nil {
+		panic("mockDo req'd")
+	}
+	return &fakeHttpClient{
+		mockDo:        mockDo,
+		callsByMethod: make(map[string]int),
+	}
 }
 
 func (f *fakeHttpClient) Do(req *http.Request) (resp *http.Response, err error) {
-	if f.mockDo != nil {
-		return f.mockDo(req)
-	}
+	f.mu.Lock()
+	f.callsByMethod[req.Method]++
+	f.mu.Unlock()
 
-	return &http.Response{
-		StatusCode: f.statusCode,
-		Body:       io.NopCloser(bytes.NewBuffer([]byte(""))),
-	}, nil
+	return f.mockDo(req)
+}
+
+func (f *fakeHttpClient) calls(method string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.callsByMethod[method]
 }
 
 func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, options ...optionFunc) {
@@ -263,7 +291,13 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 		)
 	}
 	api := fake.NewSimpleClientset(objects...)
-	f := &fakeHttpClient{statusCode: params.statusCode}
+	f := newFakeHttpClient(
+		func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: params.statusCode,
+				Body:       io.NopCloser(bytes.NewBuffer([]byte(""))),
+			}, nil
+		})
 
 	admissionResponse := prepareDownscale(ctx, logger, ar, api, f)
 	require.Equal(t, params.allowed, admissionResponse.Allowed, "Unexpected result for allowed: got %v, expected %v", admissionResponse.Allowed, params.allowed)
@@ -275,45 +309,41 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 		require.NotNil(t, updatedSts.Annotations)
 		require.NotNil(t, updatedSts.Annotations[config.LastDownscaleAnnotationKey])
 	}
+
+	if params.expectDeletes {
+		require.Greater(t, f.calls(http.MethodDelete), 0)
+	}
 }
 
 func TestSendPrepareShutdown(t *testing.T) {
 	cases := map[string]struct {
 		numEndpoints  int
 		lastPostsFail int
-		expectDeletes int
-		deletesFail   bool
 		expectErr     bool
 	}{
 		"no endpoints": {
 			numEndpoints:  0,
 			lastPostsFail: 0,
-			expectDeletes: 0,
 			expectErr:     false,
 		},
 		"all posts succeed": {
 			numEndpoints:  64,
 			lastPostsFail: 0,
-			expectDeletes: 0,
 			expectErr:     false,
 		},
 		"all posts fail": {
 			numEndpoints:  64,
 			lastPostsFail: 64,
-			expectDeletes: 64,
 			expectErr:     true,
 		},
 		"last post fails": {
 			numEndpoints:  64,
 			lastPostsFail: 1,
-			expectDeletes: 64,
 			expectErr:     true,
 		},
 		"delete failures should still call all deletes": {
 			numEndpoints:  64,
 			lastPostsFail: 64,
-			expectDeletes: 64,
-			deletesFail:   true,
 			expectErr:     true,
 		},
 	}
@@ -321,7 +351,6 @@ func TestSendPrepareShutdown(t *testing.T) {
 	for n, c := range cases {
 		t.Run(n, func(t *testing.T) {
 			var postCalls atomic.Int32
-			var deleteCalls atomic.Int32
 
 			errResponse := &http.Response{
 				StatusCode: http.StatusInternalServerError,
@@ -332,8 +361,8 @@ func TestSendPrepareShutdown(t *testing.T) {
 				Body:       io.NopCloser(strings.NewReader("good")),
 			}
 
-			httpClient := &fakeHttpClient{
-				mockDo: func(r *http.Request) (*http.Response, error) {
+			httpClient := newFakeHttpClient(
+				func(r *http.Request) (*http.Response, error) {
 					if r.Method == http.MethodPost {
 						calls := postCalls.Add(1)
 						if calls > int32(c.numEndpoints-c.lastPostsFail) {
@@ -341,17 +370,10 @@ func TestSendPrepareShutdown(t *testing.T) {
 						} else {
 							return successResponse, nil
 						}
-					} else if r.Method == http.MethodDelete {
-						deleteCalls.Add(1)
-						if c.deletesFail {
-							return errResponse, nil
-						} else {
-							return successResponse, nil
-						}
 					}
 					panic("unexpected method")
 				},
-			}
+			)
 
 			endpoints := make([]endpoint, 0, c.numEndpoints)
 			for i := range cap(endpoints) {
@@ -373,7 +395,63 @@ func TestSendPrepareShutdown(t *testing.T) {
 			} else {
 				assert.Equal(t, int32(c.numEndpoints), postCalls.Load(), "all endpoints should have been sent a POST")
 			}
-			assert.Equal(t, int32(c.expectDeletes), deleteCalls.Load())
+		})
+	}
+}
+
+func TestUndoPrepareShutdown(t *testing.T) {
+	cases := map[string]struct {
+		numEndpoints int
+		deletesFail  bool
+	}{
+		"no endpoints": {
+			numEndpoints: 0,
+			deletesFail:  false,
+		},
+		"all posts succeed": {
+			numEndpoints: 64,
+			deletesFail:  false,
+		},
+		"delete failures should still call all deletes": {
+			numEndpoints: 64,
+			deletesFail:  true,
+		},
+	}
+
+	for n, c := range cases {
+		t.Run(n, func(t *testing.T) {
+			errResponse := &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader("we've had a problem")),
+			}
+			successResponse := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("good")),
+			}
+
+			httpClient := newFakeHttpClient(
+				func(r *http.Request) (*http.Response, error) {
+					if r.Method == http.MethodDelete {
+						if c.deletesFail {
+							return errResponse, nil
+						} else {
+							return successResponse, nil
+						}
+					}
+					panic("unexpected method")
+				},
+			)
+
+			endpoints := make([]endpoint, 0, c.numEndpoints)
+			for i := range cap(endpoints) {
+				endpoints = append(endpoints, endpoint{
+					url:   fmt.Sprintf("url-something.foo.%d.example.biz", i),
+					index: i,
+				})
+			}
+
+			undoPrepareShutdownRequests(context.Background(), log.NewNopLogger(), httpClient, endpoints)
+			assert.Equal(t, c.numEndpoints, httpClient.calls(http.MethodDelete), "")
 		})
 	}
 }
@@ -679,8 +757,14 @@ func testPrepDownscaleWebhookWithZoneTracker(t *testing.T, oldReplicas, newRepli
 			},
 		)
 	}
+
 	api := fake.NewSimpleClientset(objects...)
-	f := &fakeHttpClient{statusCode: params.statusCode}
+	f := newFakeHttpClient(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: params.statusCode,
+			Body:       io.NopCloser(bytes.NewBuffer([]byte(""))),
+		}, nil
+	})
 
 	zt := newZoneTracker(api, namespace, "zone-tracker-test-cm")
 

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -63,11 +63,6 @@ func TestInvalidDownscale(t *testing.T) {
 	testPrepDownscaleWebhookWithZoneTracker(t, 5, 3, withStatusCode(http.StatusInternalServerError), expectDeletes())
 }
 
-func TestFailStoreAnnotation(t *testing.T) {
-	testPrepDownscaleWebhook(t, 5, 3, expectDeletes())
-	testPrepDownscaleWebhookWithZoneTracker(t, 5, 3, expectDeletes())
-}
-
 func TestDownscaleDryRun(t *testing.T) {
 	testPrepDownscaleWebhook(t, 5, 3, withDryRun())
 	testPrepDownscaleWebhookWithZoneTracker(t, 5, 3, withDryRun())
@@ -291,6 +286,7 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 		)
 	}
 	api := fake.NewSimpleClientset(objects...)
+
 	f := newFakeHttpClient(
 		func(r *http.Request) (*http.Response, error) {
 			return &http.Response{

--- a/pkg/admission/zone_tracker.go
+++ b/pkg/admission/zone_tracker.go
@@ -143,15 +143,18 @@ func (zt *zoneTracker) prepareDownscale(ctx context.Context, l log.Logger, ar v1
 		}
 	}
 
-	// Since it's a downscale, check if the resource has the label that indicates it needs to be prepared to be downscaled.
-	// Create a slice of endpoint addresses for pods to send HTTP post requests to and to fail if any don't return 200
+	// It's a downscale, so we need to prepare the pods that are going away for shutdown.
 	eps := createEndpoints(ar, oldInfo, newInfo, port, path)
 
 	err = sendPrepareShutdownRequests(ctx, logger, client, eps)
 	if err != nil {
-		// At least one failed. Undo them all.
-		level.Warn(logger).Log("msg", "failed to prepare hosts for shutdown. unpreparing...", "err", err)
+		// Down-scale operation is disallowed because at least one pod failed to
+		// prepare for shutdown and cannot be deleted. We also need to
+		// un-prepare them all.
+
+		level.Error(logger).Log("msg", "downscale not allowed due to host(s) failing to prepare for downscale. unpreparing...", "err", err)
 		undoPrepareShutdownRequests(ctx, logger, client, eps)
+
 		return deny(
 			"downscale of %s/%s in %s from %d to %d replicas is not allowed because one or more pods failed to prepare for shutdown.",
 			ar.Request.Resource.Resource, ar.Request.Name, ar.Request.Namespace, *oldInfo.replicas, *newInfo.replicas,
@@ -159,7 +162,9 @@ func (zt *zoneTracker) prepareDownscale(ctx context.Context, l log.Logger, ar v1
 	}
 
 	if err := zt.setDownscaled(ctx, ar.Request.Name); err != nil {
-		level.Error(logger).Log("msg", "downscale not allowed due to error while setting downscale timestamp in the zone ConfigMap", "err", err)
+		// Down-scale operation is disallowed because we failed to add the
+		// annotation to the statefulset. We again need to un-prepare all pods.
+		level.Error(logger).Log("msg", "downscale not allowed due to error while adding annotation. unpreparing...", "err", err)
 		undoPrepareShutdownRequests(ctx, logger, client, eps)
 		return deny(
 			"downscale of %s/%s in %s from %d to %d replicas is not allowed because setting downscale timestamp in the zone ConfigMap failed.",
@@ -167,7 +172,7 @@ func (zt *zoneTracker) prepareDownscale(ctx context.Context, l log.Logger, ar v1
 		)
 	}
 
-	// Down-scale operation is allowed because all pods successfully prepared for shutdown
+	// Otherwise, we've made it through the gauntlet, and the downscale is allowed.
 	level.Info(logger).Log("msg", "downscale allowed")
 	return &v1.AdmissionResponse{
 		Allowed: true,


### PR DESCRIPTION
Fix a snag found in #146 where if the "downscaled" annotation/configmap fails to persist, the scale operation is denied, but the pods are not informed via `DELETE` that they should no longer shutdown.