### PR TITLE
Include username in 'handling request' log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * The standard base image is now `gcr.io/distroless/static-debian12:nonroot`.
   * The boringcrypto base image is now `gcr.io/distroless/base-nossl-debian12:nonroot` (for glibc).
 * [ENHANCEMENT] Include unique IDs of webhook requests in logs for easier debugging. #150
+* [ENHANCEMENT] Include k8s operation username in request debug logs. #152
 
 ## v0.16.0
 

--- a/pkg/admission/serve.go
+++ b/pkg/admission/serve.go
@@ -78,6 +78,7 @@ func Serve(admit AdmitV1Func, logger log.Logger, api *kubernetes.Clientset) http
 				"namespace", requestedAdmissionReview.Request.Namespace,
 				"name", requestedAdmissionReview.Request.Name,
 				"request.uid", requestedAdmissionReview.Request.UID,
+				"request.username", requestedAdmissionReview.Request.UserInfo.Username,
 			)
 			responseAdmissionReview := &v1beta1.AdmissionReview{}
 			responseAdmissionReview.SetGroupVersionKind(*gvk)
@@ -97,6 +98,7 @@ func Serve(admit AdmitV1Func, logger log.Logger, api *kubernetes.Clientset) http
 				"namespace", requestedAdmissionReview.Request.Namespace,
 				"name", requestedAdmissionReview.Request.Name,
 				"request.uid", requestedAdmissionReview.Request.UID,
+				"request.username", requestedAdmissionReview.Request.UserInfo.Username,
 			)
 			responseAdmissionReview := &v1.AdmissionReview{}
 			responseAdmissionReview.SetGroupVersionKind(*gvk)


### PR DESCRIPTION
Who is calling the webhook? Often this would be useful to know. Sometimes it is rollout-operator itself patching a resource.