### PR TITLE
Support percentages in rollout-max-unavailable annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * The boringcrypto base image is now `gcr.io/distroless/base-nossl-debian12:nonroot` (for glibc).
 * [ENHANCEMENT] Include unique IDs of webhook requests in logs for easier debugging. #150
 * [ENHANCEMENT] Include k8s operation username in request debug logs. #152
+* [ENHANCEMENT] `rollout-max-unavailable` annotation can now be specified as percentage, e.g.: `rollout-max-unavailable: 25%`. Resulting value is computed as `floor(replicas * percentage)`, but is never less than 1. #153
 
 ## v0.16.0
 


### PR DESCRIPTION
This PR enhances `rollout-max-unavailable` annotation to support values specified as percentage of statefulset replicas. Eg. `rollout-max-unavailable: 50%`. Returned value is `floor(replicas * percentage)`, but never less than 1.