### PR TITLE
Fix unbalanced pairs in log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [ENHANCEMENT] Include unique IDs of webhook requests in logs for easier debugging. #150
 * [ENHANCEMENT] Include k8s operation username in request debug logs. #152
 * [ENHANCEMENT] `rollout-max-unavailable` annotation can now be specified as percentage, e.g.: `rollout-max-unavailable: 25%`. Resulting value is computed as `floor(replicas * percentage)`, but is never less than 1. #153
+* [BUGFIX] Fix a mangled error log in controller's delayed downscale code. #154
 
 ## v0.16.0
 

--- a/pkg/controller/delay.go
+++ b/pkg/controller/delay.go
@@ -166,7 +166,7 @@ func callPrepareDownscaleAndReturnMaxPrepareTimestamp(ctx context.Context, logge
 
 			resp, err := client.Do(req)
 			if err != nil {
-				level.Error(epLogger).Log("error sending HTTP POST request to endpoint", "err", err)
+				level.Error(epLogger).Log("msg", "error sending HTTP POST request to endpoint", "err", err)
 				return err
 			}
 


### PR DESCRIPTION
Drive-by bug fix while looking at logs:

`level=error ts=2024-06-13T03:30:49.769575693Z pod=ingester-zone-a-16 url=http://ingester-zone-a-16.ingester-zone-a.mimir-dev.svc.cluster.local./ingester/prepare-partition-downscale errorsendingHTTPPOSTrequesttoendpoint=err`