### PR TITLE
Allow delayed downscale of subset of pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [ENHANCEMENT] Include unique IDs of webhook requests in logs for easier debugging. #150
 * [ENHANCEMENT] Include k8s operation username in request debug logs. #152
 * [ENHANCEMENT] `rollout-max-unavailable` annotation can now be specified as percentage, e.g.: `rollout-max-unavailable: 25%`. Resulting value is computed as `floor(replicas * percentage)`, but is never less than 1. #153
+* [ENHANCEMENT] Delayed downscale of statefulset can now reduce replicas earlier, if subset of pods at the end of statefulset have already reached their delay. #156
 * [BUGFIX] Fix a mangled error log in controller's delayed downscale code. #154
 
 ## v0.16.0

--- a/pkg/controller/custom_resource_replicas.go
+++ b/pkg/controller/custom_resource_replicas.go
@@ -45,7 +45,7 @@ func (c *RolloutController) adjustStatefulSetsGroupReplicasToMirrorResource(ctx 
 		// We're going to change number of replicas on the statefulset.
 		// If there is delayed downscale configured on the statefulset, we will first handle delay part, and only if that succeeds,
 		// continue with downscaling or upscaling.
-		desiredReplicas := referenceResourceDesiredReplicas
+		var desiredReplicas int32
 		if newDesiredReplicas, err := checkScalingDelay(ctx, c.logger, sts, client, currentReplicas, referenceResourceDesiredReplicas); err != nil {
 			level.Warn(c.logger).Log("msg", "not scaling statefulset due to failed scaling delay check",
 				"group", groupName,

--- a/pkg/controller/custom_resource_replicas.go
+++ b/pkg/controller/custom_resource_replicas.go
@@ -45,8 +45,8 @@ func (c *RolloutController) adjustStatefulSetsGroupReplicasToMirrorResource(ctx 
 		// We're going to change number of replicas on the statefulset.
 		// If there is delayed downscale configured on the statefulset, we will first handle delay part, and only if that succeeds,
 		// continue with downscaling or upscaling.
-		var desiredReplicas int32
-		if newDesiredReplicas, err := checkScalingDelay(ctx, c.logger, sts, client, currentReplicas, referenceResourceDesiredReplicas); err != nil {
+		desiredReplicas, err := checkScalingDelay(ctx, c.logger, sts, client, currentReplicas, referenceResourceDesiredReplicas)
+		if err != nil {
 			level.Warn(c.logger).Log("msg", "not scaling statefulset due to failed scaling delay check",
 				"group", groupName,
 				"name", sts.GetName(),
@@ -58,8 +58,6 @@ func (c *RolloutController) adjustStatefulSetsGroupReplicasToMirrorResource(ctx 
 			updateStatusReplicasOnReferenceResourceIfNeeded(ctx, c.logger, c.dynamicClient, sts, scaleObj, referenceGVR, referenceName, currentReplicas)
 			// If delay has not been reached, we can check next statefulset.
 			continue
-		} else {
-			desiredReplicas = newDesiredReplicas
 		}
 
 		logMsg := ""

--- a/pkg/controller/delay.go
+++ b/pkg/controller/delay.go
@@ -47,7 +47,7 @@ func checkScalingDelay(ctx context.Context, logger log.Logger, sts *v1.StatefulS
 
 	delay, prepareURL, err := parseDelayedDownscaleAnnotations(sts.GetAnnotations())
 	if delay == 0 || prepareURL == nil || err != nil {
-		return desiredReplicas, err
+		return currentReplicas, err
 	}
 
 	if desiredReplicas >= currentReplicas {
@@ -66,7 +66,7 @@ func checkScalingDelay(ctx context.Context, logger log.Logger, sts *v1.StatefulS
 	downscaleEndpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), int(desiredReplicas), int(currentReplicas), prepareURL)
 	elapsedTimeSinceDownscaleInitiated, err := callPrepareDownscaleAndReturnElapsedDurationsSinceInitiatedDownscale(ctx, logger, httpClient, downscaleEndpoints)
 	if err != nil {
-		return desiredReplicas, fmt.Errorf("failed prepare pods for delayed downscale: %v", err)
+		return currentReplicas, fmt.Errorf("failed prepare pods for delayed downscale: %v", err)
 	}
 
 	// Find how many pods from the end of statefulset we can already scale down

--- a/pkg/controller/delay.go
+++ b/pkg/controller/delay.go
@@ -46,8 +46,11 @@ func checkScalingDelay(ctx context.Context, logger log.Logger, sts *v1.StatefulS
 	}
 
 	delay, prepareURL, err := parseDelayedDownscaleAnnotations(sts.GetAnnotations())
-	if delay == 0 || prepareURL == nil || err != nil {
+	if err != nil {
 		return currentReplicas, err
+	}
+	if delay == 0 || prepareURL == nil {
+		return desiredReplicas, err
 	}
 
 	if desiredReplicas >= currentReplicas {


### PR DESCRIPTION
This PR implements earlier delayed downscale of pods that have already reached their delay, even if not ALL pods have reached it yet. 

Fixes https://github.com/grafana/rollout-operator/issues/155
