### PR TITLE
Allow for podSelectorKey

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -48,6 +48,7 @@ type RolloutController struct {
 	kubeClient           kubernetes.Interface
 	namespace            string
 	reconcileInterval    time.Duration
+	podSelectorKey       string
 	statefulSetsFactory  informers.SharedInformerFactory
 	statefulSetLister    listersv1.StatefulSetLister
 	statefulSetsInformer cache.SharedIndexInformer
@@ -77,7 +78,7 @@ type RolloutController struct {
 	discoveredGroups map[string]struct{}
 }
 
-func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTMapper, scaleClient scale.ScalesGetter, dynamic dynamic.Interface, namespace string, client httpClient, reconcileInterval time.Duration, reg prometheus.Registerer, logger log.Logger) *RolloutController {
+func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTMapper, scaleClient scale.ScalesGetter, dynamic dynamic.Interface, namespace string, client httpClient, reconcileInterval time.Duration, podSelectorKey string, reg prometheus.Registerer, logger log.Logger) *RolloutController {
 	namespaceOpt := informers.WithNamespace(namespace)
 
 	// Initialise the StatefulSet informer to restrict the returned StatefulSets to only the ones
@@ -96,6 +97,7 @@ func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTM
 		kubeClient:           kubeClient,
 		namespace:            namespace,
 		reconcileInterval:    reconcileInterval,
+		podSelectorKey:       podSelectorKey,
 		statefulSetsFactory:  statefulSetsFactory,
 		statefulSetLister:    statefulSetsInformer.Lister(),
 		statefulSetsInformer: statefulSetsInformer.Informer(),
@@ -452,7 +454,7 @@ func (c *RolloutController) hasStatefulSetNotReadyPods(sts *v1.StatefulSet) (boo
 func (c *RolloutController) listPodsByStatefulSet(sts *v1.StatefulSet) ([]*corev1.Pod, error) {
 	// Select all pods belonging to the input StatefulSet.
 	podsSelector := labels.NewSelector().Add(
-		util.MustNewLabelsRequirement("name", selection.Equals, []string{sts.Spec.Template.Labels["name"]}),
+		util.MustNewLabelsRequirement(c.podSelectorKey, selection.Equals, []string{sts.Spec.Template.Labels[c.podSelectorKey]}),
 	)
 
 	pods, err := c.listPods(podsSelector)
@@ -584,7 +586,7 @@ func (c *RolloutController) podsNotMatchingUpdateRevision(sts *v1.StatefulSet) (
 	// and so it means they still need to be updated.
 	podsSelector := labels.NewSelector().Add(
 		util.MustNewLabelsRequirement(v1.ControllerRevisionHashLabelKey, selection.NotEquals, []string{updateRev}),
-		util.MustNewLabelsRequirement("name", selection.Equals, []string{sts.Spec.Template.Labels["name"]}),
+		util.MustNewLabelsRequirement(c.podSelectorKey, selection.Equals, []string{sts.Spec.Template.Labels[c.podSelectorKey]}),
 	)
 
 	pods, err := c.listPods(podsSelector)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -540,7 +540,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 
 			// Create the controller and start informers.
 			reg := prometheus.NewPedanticRegistry()
-			c := NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger())
+			c := NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, testNamespace, nil, 5*time.Second, "name", reg, log.NewNopLogger())
 			require.NoError(t, c.Init())
 			defer c.Stop()
 
@@ -849,7 +849,7 @@ func TestRolloutController_ReconcileStatefulsetWithDownscaleDelay(t *testing.T) 
 
 			// Create the controller and start informers.
 			reg := prometheus.NewPedanticRegistry()
-			c := NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, testNamespace, httpClient, 5*time.Second, reg, log.NewNopLogger())
+			c := NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, testNamespace, httpClient, 5*time.Second, "name", reg, log.NewNopLogger())
 			require.NoError(t, c.Init())
 			defer c.Stop()
 
@@ -952,7 +952,7 @@ func TestRolloutController_ReconcileShouldDeleteMetricsForDecommissionedRolloutG
 
 	// Create the controller and start informers.
 	reg := prometheus.NewPedanticRegistry()
-	c := NewRolloutController(kubeClient, nil, nil, nil, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger())
+	c := NewRolloutController(kubeClient, nil, nil, nil, testNamespace, nil, 5*time.Second, "name", reg, log.NewNopLogger())
 	require.NoError(t, c.Init())
 	defer c.Stop()
 


### PR DESCRIPTION
This PR allows for the Grafana Rollout Operator to customize the key used to select for pods. My org's internal infra uses a different label from `name` and customizing it is trickier than having the rollout operator use for a different key instead.