### PR TITLE
Allow for graceful delete through a pod label

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,10 @@ const (
 	PrepareDownscaleLabelKey   = "grafana.com/prepare-downscale"
 	PrepareDownscaleLabelValue = "true"
 
+	// GracefulShutdownLabelKey is the label to gracefully shut down a pod of a statefulset.
+	GracefulShutdownLabelKey   = "grafana.com/graceful-shutdown"
+	GracefulShutdownLabelValue = "delete-pod"
+
 	// RolloutGroupLabelKey is the group to which multiple statefulsets belong and must be operated on together.
 	RolloutGroupLabelKey = "rollout-group"
 	// RolloutMaxUnavailableAnnotationKey is the max number of pods in each statefulset that may be stopped at


### PR DESCRIPTION
### Summary 

This PR introduces a new pod-level label that can be added by any external operator in order to gracefully terminate a pod without causing unavailability for Mimir across a set of statefulsets (ingesters or store-gateways). 

I've chosen to explicitly check for delete-label pods _only_ if there are no pods requiring a rotation due to a statefulset deploy.  **Therefore, priority is maintained for rollouts first for a given statefulset before deleting.** 

I also chose label instead of the original issue calling for an annotation to be able to reuse the selector code paths. I've found this to be more idiomatic when searching for Kubernetes resources. 

I'm happy to explore annotations if there's a strong desire to go that way, it would just require pulling down all the pods and performing the filtering in code as opposed to the Kubernetes API.

I'm opening this PR for feedback. PTAL and let me know what changes I can make. Thank you.

### Testing
I added three unit tests for three different behaviors:
1. should delete pods that are labeled for deletion when all statefulsets are up-to-date
2. should delete pods that are labeled for deletion for an up-to-date statefulset during rollout
3. should ignore labeled pods and delete those that are not running up-to-date revision during rollout

I also tested this in our internal infrastructure:

Command issued:
```
$ kubectl --context mesh-obs-a-ea1-us -n test-2 label pods ingester-zone-b-test-2-0 grafana.com/graceful-shutdown=delete-pod 
pod/ingester-zone-b-test-2-0 labeled
```

Logs:
```
level=info ts=2024-08-02T04:42:44.800730171Z msg="reconcile started"
level=debug ts=2024-08-02T04:42:44.801069706Z msg="reconciling StatefulSet" statefulset=ingester-zone-a-test-2
level=debug ts=2024-08-02T04:42:44.80109812Z msg="reconciling StatefulSet" statefulset=ingester-zone-b-test-2
level=debug ts=2024-08-02T04:42:44.801116072Z msg="found 1 pod(s) marked for graceful termination"
level=info ts=2024-08-02T04:42:44.801120419Z msg="terminating pod ingester-zone-b-test-2-0"
level=debug ts=2024-08-02T04:42:44.812272065Z msg="reconciling StatefulSet" statefulset=store-gtwy-zone-a-test-2
level=debug ts=2024-08-02T04:42:44.81230467Z msg="reconciling StatefulSet" statefulset=store-gtwy-zone-b-test-2
level=debug ts=2024-08-02T04:42:44.812323907Z msg="reconciling StatefulSet" statefulset=store-gtwy-zone-c-test-2
level=info ts=2024-08-02T04:42:44.812344139Z msg="reconcile done"
level=info ts=2024-08-02T04:42:49.812925318Z msg="reconcile started"
level=info ts=2024-08-02T04:42:49.8132528Z msg="StatefulSet status is reporting all pods ready, but the rollout operator has found some not-Ready pods" statefulset=ingester-zone-b-test-2 not_ready_pods=ingester-zone-b-test-2-0
level=info ts=2024-08-02T04:42:49.813265063Z msg="a StatefulSet has some not-Ready pods, reconcile it first" statefulset=ingester-zone-b-test-2
level=debug ts=2024-08-02T04:42:49.813267779Z msg="reconciling StatefulSet" statefulset=ingester-zone-b-test-2
level=debug ts=2024-08-02T04:42:49.813291663Z msg="found 1 pod(s) marked for graceful termination"
level=debug ts=2024-08-02T04:42:49.813295854Z msg="waiting for pod ingester-zone-b-test-2-0 to be terminated"
level=debug ts=2024-08-02T04:42:49.813316609Z msg="reconciling StatefulSet" statefulset=store-gtwy-zone-a-test-2
level=debug ts=2024-08-02T04:42:49.81333483Z msg="reconciling StatefulSet" statefulset=store-gtwy-zone-b-test-2
level=debug ts=2024-08-02T04:42:49.81335237Z msg="reconciling StatefulSet" statefulset=store-gtwy-zone-c-test-2
level=info ts=2024-08-02T04:42:49.813369711Z msg="reconcile done"
level=info ts=2024-08-02T04:43:09.816083005Z msg="reconcile started"
level=debug ts=2024-08-02T04:43:09.816436732Z msg="reconciling StatefulSet" statefulset=store-gtwy-zone-a-test-2
level=debug ts=2024-08-02T04:43:09.816476657Z msg="reconciling StatefulSet" statefulset=store-gtwy-zone-b-test-2
level=debug ts=2024-08-02T04:43:09.816496851Z msg="reconciling StatefulSet" statefulset=store-gtwy-zone-c-test-2
level=info ts=2024-08-02T04:43:09.816525269Z msg="a StatefulSet has some not-Ready pods, reconcile it first" statefulset=ingester-zone-b-test-2
level=debug ts=2024-08-02T04:43:09.816527614Z msg="reconciling StatefulSet" statefulset=ingester-zone-b-test-2
level=debug ts=2024-08-02T04:43:09.816543425Z msg="found 1 pod(s) marked for graceful termination"
level=info ts=2024-08-02T04:43:09.81654687Z msg="StatefulSet has some pods to be updated but maxUnavailable pods has been reached" statefulset=ingester-zone-b-test-2 pods_to_update=1 replicas=1 ready_replicas=0 max_unavailable=1
level=info ts=2024-08-02T04:43:09.816553377Z msg="reconcile done"
```

### Fixes 

https://github.com/grafana/rollout-operator/issues/148

### Reviewers

@pracucci @rishabhkumar92 