### PR TITLE
Shorten `grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas` annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [CHANGE] Renamed `grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas` annotation to `grafana.com/rollout-mirror-replicas-from-resource-write-back`, because it was too long (over 64 chars). #
+
 ## v0.19.0
 
 * [ENHANCEMENT] Updated dependencies, including: #165
@@ -13,7 +15,7 @@
   * `k8s.io/client-go` from `v0.30.0` to `v0.30.3`
   * `sigs.k8s.io/controller-runtime` from `v0.18.1` to `v0.18.5`
 * [ENHANCEMENT] Update Go to `1.23`. #168
-* [ENHANCEMENT] When mirroring replicas of statefulset, rollout-operator can now skip writing back number of replicas to reference resource, by setting `grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas` annotation to `false`. #169
+* [ENHANCEMENT] When mirroring replicas of statefulset, rollout-operator can now skip writing back number of replicas to reference resource, by setting `grafana.com/rollout-mirror-replicas-from-resource-write-back` annotation to `false`. #169
 
 ## v0.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main / unreleased
 
-* [CHANGE] Renamed `grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas` annotation to `grafana.com/rollout-mirror-replicas-from-resource-write-back`, because it was too long (over 64 chars). #
+* [CHANGE] Renamed `grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas` annotation to `grafana.com/rollout-mirror-replicas-from-resource-write-back`, because it was too long (over 64 chars). #171
 
 ## v0.19.0
 
@@ -15,7 +15,7 @@
   * `k8s.io/client-go` from `v0.30.0` to `v0.30.3`
   * `sigs.k8s.io/controller-runtime` from `v0.18.1` to `v0.18.5`
 * [ENHANCEMENT] Update Go to `1.23`. #168
-* [ENHANCEMENT] When mirroring replicas of statefulset, rollout-operator can now skip writing back number of replicas to reference resource, by setting `grafana.com/rollout-mirror-replicas-from-resource-write-back` annotation to `false`. #169
+* [ENHANCEMENT] When mirroring replicas of statefulset, rollout-operator can now skip writing back number of replicas to reference resource, by setting `grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas` annotation to `false`. #169
 
 ## v0.18.0
 

--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ Rollout-operator can use custom resource with `scale` and `status` subresources 
 * `grafana.com/rollout-mirror-replicas-from-resource-name`
 * `grafana.com/rollout-mirror-replicas-from-resource-kind`
 * `grafana.com/rollout-mirror-replicas-from-resource-api-version`
-* `grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas`
+* `grafana.com/rollout-mirror-replicas-from-resource-write-back`
 
 These annotations must be set on StatefulSet that rollout-operator will scale (ie. target statefulset).
 Number of replicas in target statefulset will follow replicas in reference resource (from `scale` subresource).
 Reference resource's `status` subresource will be updated with current number of replicas in target statefulset,
-unless explicitly disabled by setting `grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas` annotation to `false`.
+unless explicitly disabled by setting `grafana.com/rollout-mirror-replicas-from-resource-write-back` annotation to `false`.
 
 This is similar to using `grafana.com/rollout-downscale-leader`, but reference resource can be any kind of resource, not just statefulset. Furthermore `grafana.com/min-time-between-zones-downscale` is not respected when using scaling based on reference resource.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,8 +37,8 @@ const (
 	// replicas based on replicas in this resource (its scale subresource).
 	RolloutMirrorReplicasFromResourceNameAnnotationKey       = rolloutMirrorReplicasFromResourceAnnotationKeyPrefix + "-name"
 	RolloutMirrorReplicasFromResourceKindAnnotationKey       = rolloutMirrorReplicasFromResourceAnnotationKeyPrefix + "-kind"
-	RolloutMirrorReplicasFromResourceAPIVersionAnnotationKey = rolloutMirrorReplicasFromResourceAnnotationKeyPrefix + "-api-version"                // optional
-	RolloutMirrorReplicasFromResourceWriteBackStatusReplicas = rolloutMirrorReplicasFromResourceAnnotationKeyPrefix + "-write-back-status-replicas" // optional
+	RolloutMirrorReplicasFromResourceAPIVersionAnnotationKey = rolloutMirrorReplicasFromResourceAnnotationKeyPrefix + "-api-version" // optional
+	RolloutMirrorReplicasFromResourceWriteBackStatusReplicas = rolloutMirrorReplicasFromResourceAnnotationKeyPrefix + "-write-back"  // optional
 
 	// RolloutDelayedDownscaleAnnotationKey configures delay for downscaling. Prepare-url must be configured as well, and must support GET, POST and DELETE methods.
 	RolloutDelayedDownscaleAnnotationKey = "grafana.com/rollout-delayed-downscale"

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -413,10 +413,10 @@ func TestRolloutController_Reconcile(t *testing.T) {
 		"should return early and scale up statefulset based on reference custom resource, but not patch the resource since it's disabled": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-b", withReplicas(2, 2), withAnnotations(map[string]string{
-					"grafana.com/rollout-mirror-replicas-from-resource-name":                       "test",
-					"grafana.com/rollout-mirror-replicas-from-resource-kind":                       customResourceGVK.Kind,
-					"grafana.com/rollout-mirror-replicas-from-resource-api-version":                customResourceGVK.GroupVersion().String(),
-					"grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas": "false",
+					"grafana.com/rollout-mirror-replicas-from-resource-name":        "test",
+					"grafana.com/rollout-mirror-replicas-from-resource-kind":        customResourceGVK.Kind,
+					"grafana.com/rollout-mirror-replicas-from-resource-api-version": customResourceGVK.GroupVersion().String(),
+					"grafana.com/rollout-mirror-replicas-from-resource-write-back":  "false",
 				})),
 			},
 			customResourceScaleSpecReplicas:   5,
@@ -440,10 +440,10 @@ func TestRolloutController_Reconcile(t *testing.T) {
 		"should return early and scale down statefulset based on reference custom resource, but not patch the resource since it's disabled": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-b", withReplicas(3, 3), withAnnotations(map[string]string{
-					"grafana.com/rollout-mirror-replicas-from-resource-name":                       "test",
-					"grafana.com/rollout-mirror-replicas-from-resource-kind":                       customResourceGVK.Kind,
-					"grafana.com/rollout-mirror-replicas-from-resource-api-version":                customResourceGVK.GroupVersion().String(),
-					"grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas": "false",
+					"grafana.com/rollout-mirror-replicas-from-resource-name":        "test",
+					"grafana.com/rollout-mirror-replicas-from-resource-kind":        customResourceGVK.Kind,
+					"grafana.com/rollout-mirror-replicas-from-resource-api-version": customResourceGVK.GroupVersion().String(),
+					"grafana.com/rollout-mirror-replicas-from-resource-write-back":  "false",
 				})),
 			},
 			customResourceScaleSpecReplicas:   2,
@@ -467,10 +467,10 @@ func TestRolloutController_Reconcile(t *testing.T) {
 		"should not patch scale subresource status.replicas since it's disabled, even though spec.replicas != statefulset.spec.replicas": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-b", withReplicas(3, 3), withAnnotations(map[string]string{
-					"grafana.com/rollout-mirror-replicas-from-resource-name":                       "test",
-					"grafana.com/rollout-mirror-replicas-from-resource-kind":                       customResourceGVK.Kind,
-					"grafana.com/rollout-mirror-replicas-from-resource-api-version":                customResourceGVK.GroupVersion().String(),
-					"grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas": "false",
+					"grafana.com/rollout-mirror-replicas-from-resource-name":        "test",
+					"grafana.com/rollout-mirror-replicas-from-resource-kind":        customResourceGVK.Kind,
+					"grafana.com/rollout-mirror-replicas-from-resource-api-version": customResourceGVK.GroupVersion().String(),
+					"grafana.com/rollout-mirror-replicas-from-resource-write-back":  "false",
 				})),
 			},
 			customResourceScaleSpecReplicas:   3,
@@ -521,10 +521,10 @@ func TestRolloutController_Reconcile(t *testing.T) {
 					"grafana.com/rollout-mirror-replicas-from-resource-api-version": customResourceGVK.GroupVersion().String(),
 				})),
 				mockStatefulSet("ingester-zone-c", withReplicas(5, 5), withAnnotations(map[string]string{
-					"grafana.com/rollout-mirror-replicas-from-resource-name":                       "test",
-					"grafana.com/rollout-mirror-replicas-from-resource-kind":                       customResourceGVK.Kind,
-					"grafana.com/rollout-mirror-replicas-from-resource-api-version":                customResourceGVK.GroupVersion().String(),
-					"grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas": "true", // Patching of reference resource is explicitly enabled.
+					"grafana.com/rollout-mirror-replicas-from-resource-name":        "test",
+					"grafana.com/rollout-mirror-replicas-from-resource-kind":        customResourceGVK.Kind,
+					"grafana.com/rollout-mirror-replicas-from-resource-api-version": customResourceGVK.GroupVersion().String(),
+					"grafana.com/rollout-mirror-replicas-from-resource-write-back":  "true", // Patching of reference resource is explicitly enabled.
 				})),
 				mockStatefulSet("ingester-zone-d", withReplicas(2, 2), withAnnotations(map[string]string{
 					"grafana.com/rollout-mirror-replicas-from-resource-name":        "test",
@@ -543,16 +543,16 @@ func TestRolloutController_Reconcile(t *testing.T) {
 				mockStatefulSet("ingester-zone-a", withReplicas(4, 4)),
 				// Is already scaled.
 				mockStatefulSet("ingester-zone-b", withReplicas(5, 5), withAnnotations(map[string]string{
-					"grafana.com/rollout-mirror-replicas-from-resource-name":                       "test",
-					"grafana.com/rollout-mirror-replicas-from-resource-kind":                       customResourceGVK.Kind,
-					"grafana.com/rollout-mirror-replicas-from-resource-api-version":                customResourceGVK.GroupVersion().String(),
-					"grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas": "false", // Explicitly disabled.
+					"grafana.com/rollout-mirror-replicas-from-resource-name":        "test",
+					"grafana.com/rollout-mirror-replicas-from-resource-kind":        customResourceGVK.Kind,
+					"grafana.com/rollout-mirror-replicas-from-resource-api-version": customResourceGVK.GroupVersion().String(),
+					"grafana.com/rollout-mirror-replicas-from-resource-write-back":  "false", // Explicitly disabled.
 				})),
 				mockStatefulSet("ingester-zone-c", withReplicas(5, 5), withAnnotations(map[string]string{
-					"grafana.com/rollout-mirror-replicas-from-resource-name":                       "test",
-					"grafana.com/rollout-mirror-replicas-from-resource-kind":                       customResourceGVK.Kind,
-					"grafana.com/rollout-mirror-replicas-from-resource-api-version":                customResourceGVK.GroupVersion().String(),
-					"grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas": "bad value", // Disabled through wrong value.
+					"grafana.com/rollout-mirror-replicas-from-resource-name":        "test",
+					"grafana.com/rollout-mirror-replicas-from-resource-kind":        customResourceGVK.Kind,
+					"grafana.com/rollout-mirror-replicas-from-resource-api-version": customResourceGVK.GroupVersion().String(),
+					"grafana.com/rollout-mirror-replicas-from-resource-write-back":  "bad value", // Disabled through wrong value.
 				})),
 				mockStatefulSet("ingester-zone-d", withReplicas(2, 2), withAnnotations(map[string]string{
 					"grafana.com/rollout-mirror-replicas-from-resource-name":        "test",


### PR DESCRIPTION
Renamed `grafana.com/rollout-mirror-replicas-from-resource-write-back-status-replicas` annotation to `grafana.com/rollout-mirror-replicas-from-resource-write-back`, because it was longer than 64 characters. New length is 60 chars.