### PR TITLE
fix: add support for delayed downscale port in the URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [ENHANCEMENT] Improved handling of URL ports in `createPrepareDownscaleEndpoints` function. The function now correctly preserves the port when replacing the host in the URL. #[PR_NUMBER]
+
 ## v0.20.0
 
 * [ENHANCEMENT] Updated dependencies, including: #174

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main / unreleased
 
-* [ENHANCEMENT] Improved handling of URL ports in `createPrepareDownscaleEndpoints` function. The function now correctly preserves the port when replacing the host in the URL. #[PR_NUMBER]
+* [BUGFIX] Improved handling of URL ports in `createPrepareDownscaleEndpoints` function. The function now correctly preserves the port when replacing the host in the URL. #176
 
 ## v0.20.0
 

--- a/pkg/controller/delay.go
+++ b/pkg/controller/delay.go
@@ -147,7 +147,11 @@ func createPrepareDownscaleEndpoints(namespace, serviceName string, from, to int
 		}
 
 		ep.url = *url
-		ep.url.Host = fmt.Sprintf("%s.%v.%v.svc.cluster.local.", ep.podName, serviceName, ep.namespace)
+		newHost := fmt.Sprintf("%s.%v.%v.svc.cluster.local.", ep.podName, serviceName, ep.namespace)
+		if url.Port() != "" {
+			newHost = fmt.Sprintf("%s:%s", newHost, url.Port())
+		}
+		ep.url.Host = newHost
 
 		eps = append(eps, ep)
 	}

--- a/pkg/controller/delay_test.go
+++ b/pkg/controller/delay_test.go
@@ -1,0 +1,83 @@
+package controller
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreatePrepareDownscaleEndpoints(t *testing.T) {
+	testCases := []struct {
+		name        string
+		namespace   string
+		serviceName string
+		from        int
+		to          int
+		inputURL    string
+		expected    []endpoint
+	}{
+		{
+			name:        "URL without port",
+			namespace:   "test-namespace",
+			serviceName: "test-service",
+			from:        0,
+			to:          2,
+			inputURL:    "http://example.com/api/prepare",
+			expected: []endpoint{
+				{
+					namespace: "test-namespace",
+					podName:   "test-service-0",
+					url:       mustParseURL(t, "http://test-service-0.test-service.test-namespace.svc.cluster.local./api/prepare"),
+					replica:   0,
+				},
+				{
+					namespace: "test-namespace",
+					podName:   "test-service-1",
+					url:       mustParseURL(t, "http://test-service-1.test-service.test-namespace.svc.cluster.local./api/prepare"),
+					replica:   1,
+				},
+			},
+		},
+		{
+			name:        "URL with port",
+			namespace:   "prod-namespace",
+			serviceName: "prod-service",
+			from:        1,
+			to:          3,
+			inputURL:    "http://example.com:8080/api/prepare",
+			expected: []endpoint{
+				{
+					namespace: "prod-namespace",
+					podName:   "prod-service-1",
+					url:       mustParseURL(t, "http://prod-service-1.prod-service.prod-namespace.svc.cluster.local.:8080/api/prepare"),
+					replica:   1,
+				},
+				{
+					namespace: "prod-namespace",
+					podName:   "prod-service-2",
+					url:       mustParseURL(t, "http://prod-service-2.prod-service.prod-namespace.svc.cluster.local.:8080/api/prepare"),
+					replica:   2,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputURL, err := url.Parse(tc.inputURL)
+			require.NoError(t, err)
+
+			result := createPrepareDownscaleEndpoints(tc.namespace, tc.serviceName, tc.from, tc.to, inputURL)
+
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func mustParseURL(t *testing.T, urlString string) url.URL {
+	u, err := url.Parse(urlString)
+	require.NoError(t, err)
+	return *u
+}


### PR DESCRIPTION
This adds support for port in the delayed downscale annotations

```
         'grafana.com/rollout-prepare-delayed-downscale-url': 'http://pod:3100/ingester/prepare_partition_downscale',
```

Previously the port would get erased.