### PR TITLE
Log information about StatefulSets as they are created, updated and deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [ENHANCEMENT] Log debug information about StatefulSets as they are created, updated and deleted. #182
+
 ## v0.20.1
 
 * [BUGFIX] Improved handling of URL ports in `createPrepareDownscaleEndpoints` function. The function now correctly preserves the port when replacing the host in the URL. #176

--- a/development/test-app.yaml
+++ b/development/test-app.yaml
@@ -19,6 +19,7 @@ metadata:
   name: test-app
   labels:
     grafana.com/prepare-downscale: "true"
+    rollout-group: test-app
   annotations:
     grafana.com/prepare-downscale-http-path: "/"
     grafana.com/prepare-downscale-http-port: "80"
@@ -36,3 +37,5 @@ spec:
       containers:
         - name: app
           image: nginx:latest
+  updateStrategy:
+    type: OnDelete


### PR DESCRIPTION
This PR adds extra logging to rollout-operator to aid in reconstructing the series of events that affected a StatefulSet.

This is useful when trying to debug the behaviour of a StatefulSet. For example, we recently had an issue where a StatefulSet was deleted and was recreated with fewer replicas than expected, and this kind of logging would have been helpful to understand what happened.

Sample logs:

```
level=debug ts=2024-11-29T02:54:15.199822428Z msg="observed StatefulSet added" name=test-app namespace=rollout-operator-development replicas=5 generation=1 creation_timestamp=2024-11-29T02:54:15Z
level=debug ts=2024-11-29T02:54:50.2751915Z msg="observed StatefulSet updated" name=test-app namespace=rollout-operator-development old_replicas=5 new_replicas=7 old_generation=1 new_generation=2
level=debug ts=2024-11-29T02:55:20.447203583Z msg="observed StatefulSet deleted" name=test-app namespace=rollout-operator-development replicas=7 generation=2
```