### PR TITLE
Cut changelog for v0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+## v0.21.0
+
 * [ENHANCEMENT] Log debug information about StatefulSets as they are created, updated and deleted. #182
 
 ## v0.20.1


### PR DESCRIPTION
I'm following [the release instructions](https://github.com/grafana/rollout-operator/blob/main/RELEASE.md) to cut a new release of rollout-operator. This is the first step.