### PR TITLE
Added json format logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [ENHANCEMENT] New parameter log.format allows to set logging format to logfmt (default) or json (new). #184
+
 ## v0.21.0
 
 * [ENHANCEMENT] Log debug information about StatefulSets as they are created, updated and deleted. #182


### PR DESCRIPTION
In this PR I am adding support for logging in json format to ease properly formatted logs in logging systems.

logfmt is a bit too less constrained for me and json works in every major log routing software.