### PR TITLE
Make Kubernetes client timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main / unreleased
 
-* [ENHANCEMENT] Make timeout for requests to Pods and to the Kubernetes control plane configurable. #TBD
+* [ENHANCEMENT] Make timeout for requests to Pods and to the Kubernetes control plane configurable. #188
 
 ## v0.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [ENHANCEMENT] Make timeout for requests to Pods and to the Kubernetes control plane configurable. #TBD
+
 ## v0.22.0
 
 * [ENHANCEMENT] New parameter log.format allows to set logging format to logfmt (default) or json (new). #184


### PR DESCRIPTION
Make the timeout added in #186 configurable and default to 5 minutes.