### PR TITLE
Introduce a secondary grouping key for rollout operation

### DIFF
--- a/pkg/admission/zone_tracker.go
+++ b/pkg/admission/zone_tracker.go
@@ -97,8 +97,9 @@ func (zt *zoneTracker) prepareDownscale(ctx context.Context, l log.Logger, ar v1
 	}
 
 	rolloutGroup := lbls[config.RolloutGroupLabelKey]
+	rolloutSecondaryGroup := lbls[config.RolloutSecondaryGroupLabelKey]
 	if rolloutGroup != "" {
-		stsList, err := findStatefulSetsForRolloutGroup(ctx, api, ar.Request.Namespace, rolloutGroup)
+		stsList, err := findStatefulSetsForRolloutGroup(ctx, api, ar.Request.Namespace, rolloutGroup, rolloutSecondaryGroup)
 		if err != nil {
 			level.Warn(logger).Log("msg", "downscale not allowed due to error while finding other statefulsets", "err", err)
 			return deny(

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,7 @@ const (
 
 	// RolloutGroupLabelKey is the group to which multiple statefulsets belong and must be operated on together.
 	RolloutGroupLabelKey = "rollout-group"
+	RolloutSecondaryGroupLabelKey = "rollout-secondary-group"
 	// RolloutMaxUnavailableAnnotationKey is the max number of pods in each statefulset that may be stopped at
 	// one time.
 	RolloutMaxUnavailableAnnotationKey = "rollout-max-unavailable"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -261,7 +261,7 @@ func (c *RolloutController) reconcile(ctx context.Context) error {
 	}
 
 	// Group statefulsets by the rollout group label. Each group will be reconciled independently.
-	groups := util.GroupStatefulSetsByLabel(sets, config.RolloutGroupLabelKey)
+	groups := util.GroupStatefulSetsByLabel(sets, config.RolloutGroupLabelKey, config.RolloutSecondaryGroupLabelKey)
 	var reconcileErrs error
 	for groupName, groupSets := range groups {
 		if err := c.reconcileStatefulSetsGroup(ctx, groupName, groupSets); err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -76,11 +76,16 @@ func MoveStatefulSetToFront(sets []*v1.StatefulSet, toMove *v1.StatefulSet) []*v
 
 // GroupStatefulSetsByLabel returns a map containing the input StatefulSets grouped by
 // the input label's value.
-func GroupStatefulSetsByLabel(sets []*v1.StatefulSet, label string) map[string][]*v1.StatefulSet {
+func GroupStatefulSetsByLabel(sets []*v1.StatefulSet, primaryLabel string, secondaryLabel string) map[string][]*v1.StatefulSet {
 	groups := make(map[string][]*v1.StatefulSet)
 
 	for _, sts := range sets {
-		value := sts.GetLabels()[label]
+		labels := sts.GetLabels()
+		value := labels[primaryLabel]
+		secondaryValue := labels[secondaryLabel]
+		if secondaryValue != "" {
+			value = value + "-" + secondaryValue
+		}
 		groups[value] = append(groups[value], sts)
 	}
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -161,28 +161,40 @@ func TestMoveStatefulSetToFront(t *testing.T) {
 
 func TestGroupStatefulSetsByLabel(t *testing.T) {
 	input := []*v1.StatefulSet{
-		{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-a", Labels: map[string]string{config.RolloutGroupLabelKey: "ingester"}}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-b", Labels: map[string]string{config.RolloutGroupLabelKey: "ingester"}}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "compactor-zone-a", Labels: map[string]string{config.RolloutGroupLabelKey: "compactor"}}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "compactor-zone-b", Labels: map[string]string{config.RolloutGroupLabelKey: "compactor"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-a", Labels: map[string]string{config.RolloutGroupLabelKey: "ingester", config.RolloutSecondaryGroupLabelKey: "mimir"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-b", Labels: map[string]string{config.RolloutGroupLabelKey: "ingester", config.RolloutSecondaryGroupLabelKey: "mimir"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-a", Labels: map[string]string{config.RolloutGroupLabelKey: "ingester", config.RolloutSecondaryGroupLabelKey: "loki"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-b", Labels: map[string]string{config.RolloutGroupLabelKey: "ingester", config.RolloutSecondaryGroupLabelKey: "loki"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "compactor-zone-a", Labels: map[string]string{config.RolloutGroupLabelKey: "compactor", config.RolloutSecondaryGroupLabelKey: "mimir"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "compactor-zone-b", Labels: map[string]string{config.RolloutGroupLabelKey: "compactor", config.RolloutSecondaryGroupLabelKey: "mimir"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "compactor-zone-a", Labels: map[string]string{config.RolloutGroupLabelKey: "compactor", config.RolloutSecondaryGroupLabelKey: "loki"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "compactor-zone-b", Labels: map[string]string{config.RolloutGroupLabelKey: "compactor", config.RolloutSecondaryGroupLabelKey: "loki"}}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "store-gateway"}},
 	}
 
 	expected := map[string][]*v1.StatefulSet{
-		"ingester": {
-			{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-a", Labels: map[string]string{config.RolloutGroupLabelKey: "ingester"}}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-b", Labels: map[string]string{config.RolloutGroupLabelKey: "ingester"}}},
+		"ingester-mimir": {
+			{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-a", Labels: map[string]string{config.RolloutGroupLabelKey: "ingester", config.RolloutSecondaryGroupLabelKey: "mimir"}}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-b", Labels: map[string]string{config.RolloutGroupLabelKey: "ingester", config.RolloutSecondaryGroupLabelKey: "mimir"}}},
 		},
-		"compactor": {
-			{ObjectMeta: metav1.ObjectMeta{Name: "compactor-zone-a", Labels: map[string]string{config.RolloutGroupLabelKey: "compactor"}}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "compactor-zone-b", Labels: map[string]string{config.RolloutGroupLabelKey: "compactor"}}},
+		"compactor-mimir": {
+			{ObjectMeta: metav1.ObjectMeta{Name: "compactor-zone-a", Labels: map[string]string{config.RolloutGroupLabelKey: "compactor", config.RolloutSecondaryGroupLabelKey: "mimir"}}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "compactor-zone-b", Labels: map[string]string{config.RolloutGroupLabelKey: "compactor", config.RolloutSecondaryGroupLabelKey: "mimir"}}},
+		},
+		"ingester-loki": {
+			{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-a", Labels: map[string]string{config.RolloutGroupLabelKey: "ingester", config.RolloutSecondaryGroupLabelKey: "loki"}}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "ingester-zone-b", Labels: map[string]string{config.RolloutGroupLabelKey: "ingester", config.RolloutSecondaryGroupLabelKey: "loki"}}},
+		},
+		"compactor-loki": {
+			{ObjectMeta: metav1.ObjectMeta{Name: "compactor-zone-a", Labels: map[string]string{config.RolloutGroupLabelKey: "compactor", config.RolloutSecondaryGroupLabelKey: "loki"}}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "compactor-zone-b", Labels: map[string]string{config.RolloutGroupLabelKey: "compactor", config.RolloutSecondaryGroupLabelKey: "loki"}}},
 		},
 		"": {
 			{ObjectMeta: metav1.ObjectMeta{Name: "store-gateway"}},
 		},
 	}
 
-	assert.Equal(t, expected, GroupStatefulSetsByLabel(input, config.RolloutGroupLabelKey))
+	assert.Equal(t, expected, GroupStatefulSetsByLabel(input, config.RolloutGroupLabelKey, config.RolloutSecondaryGroupLabelKey))
 }
 
 func TestMax(t *testing.T) {


### PR DESCRIPTION
The way rollout-operator currently is designed in percludes deploying all of the LGTM stack to a single namespace (which is required in some circumstances). This adds an optional additional label that can be used to employ a secondary grouping to allow for all components to be deployed in a single namespace and have the rollout-operator execute as expected. For example:

Loki ingester:
```
apiVersion: apps/v1
kind: StatefulSet
metadata:
  labels:
    name: loki-ingester-zone-a
    rollout-group: ingester
    rollout-secondary-group: loki
```

Mimir ingester:
```
apiVersion: apps/v1
kind: StatefulSet
metadata:
  labels:
    name: mimir-ingester-zone-a
    rollout-group: ingester
    rollout-secondary-group: mimir
```