### PR TITLE
Address CVE-2024-45338

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 ## main / unreleased
 
 * [ENHANCEMENT] Make timeout for requests to Pods and to the Kubernetes control plane configurable. #188
-* [ENHANCEMENT] Updated dependencies, including: #189
+* [ENHANCEMENT] Updated dependencies, including: #189 #191
   * `github.com/prometheus/client_golang` from `v1.20.4` to `v1.20.5`
   * `github.com/prometheus/common` from `v0.59.1` to `v0.61.0`
   * `k8s.io/api` from `v0.31.1` to `v0.32.0`
   * `k8s.io/apimachinery` from `v0.31.1` to `v0.32.0`
   * `k8s.io/client-go` from `v0.31.1` to `v0.32.0`
   * `sigs.k8s.io/controller-runtime` from `v0.19.0` to `v0.19.3`
+  * `golang.org/x/net` from `v0.28.0` to `v0.33.0`
 
 ## v0.22.0
 

--- a/go.mod
+++ b/go.mod
@@ -132,7 +132,7 @@ require (
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
 	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
-	golang.org/x/net v0.32.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/term v0.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -443,8 +443,8 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.32.0 h1:ZqPmj8Kzc+Y6e0+skZsuACbx+wzMgo5MQsJh9Qd6aYI=
-golang.org/x/net v0.32.0/go.mod h1:CwU0IoeOlnQQWJ6ioyFrfRuomB8GKF6KbYXZVyeXNfs=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/oauth2 v0.24.0 h1:KTBBxWqUa0ykRPLtV69rRto9TLXcqYkeswu48x/gvNE=
 golang.org/x/oauth2 v0.24.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -638,7 +638,7 @@ golang.org/x/exp/slices
 golang.org/x/exp/slog
 golang.org/x/exp/slog/internal
 golang.org/x/exp/slog/internal/buffer
-# golang.org/x/net v0.32.0
+# golang.org/x/net v0.33.0
 ## explicit; go 1.18
 golang.org/x/net/http/httpguts
 golang.org/x/net/http2


### PR DESCRIPTION
Updates `golang.org/x/net` to `v0.33.0` to address CVE-2024-45338 in preparation for cutting a release. 

As a note the changelog entry specifies `v0.28.0` as the from version when this PR is updating from `v0.32.0` because I'm including the change from #189 as well.