### PR TITLE
Use a default for Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE
+ARG BASEIMAGE=gcr.io/distroless/static-debian12:nonroot
 
 FROM golang:1.23-bookworm AS build
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ GOARCH ?= $(shell go env GOARCH)
 DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune
 GO_FILES := $(shell find . $(DONT_FIND) -o -type f -name '*.go' -print)
 
-BASE_IMAGE=gcr.io/distroless/static-debian12:nonroot
 # Boringcrypto has a different base image for glibc
 BORINGCRYPTO_BASE_IMAGE=gcr.io/distroless/base-nossl-debian12:nonroot
 
@@ -35,7 +34,7 @@ rollout-operator-boringcrypto: $(GO_FILES) ## Build the rollout-operator binary 
 
 .PHONY: build-image
 build-image: clean ## Build the rollout-operator image
-	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) --build-arg BASEIMAGE=$(BASE_IMAGE) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
+	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
 
 .PHONY: build-image-boringcrypto
 build-image-boringcrypto: clean ## Build the rollout-operator image with boringcrypto
@@ -47,7 +46,7 @@ publish-images: publish-standard-image publish-boringcrypto-image ## Build and p
 
 .PHONY: publish-standard-image
 publish-standard-image: clean ## Build and publish only the standard rollout-operator image
-	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BASEIMAGE=$(BASE_IMAGE) --build-arg BUILDTARGET=rollout-operator -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
+	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
 
 .PHONY: publish-boringcrypto-image
 publish-boringcrypto-image: clean ## Build and publish only the boring-crypto rollout-operator image


### PR DESCRIPTION
A Docker warning appears when building a rollout-operator image:

`=> WARN: InvalidDefaultArgInFrom: Default value for ARG ${BASEIMAGE} results in empty or invalid base image name (line 13)`

When using the Makefile this isn't an issue since the arguments are always supplied, but to make the warning go away I moved the defaults from the Makefile to the Dockerfile. Similarly, `BUILDTARGET` defaults to `rollout-operator` so it also doesn't need to be specified when building the standard image.

Related documentation is here: https://docs.docker.com/reference/build-checks/invalid-default-arg-in-from/