### PR TITLE
Add renovate workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended",
+        "helpers:pinGitHubActionDigests",
+        "schedule:weekly"
+    ],
+    "postUpdateOptions": [
+        "gomodTidy"
+    ],
+    "branchPrefix": "grafanarenovatebot/",
+    "platformCommit": true,
+    "dependencyDashboard": false,
+    "rebaseWhen": "behind-base-branch",
+    "packageRules": [
+         {
+             "description": "Group all go dependencies together to reduce noise",
+             "matchDatasources": ["go"],
+             "groupName": "go",
+             "enabled": true
+         },
+         {
+             "description": "Disable Docker updates",
+             "matchManagers": ["dockerfile"],
+             "enabled": false
+         }
+     ],
+     "separateMajorMinor": false,
+     "vulnerabilityAlerts": {
+         "enabled": true
+     },
+    "osvVulnerabilityAlerts": true
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,42 @@
+name: Renovate
+on:
+  schedule:
+    # Every 12 hours, offset by 22 minutes to avoid busy times
+    - cron: "22 */12 * * *"
+  # Allow manually triggering
+  workflow_dispatch:
+jobs:
+  renovate:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: retrieve secrets
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@7d18a46aafb8b875ed76a0bc98852d74b91e7f91 # v1.0.0
+        with:
+          common_secrets: |
+            GRAFANA_RENOVATE_APP_ID=grafana-renovate-app:app-id
+            GRAFANA_RENOVATE_PRIVATE_KEY=grafana-renovate-app:private-key
+
+      - name: Create GitHub app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.GRAFANA_RENOVATE_APP_ID }}
+          private-key: ${{ env.GRAFANA_RENOVATE_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v41.0.17
+        with:
+          renovate-version: 39.102.0
+          token: "${{ steps.app-token.outputs.token }}"
+        env:
+          RENOVATE_PLATFORM: github
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_USERNAME: GrafanaRenovateBot


### PR DESCRIPTION
I'd like to give Renovate a try instead of manually updating this repository's dependencies every month. A motivating factor here is that I was looking into pinning github action versions manually, but then realized that would add even more toil to the manual process.

A goal is to have this be as free of noise as possible by grouping the go dependency updates (which was how it was done manually). That should run weekly (or can be triggered manually) to create a PR that won't auto-merge. I also disabled Dockerfile updates since the two candidates there are:
-  the Go build container (which updating would require other changes as well that I won't even attempt to automate)
-  the distroless container (which uses a tag that is updated very infrequently corresponding to Debian versions)

I'm no Renovate expert, but went through the configuration to try to understand what's going on. Most of `.github/workflows/renovate.yml` is similar to other grafana repositories where the workflow is present, with the exception of the cron scheduling and not providing a `configurationFile` to the `Self-hosted Renovate` step (it seemed unnecessary). `.github/renovate.json` is similar to others as well with the exception of the `extends` and `packageRules` sections.