### PR TITLE
Cut v0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main / unreleased
 
+## v0.24.1
+
+* [ENHANCEMENT] Rebuild of main branch to resolve [CVE-2025-0395](https://nvd.nist.gov/vuln/detail/CVE-2025-0395)
+
 ## v0.24.0
 
 * [ENHANCEMENT] Update Go to `1.24` #196


### PR DESCRIPTION
We are tracking `libc`'s [CVE-2025-0395](https://nvd.nist.gov/vuln/detail/CVE-2025-0395) in our FedRAMP environments and are coming up on our SLO grace period. It seems like this CVE is fixed in the latest `gcr.io/distroless/static-debian12:nonroot` as I reran the docker build locally and the new image did not have this CVE.
```bash
kevinsimons@Kevins-MacBook-Pro: ~/workspace/rollout-operator (main) dev-us-gov-east-1
$ docker build -t rollout-operator:local .
...
 => exporting to image                                                                                                                                                                                                                                                                 0.1s
 => => exporting layers                                                                                                                                                                                                                                                                0.1s
 => => writing image sha256:f1f092e3e67b1b6aba9b437f1de7c19e1650c7f0e5780a53faaada6871f7fd37                                                                                                                                                                                           0.0s
 => => naming to docker.io/library/rollout-operator:local                                                                                                                                                                                                                              0.0s

kevinsimons@Kevins-MacBook-Pro: ~/workspace/rollout-operator (main) dev-us-gov-east-1
$ trivy image docker.io/library/rollout-operator:local
2025-03-27 15:02:41
2025-03-27T15:02:41-05:00       INFO    [vuln] Vulnerability scanning is enabled
2025-03-27T15:02:41-05:00       INFO    [secret] Secret scanning is enabled
2025-03-27T15:02:41-05:00       INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-03-27T15:02:41-05:00       INFO    [secret] Please see also https://aquasecurity.github.io/trivy/v0.57/docs/scanner/secret#recommendation for faster secret detection
2025-03-27T15:02:42-05:00       INFO    Detected OS     family="debian" version="12.10"
2025-03-27T15:02:42-05:00       INFO    [debian] Detecting vulnerabilities...   os_version="12" pkg_num=3
2025-03-27T15:02:42-05:00       INFO    Number of language-specific files       num=1
2025-03-27T15:02:42-05:00       INFO    [gobinary] Detecting vulnerabilities...

docker.io/library/rollout-operator:local (debian 12.10)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


bin/rollout-operator (gobinary)

Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌──────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│     Library      │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├──────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ golang.org/x/net │ CVE-2025-22870 │ MEDIUM   │ fixed  │ v0.33.0           │ 0.36.0        │ golang.org/x/net/proxy: golang.org/x/net/http/httpproxy:  │
│                  │                │          │        │                   │               │ HTTP Proxy bypass using IPv6 Zone IDs in golang.org/x/net │
│                  │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-22870                │
└──────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘
```

Creating this PR just to make a new patch release without this CVE.