### PR TITLE
Cut v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+## v0.25.0
+
 * [ENHANCEMENT] Updated dependencies, including: #203
   * `github.com/prometheus/client_golang` from `v1.20.5` to `v1.21.1`
   * `github.com/prometheus/common` from `v0.62.0` to `v0.63.0`


### PR DESCRIPTION
Cutting a new version. ~I'm going to keep this in draft until tests can run with Go 1.24.2 since that was released today (2025-04-01)~. Tests succeeded with 1.24.2.