### PR TITLE
Update golangci-lint to v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           go-version: '1.24'
           check-latest: true
-      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
+      - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7
         with:
-          version: v1.64.2
+          version: v2.0.2
           args: --timeout=5m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,16 +8,11 @@ linters:
       exclude-functions:
         - (github.com/go-kit/log.Logger).Log
   exclusions:
-    generated: lax
     presets:
       - comments
       - common-false-positives
       - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 formatters:
   enable:
     - gci
@@ -29,9 +24,3 @@ formatters:
         - default
         - prefix(github.com/grafana/rollout-operator)
       custom-order: true
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,9 @@ run:
 linters:
   settings:
     errcheck:
+      # Use exclude-functions instead of exclude, since the GitHub Action's caching is broken.
+      # When changing the file referenced by exclude, the GitHub Action may use an older cache
+      # entry and ignore the changes in said file (thus breaking CI).
       exclude-functions:
         - (github.com/go-kit/log.Logger).Log
   exclusions:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,24 +1,37 @@
+version: "2"
 run:
   build-tags:
     - requires_docker
-
 linters:
+  settings:
+    errcheck:
+      exclude-functions:
+        - (github.com/go-kit/log.Logger).Log
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
   enable:
     - gci
     - gofmt
-
-linters-settings:
-  errcheck:
-    # Use exclude-functions instead of exclude, since the GitHub Action's caching is broken.
-    # When changing the file referenced by exclude, the GitHub Action may use an older cache
-    # entry and ignore the changes in said file (thus breaking CI).
-    exclude-functions:
-      - (github.com/go-kit/log.Logger).Log
-
-  gci:
-    skip-generated: true
-    custom-order: true
-    sections:
-      - standard
-      - default
-      - prefix(github.com/grafana/rollout-operator)
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/grafana/rollout-operator)
+      custom-order: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -135,7 +135,7 @@ func TestNoDownscale_DownscaleUpdatingStatefulSet(t *testing.T) {
 	mock := mockServiceStatefulSet("mock", "1", true)
 	{
 		t.Log("Create the service with two replicas.")
-		mock.ObjectMeta.Labels["grafana.com/no-downscale"] = "true"
+		mock.Labels["grafana.com/no-downscale"] = "true"
 		mock.Spec.Replicas = ptr[int32](2)
 		requireCreateStatefulSet(ctx, t, api, mock)
 		requireEventuallyPodCount(ctx, t, api, "name=mock", 2)
@@ -183,7 +183,7 @@ func TestNoDownscale_UpdatingScaleSubresource(t *testing.T) {
 	}
 
 	mock := mockServiceStatefulSet("mock", "1", true)
-	mock.ObjectMeta.Labels["grafana.com/no-downscale"] = "true"
+	mock.Labels["grafana.com/no-downscale"] = "true"
 	{
 		t.Log("Create the service with two replicas.")
 		mock.Spec.Replicas = ptr[int32](2)

--- a/integration/k3t/cluster.go
+++ b/integration/k3t/cluster.go
@@ -113,7 +113,7 @@ func NewCluster(ctx context.Context, t *testing.T, opts ...Option) Cluster {
 		t.Logf("Hint: try running `docker network prune`")
 	}
 	require.NoError(t, err, "Failed creating cluster.")
-	t.Logf("Cluster '%s' created successfully!", clusterConfig.Cluster.Name)
+	t.Logf("Cluster '%s' created successfully!", clusterConfig.Name)
 
 	// Get kubeconfig and instantiate kubernetes.Clientset.
 	kubeConfigFile := filepath.Join(t.TempDir(), fmt.Sprintf("kubeconfig.%s.yaml", opt.clusterName))

--- a/pkg/admission/no_downscale.go
+++ b/pkg/admission/no_downscale.go
@@ -26,7 +26,7 @@ const (
 
 func NoDownscale(ctx context.Context, l log.Logger, ar v1.AdmissionReview, api *kubernetes.Clientset) *v1.AdmissionResponse {
 	logger, ctx := spanlogger.New(ctx, l, "admission.NoDownscale()", tenantResolver)
-	defer logger.Span.Finish()
+	defer logger.Finish()
 
 	logger.SetSpanAndLogTag("object.name", ar.Request.Name)
 	logger.SetSpanAndLogTag("object.resource", ar.Request.Resource.Resource)

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -22,8 +22,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/admission/v1"
-	apps "k8s.io/api/apps/v1"
+	admissionv1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -234,8 +233,8 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 
 	namespace := "test"
 	stsName := "my-statefulset"
-	ar := v1.AdmissionReview{
-		Request: &v1.AdmissionRequest{
+	ar := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
 			Kind: metav1.GroupVersionKind{
 				Group:   "apps",
 				Version: "v1",
@@ -258,7 +257,7 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 		},
 	}
 	objects := []runtime.Object{
-		&apps.StatefulSet{
+		&appsv1.StatefulSet{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "StatefulSet",
 				APIVersion: "apps/v1",
@@ -270,7 +269,7 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 				Labels:    map[string]string{config.RolloutGroupLabelKey: "ingester"},
 			},
 		},
-		&apps.StatefulSet{
+		&appsv1.StatefulSet{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "StatefulSet",
 				APIVersion: "apps/v1",
@@ -285,7 +284,7 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 	}
 	if params.downscaleInProgress {
 		objects = append(objects,
-			&apps.StatefulSet{
+			&appsv1.StatefulSet{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "StatefulSet",
 					APIVersion: "apps/v1",
@@ -483,25 +482,25 @@ func TestFindStatefulSetWithNonUpdatedReplicas(t *testing.T) {
 		Labels:    labels,
 	}
 	objects := []runtime.Object{
-		&apps.StatefulSet{
+		&appsv1.StatefulSet{
 			ObjectMeta: stsMeta,
-			Spec: apps.StatefulSetSpec{
+			Spec: appsv1.StatefulSetSpec{
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: stsMeta,
 				},
 			},
-			Status: apps.StatefulSetStatus{
+			Status: appsv1.StatefulSetStatus{
 				Replicas:        1,
 				UpdatedReplicas: 1,
 			},
 		},
-		&apps.StatefulSet{
+		&appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "zone-b",
 				Namespace: namespace,
 				Labels:    labels,
 			},
-			Status: apps.StatefulSetStatus{
+			Status: appsv1.StatefulSetStatus{
 				Replicas:        1,
 				UpdatedReplicas: 1,
 			},
@@ -544,14 +543,14 @@ func TestFindStatefulSetWithNonUpdatedReplicas_UnavailableReplicasSameZone(t *te
 		Labels:    labels,
 	}
 	objects := []runtime.Object{
-		&apps.StatefulSet{
+		&appsv1.StatefulSet{
 			ObjectMeta: stsMeta,
-			Spec: apps.StatefulSetSpec{
+			Spec: appsv1.StatefulSetSpec{
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: stsMeta,
 				},
 			},
-			Status: apps.StatefulSetStatus{
+			Status: appsv1.StatefulSetStatus{
 				Replicas:        1,
 				UpdatedReplicas: 0,
 			},
@@ -575,9 +574,9 @@ func TestFindPodsForStatefulSet(t *testing.T) {
 		Namespace: namespace,
 		Labels:    labels,
 	}
-	sts := &apps.StatefulSet{
+	sts := &appsv1.StatefulSet{
 		ObjectMeta: stsMeta,
-		Spec: apps.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: stsMeta,
 			},
@@ -706,8 +705,8 @@ func testPrepDownscaleWebhookWithZoneTracker(t *testing.T, oldReplicas, newRepli
 
 	namespace := "test"
 	stsName := "my-statefulset"
-	ar := v1.AdmissionReview{
-		Request: &v1.AdmissionRequest{
+	ar := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
 			Kind: metav1.GroupVersionKind{
 				Group:   "apps",
 				Version: "v1",
@@ -730,7 +729,7 @@ func testPrepDownscaleWebhookWithZoneTracker(t *testing.T, oldReplicas, newRepli
 		},
 	}
 	objects := []runtime.Object{
-		&apps.StatefulSet{
+		&appsv1.StatefulSet{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "StatefulSet",
 				APIVersion: "apps/v1",
@@ -742,7 +741,7 @@ func testPrepDownscaleWebhookWithZoneTracker(t *testing.T, oldReplicas, newRepli
 				Labels:    map[string]string{config.RolloutGroupLabelKey: "ingester"},
 			},
 		},
-		&apps.StatefulSet{
+		&appsv1.StatefulSet{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "StatefulSet",
 				APIVersion: "apps/v1",
@@ -757,7 +756,7 @@ func testPrepDownscaleWebhookWithZoneTracker(t *testing.T, oldReplicas, newRepli
 	}
 	if params.downscaleInProgress {
 		objects = append(objects,
-			&apps.StatefulSet{
+			&appsv1.StatefulSet{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "StatefulSet",
 					APIVersion: "apps/v1",
@@ -824,37 +823,37 @@ func TestCheckReplicasChange(t *testing.T) {
 		name     string
 		oldInfo  *objectInfo
 		newInfo  *objectInfo
-		expected *v1.AdmissionResponse
+		expected *admissionv1.AdmissionResponse
 	}{
 		{
 			name:     "both replicas nil",
 			oldInfo:  &objectInfo{},
 			newInfo:  &objectInfo{},
-			expected: &v1.AdmissionResponse{Allowed: true},
+			expected: &admissionv1.AdmissionResponse{Allowed: true},
 		},
 		{
 			name:     "old replicas nil",
 			oldInfo:  &objectInfo{},
 			newInfo:  &objectInfo{replicas: func() *int32 { i := int32(3); return &i }()},
-			expected: &v1.AdmissionResponse{Allowed: true},
+			expected: &admissionv1.AdmissionResponse{Allowed: true},
 		},
 		{
 			name:     "new replicas nil",
 			oldInfo:  &objectInfo{replicas: func() *int32 { i := int32(3); return &i }()},
 			newInfo:  &objectInfo{},
-			expected: &v1.AdmissionResponse{Allowed: true},
+			expected: &admissionv1.AdmissionResponse{Allowed: true},
 		},
 		{
 			name:     "upscale",
 			oldInfo:  &objectInfo{replicas: func() *int32 { i := int32(3); return &i }()},
 			newInfo:  &objectInfo{replicas: func() *int32 { i := int32(5); return &i }()},
-			expected: &v1.AdmissionResponse{Allowed: true},
+			expected: &admissionv1.AdmissionResponse{Allowed: true},
 		},
 		{
 			name:     "no replicas change",
 			oldInfo:  &objectInfo{replicas: func() *int32 { i := int32(3); return &i }()},
 			newInfo:  &objectInfo{replicas: func() *int32 { i := int32(3); return &i }()},
-			expected: &v1.AdmissionResponse{Allowed: true},
+			expected: &admissionv1.AdmissionResponse{Allowed: true},
 		},
 		{
 			name:     "downscale",
@@ -876,7 +875,7 @@ func TestCheckReplicasChange(t *testing.T) {
 
 func TestGetLabelsAndAnnotations(t *testing.T) {
 	ctx := context.Background()
-	ar := v1.AdmissionReview{}
+	ar := admissionv1.AdmissionReview{}
 	api := fake.NewSimpleClientset()
 
 	tests := []struct {
@@ -920,8 +919,8 @@ func TestGetLabelsAndAnnotations(t *testing.T) {
 }
 
 func TestCreateEndpoints(t *testing.T) {
-	ar := v1.AdmissionReview{
-		Request: &v1.AdmissionRequest{
+	ar := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
 			Name:      "test",
 			Namespace: "default",
 		},

--- a/pkg/admission/zone_tracker_test.go
+++ b/pkg/admission/zone_tracker_test.go
@@ -7,9 +7,8 @@ import (
 	"testing"
 	"time"
 
-	apps "k8s.io/api/apps/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -91,8 +90,8 @@ func TestZoneTrackerFindDownscalesDoneMinTimeAgo(t *testing.T) {
 	// Create a new zoneTracker with the fake client
 	zt := newZoneTracker(client, "testnamespace", "testconfigmap")
 
-	stsList := &apps.StatefulSetList{
-		Items: []apps.StatefulSet{
+	stsList := &appsv1.StatefulSetList{
+		Items: []appsv1.StatefulSet{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-zone",
@@ -142,8 +141,8 @@ func TestLoadZonesCreatesInitialZones(t *testing.T) {
 	// Create a new zoneTracker with the fake client
 	zt := newZoneTracker(client, "testnamespace", "testconfigmap")
 
-	stsList := &apps.StatefulSetList{
-		Items: []apps.StatefulSet{
+	stsList := &appsv1.StatefulSetList{
+		Items: []appsv1.StatefulSet{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-zone",
@@ -197,7 +196,7 @@ func TestLoadZonesEmptyConfigMap(t *testing.T) {
 	// Create a new zoneTracker with the fake client
 	zt := newZoneTracker(client, "testnamespace", "testconfigmap")
 
-	stsList := &apps.StatefulSetList{}
+	stsList := &appsv1.StatefulSetList{}
 
 	err := zt.loadZones(ctx, stsList)
 	if err != nil {
@@ -215,7 +214,7 @@ func TestSetDownscaled(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
 	// Create the configmap
-	cm := &v1.ConfigMap{
+	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testconfigmap",
 			Namespace: "testnamespace",

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1007,8 +1007,8 @@ func convertEmptyMapToNil[K comparable, V any](m map[K]V) map[K]V {
 
 func TestRolloutController_ReconcileShouldDeleteMetricsForDecommissionedRolloutGroups(t *testing.T) {
 	ingesters := []runtime.Object{
-		mockStatefulSet("ingester-zone-a", func(sts *v1.StatefulSet) { sts.ObjectMeta.Labels[config.RolloutGroupLabelKey] = "ingester" }),
-		mockStatefulSet("ingester-zone-b", func(sts *v1.StatefulSet) { sts.ObjectMeta.Labels[config.RolloutGroupLabelKey] = "ingester" }),
+		mockStatefulSet("ingester-zone-a", func(sts *v1.StatefulSet) { sts.Labels[config.RolloutGroupLabelKey] = "ingester" }),
+		mockStatefulSet("ingester-zone-b", func(sts *v1.StatefulSet) { sts.Labels[config.RolloutGroupLabelKey] = "ingester" }),
 		mockStatefulSetPod("ingester-zone-a-0", testLastRevisionHash),
 		mockStatefulSetPod("ingester-zone-a-1", testLastRevisionHash),
 		mockStatefulSetPod("ingester-zone-b-0", testLastRevisionHash),
@@ -1016,8 +1016,8 @@ func TestRolloutController_ReconcileShouldDeleteMetricsForDecommissionedRolloutG
 	}
 
 	storeGateways := []runtime.Object{
-		mockStatefulSet("store-gateway-zone-a", func(sts *v1.StatefulSet) { sts.ObjectMeta.Labels[config.RolloutGroupLabelKey] = "store-gateway" }),
-		mockStatefulSet("store-gateway-zone-b", func(sts *v1.StatefulSet) { sts.ObjectMeta.Labels[config.RolloutGroupLabelKey] = "store-gateway" }),
+		mockStatefulSet("store-gateway-zone-a", func(sts *v1.StatefulSet) { sts.Labels[config.RolloutGroupLabelKey] = "store-gateway" }),
+		mockStatefulSet("store-gateway-zone-b", func(sts *v1.StatefulSet) { sts.Labels[config.RolloutGroupLabelKey] = "store-gateway" }),
 		mockStatefulSetPod("store-gateway-zone-a-0", testLastRevisionHash),
 		mockStatefulSetPod("store-gateway-zone-a-1", testLastRevisionHash),
 		mockStatefulSetPod("store-gateway-zone-b-0", testLastRevisionHash),

--- a/pkg/instrumentation/kubernetes_api_client_test.go
+++ b/pkg/instrumentation/kubernetes_api_client_test.go
@@ -69,15 +69,15 @@ func TestNilResponse(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := k.RoundTrip(req)
 	require.Nil(t, resp)
-	require.ErrorIs(t, err, noResponseErr)
+	require.ErrorIs(t, err, errNoResponse)
 
 	// It would be nice to test for metric, but it's tricky since we're measuring duration.
 }
 
-var noResponseErr = fmt.Errorf("error")
+var errNoResponse = fmt.Errorf("error")
 
 type noResponseRoundTripper struct{}
 
 func (n noResponseRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
-	return nil, noResponseErr
+	return nil, errNoResponse
 }


### PR DESCRIPTION
Updating golangci-lint from v1 to v2 requires a migration according to this [documentation](https://golangci-lint.run/product/migration-guide/).

What I did here:
-  Ran `golangci-lint migrate -c .golangci.yaml` locally
-  Manually updated the action since it contains v2 support ([release notes](https://github.com/golangci/golangci-lint-action/releases/tag/v7.0.0))
- Ran `golangci-lint run --fix ./...` and manually fixed what remained
- Cleaned up `.golangci.yaml` to remove settings that did not apply