### PR TITLE
Add creating a GitHub release to RELEASE.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ BORINGCRYPTO_BASE_IMAGE=gcr.io/distroless/base-nossl-debian12:nonroot
 help: ## Display this help and any documented user-facing targets
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\.\-\/%]+:.*?##/ { printf "  %-45s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
+.PHONY: release-notes 
+release-notes: ## Generate the release notes for a GitHub release
+	@echo "Docker images: \`grafana/rollout-operator:${IMAGE_TAG}\` and \`grafana/rollout-operator-boringcrypto:${IMAGE_TAG}\`\n\n## Changelog"
+	@awk -v var="${IMAGE_TAG}" '$$0 ~ "## "var {flag=1; next} /^##/{flag=0} flag' CHANGELOG.md
+
 rollout-operator: $(GO_FILES) ## Build the rollout-operator binary
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help: ## Display this help and any documented user-facing targets
 
 .PHONY: release-notes 
 release-notes: ## Generate the release notes for a GitHub release
-	@echo "Docker images: \`grafana/rollout-operator:${IMAGE_TAG}\` and \`grafana/rollout-operator-boringcrypto:${IMAGE_TAG}\`\n\n## Changelog"
+	@echo "Docker images: \`${IMAGE_PREFIX}/rollout-operator:${IMAGE_TAG}\` and \`${IMAGE_PREFIX}/rollout-operator-boringcrypto:${IMAGE_TAG}\`\n\n## Changelog"
 	@awk -v var="${IMAGE_TAG}" '$$0 ~ "## "var {flag=1; next} /^##/{flag=0} flag' CHANGELOG.md
 
 rollout-operator: $(GO_FILES) ## Build the rollout-operator binary

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,6 @@ BORINGCRYPTO_BASE_IMAGE=gcr.io/distroless/base-nossl-debian12:nonroot
 help: ## Display this help and any documented user-facing targets
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\.\-\/%]+:.*?##/ { printf "  %-45s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-.PHONY: release-notes 
-release-notes: ## Generate the release notes for a GitHub release
-	@echo "Docker images: \`${IMAGE_PREFIX}/rollout-operator:${IMAGE_TAG}\` and \`${IMAGE_PREFIX}/rollout-operator-boringcrypto:${IMAGE_TAG}\`\n\n## Changelog"
-	@awk -v var="${IMAGE_TAG}" '$$0 ~ "## "var {flag=1; next} /^##/{flag=0} flag' CHANGELOG.md
-
 rollout-operator: $(GO_FILES) ## Build the rollout-operator binary
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' ./cmd/rollout-operator
 
@@ -56,6 +51,11 @@ publish-standard-image: clean ## Build and publish only the standard rollout-ope
 .PHONY: publish-boringcrypto-image
 publish-boringcrypto-image: clean ## Build and publish only the boring-crypto rollout-operator image
 	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BASEIMAGE=$(BORINGCRYPTO_BASE_IMAGE) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) .
+
+.PHONY: release-notes 
+release-notes: ## Generate the release notes for a GitHub release
+	@echo "Docker images: \`${IMAGE_PREFIX}/rollout-operator:${IMAGE_TAG}\` and \`${IMAGE_PREFIX}/rollout-operator-boringcrypto:${IMAGE_TAG}\`\n\n## Changelog"
+	@awk -v var="${IMAGE_TAG}" '$$0 ~ "## "var {flag=1; next} /^##/{flag=0} flag' CHANGELOG.md
 
 .PHONY: test
 test: ## Run tests

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,7 @@
     ```bash
     $ IMAGE_TAG="${tag}" make publish-images
     ```
-4. Create a new GitHub release based on the tag. The release notes can be generated with:
+4. Create a new GitHub release [here](https://github.com/grafana/rollout-operator/releases/new) based on the tag. The release notes can be generated with:
     ```bash
     $ IMAGE_TAG="${tag}" make release-notes
     ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,16 +2,20 @@
 
 1. Update `CHANGELOG.md`
   - Open PR and get it merged
-1. Create a new tag that follows semantic versioning:
+2. Create a new tag that follows semantic versioning:
     ```bash
     $ tag=v0.1.0
     $ git tag -s "${tag}" -m "${tag}"
     $ git push origin "${tag}"
     ```
-1. Publish the updated Docker image
+3. Publish the updated Docker image
     ```bash
     $ IMAGE_TAG="${tag}" make publish-images
     ```
-1. Update Helm Chart
+4. Create a new GitHub release based on the tag. The release notes can be generated with:
+    ```bash
+    $ echo "Docker images: \`grafana/rollout-operator:${tag}\` and \`grafana/rollout-operator-boringcrypto:${tag}\`\n\n## Changelog" && awk -v var="${tag}" '$0 ~ "## "var {flag=1; next} /^##/{flag=0} flag' CHANGELOG.md
+    ```
+5. Update the Helm Chart
   - Repository https://github.com/grafana/helm-charts/tree/main/charts/rollout-operator
   - [Example PR](https://github.com/grafana/helm-charts/pull/3177/files)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,7 @@
     ```
 4. Create a new GitHub release based on the tag. The release notes can be generated with:
     ```bash
-    $ echo "Docker images: \`grafana/rollout-operator:${tag}\` and \`grafana/rollout-operator-boringcrypto:${tag}\`\n\n## Changelog" && awk -v var="${tag}" '$0 ~ "## "var {flag=1; next} /^##/{flag=0} flag' CHANGELOG.md
+    $ IMAGE_TAG="${tag}" make release-notes
     ```
 5. Update the Helm Chart
   - Repository https://github.com/grafana/helm-charts/tree/main/charts/rollout-operator


### PR DESCRIPTION
There wasn't a step in `RELEASE.md` for creating a GitHub release. I added one along with a command to generate the release notes based on the tag.

The awk (which I stumbled through writing following examples) works by regex matching the line in `CHANGELOG.md` specifying a tag's section like `## v0.26.0`. On that match it sets a variable to print each following line until a line starts with `##` (the beginning of another section).

An example of running `make release-notes`:
```
$ IMAGE_TAG=v0.25.0 make release-notes
Docker images: `grafana/rollout-operator:v0.25.0` and `grafana/rollout-operator-boringcrypto:v0.25.0`

## Changelog

* [ENHANCEMENT] Updated dependencies, including: #203
  * `github.com/prometheus/client_golang` from `v1.20.5` to `v1.21.1`
  * `github.com/prometheus/common` from `v0.62.0` to `v0.63.0`
  * `golang.org/x/sync` from `v0.11.0` to `v0.12.0`
  * `k8s.io/api` from `v0.32.1` to `v0.32.3`
  * `k8s.io/apimachinery` from `v0.32.1` to `v0.32.3`
  * `k8s.io/client-go` from `v0.32.1` to `v0.32.3`
  * `sigs.k8s.io/controller-runtime` from `v0.20.1` to `v0.20.4`
```