### PR TITLE
Update renovate configuration for go dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,8 +16,7 @@
          {
              "description": "Group all go dependencies together to reduce noise",
              "matchDatasources": ["go"],
-             "groupName": "go",
-             "enabled": true
+             "groupName": "go dependencies",
          },
          {
              "description": "Disable Docker updates",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,7 @@
          {
              "description": "Group all go dependencies together to reduce noise",
              "matchDatasources": ["go"],
-             "groupName": "go dependencies",
+             "groupName": "go dependencies"
          },
          {
              "description": "Disable Docker updates",


### PR DESCRIPTION
Indirect dependency updates are disabled by default in Renovate according to this [documentation](https://docs.renovatebot.com/modules/manager/gomod/#post-update-options). Setting `"enabled": true` on this `packageRule` was accidentally overriding that, which resulted in creating the not so helpful PR https://github.com/grafana/rollout-operator/pull/215.

I also renamed the group so the PR wouldn't be titled "update go".