### PR TITLE
Use serviceName to construct endpoint for prepare-downscale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main / unreleased
 
 * [CHANGE] Rename metric `rollout_operator_request_invalid_cluster_validation_labels_total` to `rollout_operator_client_invalid_cluster_validation_label_requests_total`. #217
+* [BUGFIX] Use a StatefulSet's `.spec.serviceName` when constructing the prepare-downscale endpoint for a pod. #221
 
 ## v0.26.0
 

--- a/pkg/admission/prep_downscale.go
+++ b/pkg/admission/prep_downscale.go
@@ -86,20 +86,18 @@ func prepareDownscale(ctx context.Context, l log.Logger, ar admissionv1.Admissio
 		return response
 	}
 
-	// Get the labels and annotations from the old object including the prepare downscale label
-	lbls, annotations, err := getLabelsAndAnnotations(ctx, ar, api, oldInfo)
+	stsInfo, err := getStatefulSetInfo(ctx, ar, api, oldInfo)
 	if err != nil {
 		return allowWarn(logger, fmt.Sprintf("%s, allowing the change", err))
 	}
 
-	// Since it's a downscale, check if the resource has the label that indicates it needs to be prepared to be downscaled.
-	if lbls[config.PrepareDownscaleLabelKey] != config.PrepareDownscaleLabelValue {
-		// Not labeled, nothing to do.
+	// Since it's a downscale, check if the resource needs to be prepared to be downscaled.
+	if !stsInfo.prepareDownscale {
+		// Nothing to do.
 		return &admissionv1.AdmissionResponse{Allowed: true}
 	}
 
-	port := annotations[config.PrepareDownscalePortAnnotationKey]
-	if port == "" {
+	if stsInfo.port == "" {
 		level.Warn(logger).Log("msg", fmt.Sprintf("downscale not allowed because the %v annotation is not set or empty", config.PrepareDownscalePortAnnotationKey))
 		return deny(
 			fmt.Sprintf(
@@ -109,8 +107,7 @@ func prepareDownscale(ctx context.Context, l log.Logger, ar admissionv1.Admissio
 		)
 	}
 
-	path := annotations[config.PrepareDownscalePathAnnotationKey]
-	if path == "" {
+	if stsInfo.path == "" {
 		level.Warn(logger).Log("msg", fmt.Sprintf("downscale not allowed because the %v annotation is not set or empty", config.PrepareDownscalePathAnnotationKey))
 		return deny(
 			fmt.Sprintf(
@@ -120,9 +117,18 @@ func prepareDownscale(ctx context.Context, l log.Logger, ar admissionv1.Admissio
 		)
 	}
 
-	rolloutGroup := lbls[config.RolloutGroupLabelKey]
-	if rolloutGroup != "" {
-		stsList, err := findStatefulSetsForRolloutGroup(ctx, api, ar.Request.Namespace, rolloutGroup)
+	if stsInfo.serviceName == "" {
+		level.Warn(logger).Log("msg", "downscale not allowed because the serviceName is not set or empty")
+		return deny(
+			fmt.Sprintf(
+				"downscale of %s/%s in %s from %d to %d replicas is not allowed because the serviceName is not set or empty.",
+				ar.Request.Resource.Resource, ar.Request.Name, ar.Request.Namespace, *oldInfo.replicas, *newInfo.replicas,
+			),
+		)
+	}
+
+	if stsInfo.rolloutGroup != "" {
+		stsList, err := findStatefulSetsForRolloutGroup(ctx, api, ar.Request.Namespace, stsInfo.rolloutGroup)
 		if err != nil {
 			level.Warn(logger).Log("msg", "downscale not allowed due to error while finding other statefulsets", "err", err)
 			return deny(
@@ -164,7 +170,7 @@ func prepareDownscale(ctx context.Context, l log.Logger, ar admissionv1.Admissio
 	}
 
 	// It's a downscale, so we need to prepare the pods that are going away for shutdown.
-	eps := createEndpoints(ar, oldInfo, newInfo, port, path)
+	eps := createEndpoints(ar, oldInfo, newInfo, stsInfo.port, stsInfo.path, stsInfo.serviceName)
 
 	if err := sendPrepareShutdownRequests(ctx, logger, client, eps); err != nil {
 		// Down-scale operation is disallowed because at least one pod failed to
@@ -206,6 +212,38 @@ func prepareDownscale(ctx context.Context, l log.Logger, ar admissionv1.Admissio
 	}
 }
 
+type statefulSetInfo struct {
+	prepareDownscale bool
+	port             string
+	path             string
+	rolloutGroup     string
+	serviceName      string
+}
+
+func getStatefulSetInfo(ctx context.Context, ar admissionv1.AdmissionReview, api kubernetes.Interface, info *objectInfo) (*statefulSetInfo, error) {
+	var sts *appsv1.StatefulSet
+	switch o := info.obj.(type) {
+	case *appsv1.StatefulSet:
+		sts = o
+	case *autoscalingv1.Scale:
+		var err error
+		sts, err = getStatefulSet(ctx, ar, api)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported type %s (go type %T)", info.gvk, info.obj)
+	}
+
+	return &statefulSetInfo{
+		prepareDownscale: sts.Labels[config.PrepareDownscaleLabelKey] == config.PrepareDownscaleLabelValue,
+		port:             sts.Annotations[config.PrepareDownscalePortAnnotationKey],
+		path:             sts.Annotations[config.PrepareDownscalePathAnnotationKey],
+		rolloutGroup:     sts.Labels[config.RolloutGroupLabelKey],
+		serviceName:      sts.Spec.ServiceName,
+	}, nil
+}
+
 // deny returns a *v1.AdmissionResponse with Allowed: false and the message provided
 func deny(msg string) *admissionv1.AdmissionResponse {
 	return &admissionv1.AdmissionResponse{
@@ -216,8 +254,8 @@ func deny(msg string) *admissionv1.AdmissionResponse {
 	}
 }
 
-func getResourceAnnotations(ctx context.Context, ar admissionv1.AdmissionReview, api kubernetes.Interface) (map[string]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "admission.getResourceAnnotations()")
+func getStatefulSet(ctx context.Context, ar admissionv1.AdmissionReview, api kubernetes.Interface) (*appsv1.StatefulSet, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "admission.getStatefulSet()")
 	defer span.Finish()
 
 	span.SetTag("object.namespace", ar.Request.Namespace)
@@ -229,7 +267,7 @@ func getResourceAnnotations(ctx context.Context, ar admissionv1.AdmissionReview,
 		if err != nil {
 			return nil, err
 		}
-		return obj.Annotations, nil
+		return obj, nil
 	}
 	return nil, fmt.Errorf("unsupported resource %s", ar.Request.Resource.Resource)
 }
@@ -428,51 +466,20 @@ func checkReplicasChange(logger log.Logger, oldInfo, newInfo *objectInfo) *admis
 	return nil
 }
 
-func getLabelsAndAnnotations(ctx context.Context, ar admissionv1.AdmissionReview, api kubernetes.Interface, info *objectInfo) (map[string]string, map[string]string, error) {
-	var lbls, annotations map[string]string
-	var err error
-
-	switch o := info.obj.(type) {
-	case *appsv1.Deployment:
-		lbls = o.Labels
-		annotations = o.Annotations
-	case *appsv1.StatefulSet:
-		lbls = o.Labels
-		annotations = o.Annotations
-	case *appsv1.ReplicaSet:
-		lbls = o.Labels
-		annotations = o.Annotations
-	case *autoscalingv1.Scale:
-		lbls, err = getResourceLabels(ctx, ar, api)
-		if err != nil {
-			return nil, nil, err
-		}
-		annotations, err = getResourceAnnotations(ctx, ar, api)
-		if err != nil {
-			return nil, nil, err
-		}
-	default:
-		return nil, nil, fmt.Errorf("unsupported type %T", o)
-	}
-
-	return lbls, annotations, nil
-}
-
-func createEndpoints(ar admissionv1.AdmissionReview, oldInfo, newInfo *objectInfo, port, path string) []endpoint {
+func createEndpoints(ar admissionv1.AdmissionReview, oldInfo, newInfo *objectInfo, port, path, serviceName string) []endpoint {
 	diff := (*oldInfo.replicas - *newInfo.replicas)
 	eps := make([]endpoint, diff)
 
 	// The DNS entry for a pod of a stateful set is
 	// ingester-zone-a-0.$(servicename).$(namespace).svc.cluster.local
-	// The service in this case is ingester-zone-a as well.
 	// https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id
 
-	for i := 0; i < int(diff); i++ {
+	for i := range int(diff) {
 		index := int(*oldInfo.replicas) - i - 1 // nr in statefulset
 		eps[i].url = fmt.Sprintf("%v-%v.%v.%v.svc.cluster.local:%s/%s",
 			ar.Request.Name, // pod name
 			index,
-			ar.Request.Name, // svc name
+			serviceName,
 			ar.Request.Namespace,
 			port,
 			path,

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -873,7 +873,7 @@ func TestCheckReplicasChange(t *testing.T) {
 	}
 }
 
-func TestGetStatefulSetInfo(t *testing.T) {
+func TestGetStatefulSetPrepareInfo(t *testing.T) {
 	ctx := context.Background()
 	ar := admissionv1.AdmissionReview{}
 	api := fake.NewSimpleClientset()
@@ -881,7 +881,7 @@ func TestGetStatefulSetInfo(t *testing.T) {
 	tests := []struct {
 		name       string
 		info       *objectInfo
-		expectInfo *statefulSetInfo
+		expectInfo *statefulSetPrepareInfo
 		expectErr  bool
 	}{
 		{
@@ -902,7 +902,7 @@ func TestGetStatefulSetInfo(t *testing.T) {
 					},
 				},
 			},
-			expectInfo: &statefulSetInfo{
+			expectInfo: &statefulSetPrepareInfo{
 				prepareDownscale: true,
 				path:             "path",
 				port:             "port",
@@ -914,13 +914,13 @@ func TestGetStatefulSetInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stsInfo, err := getStatefulSetInfo(ctx, ar, api, tt.info)
+			stsPrepareInfo, err := getStatefulSetPrepareInfo(ctx, ar, api, tt.info)
 			if (err != nil) != tt.expectErr {
-				t.Errorf("getStatefulSetInfo() error = %v, expectErr %v", err, tt.expectErr)
+				t.Errorf("getStatefulSetPrepareInfo() error = %v, expectErr %v", err, tt.expectErr)
 				return
 			}
-			if !reflect.DeepEqual(stsInfo, tt.expectInfo) {
-				t.Errorf("getStatefulSetInfo() ssInfo= %v, want %v", stsInfo, tt.expectInfo)
+			if !reflect.DeepEqual(stsPrepareInfo, tt.expectInfo) {
+				t.Errorf("getStatefulSetPrepareInfo() stsPrepareInfo= %v, want %v", stsPrepareInfo, tt.expectInfo)
 			}
 		})
 	}

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -873,46 +873,54 @@ func TestCheckReplicasChange(t *testing.T) {
 	}
 }
 
-func TestGetLabelsAndAnnotations(t *testing.T) {
+func TestGetStatefulSetInfo(t *testing.T) {
 	ctx := context.Background()
 	ar := admissionv1.AdmissionReview{}
 	api := fake.NewSimpleClientset()
 
 	tests := []struct {
-		name        string
-		info        *objectInfo
-		expectedLbl map[string]string
-		expectedAnn map[string]string
-		expectErr   bool
+		name       string
+		info       *objectInfo
+		expectInfo *statefulSetInfo
+		expectErr  bool
 	}{
 		{
-			name: "Deployment",
+			name: "StatefulSet",
 			info: &objectInfo{
-				obj: &appsv1.Deployment{
+				obj: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels:      map[string]string{"label1": "value1"},
-						Annotations: map[string]string{"annotation1": "value1"},
+						Labels: map[string]string{
+							config.PrepareDownscaleLabelKey: config.PrepareDownscaleLabelValue,
+						},
+						Annotations: map[string]string{
+							config.PrepareDownscalePathAnnotationKey: "path",
+							config.PrepareDownscalePortAnnotationKey: "port",
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						ServiceName: "serviceName",
 					},
 				},
 			},
-			expectedLbl: map[string]string{"label1": "value1"},
-			expectedAnn: map[string]string{"annotation1": "value1"},
-			expectErr:   false,
+			expectInfo: &statefulSetInfo{
+				prepareDownscale: true,
+				path:             "path",
+				port:             "port",
+				serviceName:      "serviceName",
+			},
+			expectErr: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lbls, anns, err := getLabelsAndAnnotations(ctx, ar, api, tt.info)
+			stsInfo, err := getStatefulSetInfo(ctx, ar, api, tt.info)
 			if (err != nil) != tt.expectErr {
-				t.Errorf("getLabelsAndAnnotations() error = %v, expectErr %v", err, tt.expectErr)
+				t.Errorf("getStatefulSetInfo() error = %v, expectErr %v", err, tt.expectErr)
 				return
 			}
-			if !reflect.DeepEqual(lbls, tt.expectedLbl) {
-				t.Errorf("getLabelsAndAnnotations() labels = %v, want %v", lbls, tt.expectedLbl)
-			}
-			if !reflect.DeepEqual(anns, tt.expectedAnn) {
-				t.Errorf("getLabelsAndAnnotations() annotations = %v, want %v", anns, tt.expectedAnn)
+			if !reflect.DeepEqual(stsInfo, tt.expectInfo) {
+				t.Errorf("getStatefulSetInfo() ssInfo= %v, want %v", stsInfo, tt.expectInfo)
 			}
 		})
 	}
@@ -927,12 +935,13 @@ func TestCreateEndpoints(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		oldInfo  *objectInfo
-		newInfo  *objectInfo
-		port     string
-		path     string
-		expected []endpoint
+		name        string
+		oldInfo     *objectInfo
+		newInfo     *objectInfo
+		port        string
+		path        string
+		serviceName string
+		expected    []endpoint
 	}{
 		{
 			name: "downscale by 2",
@@ -942,15 +951,16 @@ func TestCreateEndpoints(t *testing.T) {
 			newInfo: &objectInfo{
 				replicas: func() *int32 { i := int32(3); return &i }(),
 			},
-			port: "8080",
-			path: "prepare-downscale",
+			port:        "8080",
+			path:        "prepare-downscale",
+			serviceName: "service-name",
 			expected: []endpoint{
 				{
-					url:   "test-4.test.default.svc.cluster.local:8080/prepare-downscale",
+					url:   "test-4.service-name.default.svc.cluster.local:8080/prepare-downscale",
 					index: 4,
 				},
 				{
-					url:   "test-3.test.default.svc.cluster.local:8080/prepare-downscale",
+					url:   "test-3.service-name.default.svc.cluster.local:8080/prepare-downscale",
 					index: 3,
 				},
 			},
@@ -959,7 +969,7 @@ func TestCreateEndpoints(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := createEndpoints(ar, tt.oldInfo, tt.newInfo, tt.port, tt.path)
+			actual := createEndpoints(ar, tt.oldInfo, tt.newInfo, tt.port, tt.path, tt.serviceName)
 			if len(actual) != len(tt.expected) {
 				t.Errorf("createEndpoints() = %v, want %v", actual, tt.expected)
 				return

--- a/pkg/admission/zone_tracker.go
+++ b/pkg/admission/zone_tracker.go
@@ -67,19 +67,17 @@ func (zt *zoneTracker) prepareDownscale(ctx context.Context, l log.Logger, ar ad
 		return response
 	}
 
-	// Get the labels and annotations from the old object including the prepare downscale label
-	lbls, annotations, err := getLabelsAndAnnotations(ctx, ar, api, oldInfo)
+	stsInfo, err := getStatefulSetInfo(ctx, ar, api, oldInfo)
 	if err != nil {
 		return allowWarn(logger, fmt.Sprintf("%s, allowing the change", err))
 	}
 
-	if lbls[config.PrepareDownscaleLabelKey] != config.PrepareDownscaleLabelValue {
-		// Not labeled, nothing to do.
+	if !stsInfo.prepareDownscale {
+		// Nothing to do.
 		return &admissionv1.AdmissionResponse{Allowed: true}
 	}
 
-	port := annotations[config.PrepareDownscalePortAnnotationKey]
-	if port == "" {
+	if stsInfo.port == "" {
 		level.Warn(logger).Log("msg", fmt.Sprintf("downscale not allowed because the %v annotation is not set or empty", config.PrepareDownscalePortAnnotationKey))
 		return deny(
 			fmt.Sprintf(
@@ -89,8 +87,7 @@ func (zt *zoneTracker) prepareDownscale(ctx context.Context, l log.Logger, ar ad
 		)
 	}
 
-	path := annotations[config.PrepareDownscalePathAnnotationKey]
-	if path == "" {
+	if stsInfo.path == "" {
 		level.Warn(logger).Log("msg", fmt.Sprintf("downscale not allowed because the %v annotation is not set or empty", config.PrepareDownscalePathAnnotationKey))
 		return deny(
 			fmt.Sprintf(
@@ -100,9 +97,18 @@ func (zt *zoneTracker) prepareDownscale(ctx context.Context, l log.Logger, ar ad
 		)
 	}
 
-	rolloutGroup := lbls[config.RolloutGroupLabelKey]
-	if rolloutGroup != "" {
-		stsList, err := findStatefulSetsForRolloutGroup(ctx, api, ar.Request.Namespace, rolloutGroup)
+	if stsInfo.serviceName == "" {
+		level.Warn(logger).Log("msg", "downscale not allowed because the serviceName is not set or empty")
+		return deny(
+			fmt.Sprintf(
+				"downscale of %s/%s in %s from %d to %d replicas is not allowed because the serviceName is not set or empty.",
+				ar.Request.Resource.Resource, ar.Request.Name, ar.Request.Namespace, *oldInfo.replicas, *newInfo.replicas,
+			),
+		)
+	}
+
+	if stsInfo.rolloutGroup != "" {
+		stsList, err := findStatefulSetsForRolloutGroup(ctx, api, ar.Request.Namespace, stsInfo.rolloutGroup)
 		if err != nil {
 			level.Warn(logger).Log("msg", "downscale not allowed due to error while finding other statefulsets", "err", err)
 			return deny(
@@ -154,7 +160,7 @@ func (zt *zoneTracker) prepareDownscale(ctx context.Context, l log.Logger, ar ad
 	}
 
 	// It's a downscale, so we need to prepare the pods that are going away for shutdown.
-	eps := createEndpoints(ar, oldInfo, newInfo, port, path)
+	eps := createEndpoints(ar, oldInfo, newInfo, stsInfo.port, stsInfo.path, stsInfo.serviceName)
 
 	err = sendPrepareShutdownRequests(ctx, logger, client, eps)
 	if err != nil {


### PR DESCRIPTION
Addresses #125.

Relevant Kubernetes documentation here: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id
> A StatefulSet can use a [Headless Service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) to control the domain of its Pods. The domain managed by this Service takes the form: $(service name).$(namespace).svc.cluster.local, where "cluster.local" is the cluster domain. As each Pod is created, it gets a matching DNS subdomain, taking the form: $(podname).$(governing service domain), where the governing service is defined by the serviceName field on the StatefulSet.

When constructing the endpoint to call for a pod's `prepare-downscale`, `rollout-operator` was assuming the `.spec.serviceName` of a `StatefulSet` was equal to the `.metadata.name` of the `StatefulSet`. This happens to be true for each ingester `StatefulSet` in Mimir's Jsonnet, but is not true for ingesters in Mimir's Helm since it has a single headless ingester service.

A community member kindly submitted a fix for this issue in #173, but it never got a response. From inspection I think that implementation missed support for `statefulsets/scale`. It also added another `StatefulSet` query. I implemented these changes from scratch to address these issues and avoid other unnecessary changes.

~Marking as draft until I validate some more.~ Validated locally