### PR TITLE
Always configure HTTP client with a timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * `k8s.io/api` from `v0.33.1` to `v0.33.2`
   * `k8s.io/apimachinery` from `v0.33.1` to `v0.33.2`
   * `k8s.io/client-go` from `v0.33.1` to `v0.33.2`
+* [BUGFIX] Always configure HTTP client with a timeout. #240
 
 ## v0.28.0
 


### PR DESCRIPTION
This is a fixup for #186 #188

We've recently had a reoccurring problem, where it took 30m for ingesters to respond to the `DELETE /prepare-instance-ring-downscale`.

```
duration=36m54.240982501s msg="error sending HTTP DELETE request to endpoint" err="Delete \"http://ingester-zone-c-98.ingester-zone-c.mimir-prod-24.svc.cluster.local/./ingester/prepare-instance-ring-downscale\": read tcp 10.3.188.28:37044->10.3.53.215:80: read: connection timed out"
```

Waiting for such a long time delays the reconciliation.

It's turned out that the "default" timeout that we've introduced in #186 is only applied, when the operator has a config, which we currently don't.

This PR updates the code making sure the configured timeout is always set in the HTTP client config.