### PR TITLE
fix: reject scale down request if there is already an in-process request in the same rollout group

### DIFF
--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -149,6 +149,7 @@ type templateParams struct {
 	DownScalePortKey  string
 	DownScalePort     string
 	DownScaleLabelKey string
+	RolloutGroup      string
 }
 
 type fakeHttpClient struct {
@@ -214,6 +215,7 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 		DownScalePortKey:  config.PrepareDownscalePortAnnotationKey,
 		DownScalePort:     u.Port(),
 		DownScaleLabelKey: config.PrepareDownscaleLabelKey,
+		RolloutGroup:      "ingester",
 	}
 
 	newParams := templateParams{
@@ -223,6 +225,7 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 		DownScalePortKey:  config.PrepareDownscalePortAnnotationKey,
 		DownScalePort:     u.Port(),
 		DownScaleLabelKey: config.PrepareDownscaleLabelKey,
+		RolloutGroup:      "ingester",
 	}
 
 	rawObject, err := statefulSetTemplate(newParams)
@@ -618,7 +621,7 @@ metadata:
   name: web
   labels:
     {{.DownScaleLabelKey}}: "true"
-    rollout-group: "ingester"
+    rollout-group: "{{.RolloutGroup}}"
   annotations:
     {{.DownScalePathKey}}: {{.DownScalePath}}
     {{.DownScalePortKey}}: "{{.DownScalePort}}"
@@ -686,6 +689,7 @@ func testPrepDownscaleWebhookWithZoneTracker(t *testing.T, oldReplicas, newRepli
 		DownScalePortKey:  config.PrepareDownscalePortAnnotationKey,
 		DownScalePort:     u.Port(),
 		DownScaleLabelKey: config.PrepareDownscaleLabelKey,
+		RolloutGroup:      "ingester",
 	}
 
 	newParams := templateParams{
@@ -695,6 +699,7 @@ func testPrepDownscaleWebhookWithZoneTracker(t *testing.T, oldReplicas, newRepli
 		DownScalePortKey:  config.PrepareDownscalePortAnnotationKey,
 		DownScalePort:     u.Port(),
 		DownScaleLabelKey: config.PrepareDownscaleLabelKey,
+		RolloutGroup:      "ingester",
 	}
 
 	rawObject, err := statefulSetTemplate(newParams)

--- a/pkg/admission/zone_tracker_test.go
+++ b/pkg/admission/zone_tracker_test.go
@@ -426,9 +426,11 @@ func TestZoneTrackerConcurrentDownscale(t *testing.T) {
 
 	// finishing the in progress downscaling request for rollout group ingester should let new requests to go through
 	close(ingesterZoneAPrepDownscaleDone)
-	ar = buildAdmissionRequest(rolloutGroupIngester, ingesterZoneB)
-	admissionResponse = zt.prepareDownscale(context.Background(), logger, ar, api, f)
-	require.True(t, admissionResponse.Allowed)
+
+	require.Eventually(t, func() bool {
+		ar = buildAdmissionRequest(rolloutGroupIngester, ingesterZoneB)
+		return zt.prepareDownscale(context.Background(), logger, ar, api, f).Allowed
+	}, 5*time.Second, time.Millisecond)
 
 	// index-gateway-zone-a and ingester-zone-(a|b) should have been updated
 	require.NoError(t, zt.loadZones(context.Background(), nil))

--- a/pkg/admission/zone_tracker_test.go
+++ b/pkg/admission/zone_tracker_test.go
@@ -1,15 +1,23 @@
 package admission
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/grafana/rollout-operator/pkg/config"
@@ -285,4 +293,126 @@ func TestLastDownscaledNonExistentZone(t *testing.T) {
 	if time != "" {
 		t.Errorf("lastDownscaled did not handle non-existent zone correctly")
 	}
+}
+
+func TestZoneTrackerConcurrentDownscale(t *testing.T) {
+	f := newFakeHttpClient(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewBuffer([]byte(""))),
+		}, nil
+	})
+
+	logger := newDebugLogger()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	require.NotEmpty(t, u.Port())
+
+	path := "/prepare-downscale"
+	rolloutGroupIngester := "ingester"
+	ingesterZoneA := "ingester-zone-a"
+	rolloutGroupIndexGateway := "index-gateway"
+	indexGatewayZoneA := "index-gateway-zone-a"
+
+	namespace := "test"
+	dryRun := false
+	buildAdmissionRequest := func(rolloutGroup string, stsName string) admissionv1.AdmissionReview {
+		oldParams := templateParams{
+			Replicas:          5,
+			DownScalePathKey:  config.PrepareDownscalePathAnnotationKey,
+			DownScalePath:     path,
+			DownScalePortKey:  config.PrepareDownscalePortAnnotationKey,
+			DownScalePort:     u.Port(),
+			DownScaleLabelKey: config.PrepareDownscaleLabelKey,
+			RolloutGroup:      rolloutGroup,
+		}
+
+		newParams := templateParams{
+			Replicas:          2,
+			DownScalePathKey:  config.PrepareDownscalePathAnnotationKey,
+			DownScalePath:     path,
+			DownScalePortKey:  config.PrepareDownscalePortAnnotationKey,
+			DownScalePort:     u.Port(),
+			DownScaleLabelKey: config.PrepareDownscaleLabelKey,
+			RolloutGroup:      rolloutGroup,
+		}
+
+		rawObject, err := statefulSetTemplate(newParams)
+		require.NoError(t, err)
+
+		oldRawObject, err := statefulSetTemplate(oldParams)
+		require.NoError(t, err)
+
+		return admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Statefulset",
+				},
+				Resource: metav1.GroupVersionResource{
+					Group:    "apps",
+					Version:  "v1",
+					Resource: "statefulsets",
+				},
+				Name:      stsName,
+				Namespace: namespace,
+				Object: runtime.RawExtension{
+					Raw: rawObject,
+				},
+				OldObject: runtime.RawExtension{
+					Raw: oldRawObject,
+				},
+				DryRun: &dryRun,
+			},
+		}
+	}
+
+	api := fake.NewSimpleClientset()
+
+	zt := newZoneTracker(api, namespace, "testconfigmap")
+
+	// mimic in progress downscaling request of rollout group ingester
+	zt.rolloutGroupDownscalingInProgress.Store(rolloutGroupIngester, ingesterZoneA)
+
+	// downscale request for rollout group ingester should fail
+	ar := buildAdmissionRequest(rolloutGroupIngester, ingesterZoneA)
+	admissionResponse := zt.prepareDownscale(context.Background(), logger, ar, api, f)
+	require.False(t, admissionResponse.Allowed)
+	require.Equal(t, "downscale of statefulsets/ingester-zone-a in test from 5 to 2 replicas is not allowed because statefulset ingester-zone-a is already in process of updating replicas", admissionResponse.Result.Message)
+
+	require.NoError(t, zt.loadZones(context.Background(), nil))
+	// no zones should have been updated
+	require.Len(t, zt.zones, 0)
+
+	// while downscale request for group index-gateway should pass
+	ar = buildAdmissionRequest(rolloutGroupIndexGateway, indexGatewayZoneA)
+	admissionResponse = zt.prepareDownscale(context.Background(), logger, ar, api, f)
+	require.True(t, admissionResponse.Allowed)
+
+	require.NoError(t, zt.loadZones(context.Background(), nil))
+	// only index-gateway-zone-a should have been updated
+	require.Len(t, zt.zones, 1)
+	_, zoneUpdated := zt.zones[indexGatewayZoneA]
+	require.True(t, zoneUpdated)
+
+	// clearing the in progress downscaling request of rollout group ingester should let new requests to go through
+	zt.rolloutGroupDownscalingInProgress.Delete(rolloutGroupIngester)
+	ar = buildAdmissionRequest(rolloutGroupIngester, ingesterZoneA)
+	admissionResponse = zt.prepareDownscale(context.Background(), logger, ar, api, f)
+	require.True(t, admissionResponse.Allowed)
+
+	require.NoError(t, zt.loadZones(context.Background(), nil))
+	// both index-gateway-zone-a and ingester-zone-a should have been updated
+	require.Len(t, zt.zones, 2)
+	_, zoneUpdated = zt.zones[indexGatewayZoneA]
+	require.True(t, zoneUpdated)
+	_, zoneUpdated = zt.zones[ingesterZoneA]
+	require.True(t, zoneUpdated)
 }

--- a/pkg/admission/zone_tracker_test.go
+++ b/pkg/admission/zone_tracker_test.go
@@ -430,7 +430,7 @@ func TestZoneTrackerConcurrentDownscale(t *testing.T) {
 	require.Eventually(t, func() bool {
 		ar = buildAdmissionRequest(rolloutGroupIngester, ingesterZoneB)
 		return zt.prepareDownscale(context.Background(), logger, ar, api, f).Allowed
-	}, 5*time.Second, time.Millisecond)
+	}, 5*time.Second, 50*time.Millisecond)
 
 	// index-gateway-zone-a and ingester-zone-(a|b) should have been updated
 	require.NoError(t, zt.loadZones(context.Background(), nil))


### PR DESCRIPTION
If multiple simultaneous scale-down requests are made to prepare the downscale handler for the same rollout group, the code might inadvertently allow all the requests, even if `grafana.com/min-time-between-zones-downscale` is set to a non-zero value.
The issue is that there is no synchronisation to prevent that from happening.

In this PR, I am fixing the issue by tracking ongoing prepare downscale requests by rollout group and rejecting any new downscale requests for the same rollout group until the previous request is finished serving.