### PR TITLE
fix: construct delay downscale pod FQDN using both service and sts name

### DIFF
--- a/pkg/admission/prep_downscale.go
+++ b/pkg/admission/prep_downscale.go
@@ -475,17 +475,10 @@ func createEndpoints(ar admissionv1.AdmissionReview, oldInfo, newInfo *objectInf
 	diff := (*oldInfo.replicas - *newInfo.replicas)
 	eps := make([]endpoint, diff)
 
-	// The DNS entry for a pod of a stateful set is
-	// ingester-zone-a-0.$(servicename).$(namespace).svc.cluster.local
-	// https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id
-
 	for i := range int(diff) {
 		index := int(*oldInfo.replicas) - i - 1 // nr in statefulset
-		eps[i].url = fmt.Sprintf("%v-%v.%v.%v.svc.cluster.local:%s/%s",
-			ar.Request.Name, // pod name
-			index,
-			serviceName,
-			ar.Request.Namespace,
+		eps[i].url = fmt.Sprintf("%s:%s/%s",
+			util.StatefulSetPodFQDN(ar.Request.Namespace, ar.Request.Name, index, serviceName),
 			port,
 			path,
 		)

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -956,11 +956,11 @@ func TestCreateEndpoints(t *testing.T) {
 			serviceName: "service-name",
 			expected: []endpoint{
 				{
-					url:   "test-4.service-name.default.svc.cluster.local:8080/prepare-downscale",
+					url:   "test-4.service-name.default.svc.cluster.local.:8080/prepare-downscale",
 					index: 4,
 				},
 				{
-					url:   "test-3.service-name.default.svc.cluster.local:8080/prepare-downscale",
+					url:   "test-3.service-name.default.svc.cluster.local.:8080/prepare-downscale",
 					index: 3,
 				},
 			},

--- a/pkg/controller/delay.go
+++ b/pkg/controller/delay.go
@@ -18,6 +18,7 @@ import (
 	v1 "k8s.io/api/apps/v1"
 
 	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/util"
 )
 
 func cancelDelayedDownscaleIfConfigured(ctx context.Context, logger log.Logger, sts *v1.StatefulSet, httpClient httpClient, replicas int32) {
@@ -31,7 +32,7 @@ func cancelDelayedDownscaleIfConfigured(ctx context.Context, logger log.Logger, 
 		return
 	}
 
-	endpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), 0, int(replicas), prepareURL)
+	endpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), sts.Spec.ServiceName, 0, int(replicas), prepareURL)
 
 	callCancelDelayedDownscale(ctx, logger, httpClient, endpoints)
 }
@@ -54,19 +55,19 @@ func checkScalingDelay(ctx context.Context, logger log.Logger, sts *v1.StatefulS
 	}
 
 	if desiredReplicas >= currentReplicas {
-		callCancelDelayedDownscale(ctx, logger, httpClient, createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), 0, int(currentReplicas), prepareURL))
+		callCancelDelayedDownscale(ctx, logger, httpClient, createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), sts.Spec.ServiceName, 0, int(currentReplicas), prepareURL))
 		// Proceed even if calling cancel of delayed downscale fails. We call cancellation repeatedly, so it will happen during next reconcile.
 		return desiredReplicas, nil
 	}
 
 	{
 		// Replicas in [0, desired) interval should cancel any delayed downscale, if they have any.
-		cancelEndpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), 0, int(desiredReplicas), prepareURL)
+		cancelEndpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), sts.Spec.ServiceName, 0, int(desiredReplicas), prepareURL)
 		callCancelDelayedDownscale(ctx, logger, httpClient, cancelEndpoints)
 	}
 
 	// Replicas in [desired, current) interval are going to be stopped.
-	downscaleEndpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), int(desiredReplicas), int(currentReplicas), prepareURL)
+	downscaleEndpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), sts.Spec.ServiceName, int(desiredReplicas), int(currentReplicas), prepareURL)
 	elapsedTimeSinceDownscaleInitiated, err := callPrepareDownscaleAndReturnElapsedDurationsSinceInitiatedDownscale(ctx, logger, httpClient, downscaleEndpoints)
 	if err != nil {
 		return currentReplicas, fmt.Errorf("failed prepare pods for delayed downscale: %v", err)
@@ -131,23 +132,18 @@ type endpoint struct {
 }
 
 // Create prepare-downscale endpoints for pods with index in [from, to) range. URL is fully reused except for host, which is replaced with pod's FQDN.
-func createPrepareDownscaleEndpoints(namespace, serviceName string, from, to int, url *url.URL) []endpoint {
+func createPrepareDownscaleEndpoints(namespace, statefulSetName, serviceName string, from, to int, url *url.URL) []endpoint {
 	eps := make([]endpoint, 0, to-from)
-
-	// The DNS entry for a pod of a stateful set is
-	// ingester-zone-a-0.$(servicename).$(namespace).svc.cluster.local.
-	// The service in this case is ingester-zone-a as well.
-	// https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id
 
 	for index := from; index < to; index++ {
 		ep := endpoint{
 			namespace: namespace,
-			podName:   fmt.Sprintf("%v-%v", serviceName, index),
+			podName:   fmt.Sprintf("%v-%v", statefulSetName, index),
 			replica:   index,
 		}
 
 		ep.url = *url
-		newHost := fmt.Sprintf("%s.%v.%v.svc.cluster.local.", ep.podName, serviceName, ep.namespace)
+		newHost := util.StatefulSetPodFQDN(namespace, statefulSetName, index, serviceName)
 		if url.Port() != "" {
 			newHost = fmt.Sprintf("%s:%s", newHost, url.Port())
 		}

--- a/pkg/controller/delay_test.go
+++ b/pkg/controller/delay_test.go
@@ -10,54 +10,57 @@ import (
 
 func TestCreatePrepareDownscaleEndpoints(t *testing.T) {
 	testCases := []struct {
-		name        string
-		namespace   string
-		serviceName string
-		from        int
-		to          int
-		inputURL    string
-		expected    []endpoint
+		name            string
+		namespace       string
+		statefulSetName string
+		serviceName     string
+		from            int
+		to              int
+		inputURL        string
+		expected        []endpoint
 	}{
 		{
-			name:        "URL without port",
-			namespace:   "test-namespace",
-			serviceName: "test-service",
-			from:        0,
-			to:          2,
-			inputURL:    "http://example.com/api/prepare",
+			name:            "URL without port",
+			namespace:       "test-namespace",
+			statefulSetName: "test-statefulset",
+			serviceName:     "test-service",
+			from:            0,
+			to:              2,
+			inputURL:        "http://example.com/api/prepare",
 			expected: []endpoint{
 				{
 					namespace: "test-namespace",
-					podName:   "test-service-0",
-					url:       mustParseURL(t, "http://test-service-0.test-service.test-namespace.svc.cluster.local./api/prepare"),
+					podName:   "test-statefulset-0",
+					url:       mustParseURL(t, "http://test-statefulset-0.test-service.test-namespace.svc.cluster.local./api/prepare"),
 					replica:   0,
 				},
 				{
 					namespace: "test-namespace",
-					podName:   "test-service-1",
-					url:       mustParseURL(t, "http://test-service-1.test-service.test-namespace.svc.cluster.local./api/prepare"),
+					podName:   "test-statefulset-1",
+					url:       mustParseURL(t, "http://test-statefulset-1.test-service.test-namespace.svc.cluster.local./api/prepare"),
 					replica:   1,
 				},
 			},
 		},
 		{
-			name:        "URL with port",
-			namespace:   "prod-namespace",
-			serviceName: "prod-service",
-			from:        1,
-			to:          3,
-			inputURL:    "http://example.com:8080/api/prepare",
+			name:            "URL with port",
+			namespace:       "prod-namespace",
+			statefulSetName: "prod-statefulset",
+			serviceName:     "prod-service",
+			from:            1,
+			to:              3,
+			inputURL:        "http://example.com:8080/api/prepare",
 			expected: []endpoint{
 				{
 					namespace: "prod-namespace",
-					podName:   "prod-service-1",
-					url:       mustParseURL(t, "http://prod-service-1.prod-service.prod-namespace.svc.cluster.local.:8080/api/prepare"),
+					podName:   "prod-statefulset-1",
+					url:       mustParseURL(t, "http://prod-statefulset-1.prod-service.prod-namespace.svc.cluster.local.:8080/api/prepare"),
 					replica:   1,
 				},
 				{
 					namespace: "prod-namespace",
-					podName:   "prod-service-2",
-					url:       mustParseURL(t, "http://prod-service-2.prod-service.prod-namespace.svc.cluster.local.:8080/api/prepare"),
+					podName:   "prod-statefulset-2",
+					url:       mustParseURL(t, "http://prod-statefulset-2.prod-service.prod-namespace.svc.cluster.local.:8080/api/prepare"),
 					replica:   2,
 				},
 			},
@@ -69,7 +72,7 @@ func TestCreatePrepareDownscaleEndpoints(t *testing.T) {
 			inputURL, err := url.Parse(tc.inputURL)
 			require.NoError(t, err)
 
-			result := createPrepareDownscaleEndpoints(tc.namespace, tc.serviceName, tc.from, tc.to, inputURL)
+			result := createPrepareDownscaleEndpoints(tc.namespace, tc.statefulSetName, tc.serviceName, tc.from, tc.to, inputURL)
 
 			assert.Equal(t, tc.expected, result)
 		})

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/facette/natsort"
@@ -101,4 +102,19 @@ func MustNewLabelsRequirement(key string, op selection.Operator, vals []string) 
 func Now() *metav1.Time {
 	ts := metav1.Now()
 	return &ts
+}
+
+func StatefulSetPodFQDN(namespace, statefulSetName string, ordinal int, serviceName string) string {
+	// The DNS entry for a pod of a stateful set is
+	// $(statefulset name)-(ordinal).$(service name).$(namespace).svc.cluster.local
+	// https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id
+	//
+	// Ending that with a trailing "." to signify an absolute domain name
+	// https://datatracker.ietf.org/doc/html/rfc1034#section-3.1
+	return fmt.Sprintf("%v-%v.%v.%v.svc.cluster.local.",
+		statefulSetName,
+		ordinal,
+		serviceName,
+		namespace,
+	)
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/rollout-operator/issues/251

`createPrepareDownscaleEndpoints` assumed the StatefulSet name was equal to the serviceName. That works in Mimir's Jsonnet deployment, but does not for Mimir's Helm chart. This is similar to the fix in #221.

I pulled the FQDN construction into a common method to hopefully reduce the chance of this drifting again in the future. A consequence of doing that was the prepare downscale path now specifies a trailing `.` as well when it did not before. That is not a required change for this particular fix, but it seemed right to do anyway.