### PR TITLE
Use informer to monitor for new webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ metadata:
 rules:
 - apiGroups: [admissionregistration.k8s.io]
   resources: [validatingwebhookconfigurations]
-  verbs: [list, patch]
+  verbs: [list, patch, watch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -219,6 +219,7 @@ func main() {
 	go func() {
 		waitForSignalOrRestart(logger, restart)
 		c.Stop()
+		vwo.Stop()
 	}()
 
 	// The operator is ready once the controller successfully initialised.

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/common/model"
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Required to get the GCP auth provider working.
@@ -205,8 +206,10 @@ func main() {
 	dynamicClient, err := dynamic.NewForConfigAndClient(kubeConfig, httpClient)
 	check(errors.Wrap(err, "failed to init dynamicClient"))
 
+	vwo := tlscert.NewWebhookObserver(kubeClient, cfg.kubeNamespace, logger)
+
 	// Start TLS server if enabled.
-	maybeStartTLSServer(cfg, httpRT, logger, kubeClient, restart, metrics)
+	maybeStartTLSServer(cfg, httpRT, logger, kubeClient, restart, metrics, vwo)
 
 	// Init the controller.
 	c := controller.NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, cfg.kubeNamespace, httpClient, cfg.reconcileInterval, reg, logger)
@@ -236,7 +239,7 @@ func waitForSignalOrRestart(logger log.Logger, restart chan string) {
 	}
 }
 
-func maybeStartTLSServer(cfg config, rt http.RoundTripper, logger log.Logger, kubeClient *kubernetes.Clientset, restart chan string, metrics *metrics) {
+func maybeStartTLSServer(cfg config, rt http.RoundTripper, logger log.Logger, kubeClient *kubernetes.Clientset, restart chan string, metrics *metrics, vwo *tlscert.WebhookObserver) {
 	if !cfg.serverTLSEnabled {
 		level.Info(logger).Log("msg", "tls server is not enabled")
 		return
@@ -267,9 +270,18 @@ func maybeStartTLSServer(cfg config, rt http.RoundTripper, logger log.Logger, ku
 			fatal(errors.New("self-signed certificate should be enabled to update the CA bundle in the webhook configurations"))
 		}
 
-		// TODO watch webhook configurations instead of doing one-off.
-		check(tlscert.PatchCABundleOnValidatingWebhooks(context.Background(), logger, kubeClient, cfg.kubeNamespace, cert.CA))
-		check(tlscert.PatchCABundleOnMutatingWebhooks(context.Background(), logger, kubeClient, cfg.kubeNamespace, cert.CA))
+		webHookListener := &tlscert.WebhookConfigurationListener{
+			OnValidatingWebhookConfiguration: func(webhook *admissionregistrationv1.ValidatingWebhookConfiguration) error {
+				return tlscert.PatchCABundleOnValidatingWebhooks(logger, kubeClient, cfg.kubeNamespace, cert.CA, webhook)
+			},
+			OnMutatingWebhookConfiguration: func(webhook *admissionregistrationv1.MutatingWebhookConfiguration) error {
+				return tlscert.PatchCABundleOnMutatingWebhooks(logger, kubeClient, cfg.kubeNamespace, cert.CA, webhook)
+			},
+		}
+
+		// Start monitoring for validating webhook configurations and patch if required
+		check(vwo.Init(webHookListener))
+
 	}
 
 	prepDownscaleAdmitFunc := func(ctx context.Context, logger log.Logger, ar v1.AdmissionReview, api *kubernetes.Clientset) *v1.AdmissionResponse {

--- a/development/rollout-operator-webhook-clusterrole.yaml
+++ b/development/rollout-operator-webhook-clusterrole.yaml
@@ -11,3 +11,4 @@ rules:
     verbs:
       - list
       - patch
+      - watch

--- a/integration/manifests_rollout_operator_test.go
+++ b/integration/manifests_rollout_operator_test.go
@@ -279,7 +279,7 @@ func webhookRolloutOperatorClusterRole(namespace string) *rbacv1.ClusterRole {
 			{
 				APIGroups: []string{"admissionregistration.k8s.io"},
 				Resources: []string{"validatingwebhookconfigurations", "mutatingwebhookconfigurations"},
-				Verbs:     []string{"list", "patch"},
+				Verbs:     []string{"list", "patch", "watch"},
 			},
 		},
 	}

--- a/pkg/tlscert/webhook_observer.go
+++ b/pkg/tlscert/webhook_observer.go
@@ -81,7 +81,7 @@ func (c *WebhookObserver) Init(onEvent *WebhookConfigurationListener) error {
 	// Wait until all informer caches have been synced.
 	level.Info(c.log).Log("msg", "waiting for webhook informer caches to sync")
 	if ok := cache.WaitForCacheSync(c.stopCh, c.informerValidatingWebhooks.HasSynced, c.informerMutatingWebhooks.HasSynced); !ok {
-		return errors.New("validating webhook informer caches failed to sync")
+		return fmt.Errorf("validating webhook informer caches failed to sync. validating webhook informer sync=%t, mutating webhook informer sync=%t", c.informerValidatingWebhooks.HasSynced(), c.informerMutatingWebhooks.HasSynced())
 	}
 	level.Info(c.log).Log("msg", "webhook informer caches sync completed")
 

--- a/pkg/tlscert/webhook_observer.go
+++ b/pkg/tlscert/webhook_observer.go
@@ -1,0 +1,95 @@
+package tlscert
+
+import (
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	// How frequently informers should resync
+	informerSyncInterval = 5 * time.Minute
+)
+
+type WebhookConfigurationListener struct {
+	OnValidatingWebhookConfiguration func(webhook *admissionregistrationv1.ValidatingWebhookConfiguration) error
+	OnMutatingWebhookConfiguration   func(webhook *admissionregistrationv1.MutatingWebhookConfiguration) error
+}
+
+// A WebhookObserver uses informers to monitor for ValidatingWebhookConfiguration and MutatingWebhookConfigurations.
+// When observed, a call back function is invoked with the given configuration.
+// The call back function is set as part of the Init() function.
+type WebhookObserver struct {
+	namespace                  string
+	factory                    informers.SharedInformerFactory
+	informerValidatingWebhooks cache.SharedIndexInformer
+	informerMutatingWebhooks   cache.SharedIndexInformer
+	log                        log.Logger
+	stopCh                     chan struct{}
+}
+
+func NewWebhookObserver(kubeClient kubernetes.Interface, namespace string, logger log.Logger) *WebhookObserver {
+	namespaceOpt := informers.WithNamespace(namespace)
+
+	factory := informers.NewSharedInformerFactoryWithOptions(kubeClient, informerSyncInterval, namespaceOpt)
+
+	c := &WebhookObserver{
+		namespace:                  namespace,
+		factory:                    factory,
+		informerValidatingWebhooks: factory.Admissionregistration().V1().ValidatingWebhookConfigurations().Informer(),
+		informerMutatingWebhooks:   factory.Admissionregistration().V1().MutatingWebhookConfigurations().Informer(),
+		log:                        logger,
+		stopCh:                     make(chan struct{}),
+	}
+
+	return c
+}
+
+// Init starts watching for validating and mutating webhook configurations being added.
+// The given WebhookConfigurationListener is called when any webhook configurations is added.
+func (c *WebhookObserver) Init(onEvent *WebhookConfigurationListener) error {
+
+	informers := []cache.SharedIndexInformer{c.informerValidatingWebhooks, c.informerMutatingWebhooks}
+	for _, informer := range informers {
+		if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				var err error
+				validatingWebHook, isObj := obj.(*admissionregistrationv1.ValidatingWebhookConfiguration)
+				if isObj {
+					err = onEvent.OnValidatingWebhookConfiguration(validatingWebHook)
+				} else {
+					mutatingWebHook, isObj := obj.(*admissionregistrationv1.MutatingWebhookConfiguration)
+					if isObj {
+						err = onEvent.OnMutatingWebhookConfiguration(mutatingWebHook)
+					}
+				}
+				if err != nil {
+					level.Error(c.log).Log("msg", "Unable to call webhook configuration listener", "err", err)
+				}
+			},
+		}); err != nil {
+			return errors.Wrap(err, "failed to add webhook listener")
+		}
+	}
+
+	go c.factory.Start(c.stopCh)
+
+	// Wait until all informer caches have been synced.
+	level.Info(c.log).Log("msg", "waiting for webhook informer caches to sync")
+	if ok := cache.WaitForCacheSync(c.stopCh, c.informerValidatingWebhooks.HasSynced, c.informerMutatingWebhooks.HasSynced); !ok {
+		return errors.New("validating webhook informer caches failed to sync")
+	}
+	level.Info(c.log).Log("msg", "webhook informer caches sync completed")
+
+	return nil
+}
+
+func (c *WebhookObserver) Stop() {
+	close(c.stopCh)
+}

--- a/pkg/tlscert/webhook_observer_test.go
+++ b/pkg/tlscert/webhook_observer_test.go
@@ -1,0 +1,123 @@
+package tlscert
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+type mockLogger struct{}
+
+func (m mockLogger) Log(keyvals ...interface{}) error {
+	return nil
+}
+
+func TestWebhookObserver_lifeCycle(t *testing.T) {
+	logger := &mockLogger{}
+	observer := NewWebhookObserver(k8sfake.NewClientset(), "test-namespace", logger)
+
+	listener := &WebhookConfigurationListener{}
+	require.NoError(t, observer.Init(listener))
+
+	// Ensure that stopCh has been opened
+	select {
+	case <-observer.stopCh:
+		t.Fatal("stopCh should not be closed initially")
+	default:
+		// Expected - channel is open
+	}
+
+	observer.Stop()
+
+	// Ensure that stopCh has been closed
+	select {
+	case <-observer.stopCh:
+		// Expected - channel is closed
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("stopCh should be closed after Stop()")
+	}
+}
+
+// TestWebhookObserver_ListenerInvoked tests that the WebhookObserver correctly invokes the registered callback when a new validating webhook configuration or mutating webhook configuration is observed.
+func TestWebhookObserver_ListenerInvoked(t *testing.T) {
+	logger := &mockLogger{}
+	client := k8sfake.NewClientset()
+	observer := NewWebhookObserver(client, "test-namespace", logger)
+
+	// create a listener which simply adds the observed webhooks to these slices
+	observedValidatingWebhooks := make([]*admissionregistrationv1.ValidatingWebhookConfiguration, 0)
+	observedMutatingWebhooks := make([]*admissionregistrationv1.MutatingWebhookConfiguration, 0)
+
+	listener := &WebhookConfigurationListener{
+		OnValidatingWebhookConfiguration: func(webhook *admissionregistrationv1.ValidatingWebhookConfiguration) error {
+			observedValidatingWebhooks = append(observedValidatingWebhooks, webhook)
+			return nil
+		},
+		OnMutatingWebhookConfiguration: func(webhook *admissionregistrationv1.MutatingWebhookConfiguration) error {
+			observedMutatingWebhooks = append(observedMutatingWebhooks, webhook)
+			return nil
+		},
+	}
+	require.NoError(t, observer.Init(listener))
+	defer observer.Stop()
+
+	require.Equal(t, 0, len(observedValidatingWebhooks))
+	require.Equal(t, 0, len(observedMutatingWebhooks))
+
+	_, err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(context.Background(), validatingWebhookConfiguration("validating-webhook"), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// wait for the informer to be aware of this create
+	task := func() bool {
+		return len(observedValidatingWebhooks) == 1
+	}
+	await(t, task, "ValidatingWebhookConfiguration should have 1 ValidatingWebhookConfiguration")
+	require.Equal(t, 1, len(observedValidatingWebhooks))
+	require.Equal(t, "validating-webhook", observedValidatingWebhooks[0].Name)
+	require.Equal(t, 0, len(observedMutatingWebhooks))
+
+	_, err = client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.Background(), mutatingWebhookConfiguration("mutating-webhook"), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// wait for the informer to be aware of this create
+	task = func() bool {
+		return len(observedMutatingWebhooks) == 1
+	}
+	await(t, task, "MutatingWebhookConfiguration should have 1 MutatingWebhookConfiguration")
+	require.Equal(t, 1, len(observedMutatingWebhooks))
+	require.Equal(t, "mutating-webhook", observedMutatingWebhooks[0].Name)
+}
+
+// validatingWebhookConfiguration returns a new ValidatingWebhookConfiguration with only it's name set
+func validatingWebhookConfiguration(name string) *admissionregistrationv1.ValidatingWebhookConfiguration {
+	return &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// mutatingWebhookConfiguration returns a new MutatingWebhookConfiguration with only it's name set
+func mutatingWebhookConfiguration(name string) *admissionregistrationv1.MutatingWebhookConfiguration {
+	return &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// await - sleep for a short period and invoke the given task. return if the task returns true. repeat for a fixed number of iterations
+func await(t *testing.T, task func() bool, message string) {
+	for i := 0; i < 10; i++ {
+		time.Sleep(10 * time.Millisecond)
+		if task() {
+			return
+		}
+	}
+	require.Fail(t, message)
+}

--- a/pkg/tlscert/webhookconfig.go
+++ b/pkg/tlscert/webhookconfig.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	v1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,50 +19,41 @@ import (
 // Webhook configurations should have the following labels:
 // "grafana.com/inject-rollout-operator-ca": "true",
 // "grafana.com/namespace":                  <specified namespace>,
-func PatchCABundleOnValidatingWebhooks(ctx context.Context, logger log.Logger, kubeClient kubernetes.Interface, namespace string, caPEM []byte) error {
+func PatchCABundleOnValidatingWebhooks(logger log.Logger, kubeClient kubernetes.Interface, namespace string, caPEM []byte, wh *v1.ValidatingWebhookConfiguration) error {
 	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{
 		"grafana.com/inject-rollout-operator-ca": "true",
 		"grafana.com/namespace":                  namespace,
 	}}
 
-	whcs, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{
-		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to list validating webhook configurations: %w", err)
-	}
-	if len(whcs.Items) == 0 {
-		level.Info(logger).Log("msg", "no validating webhook configurations found")
+	if selector, err := metav1.LabelSelectorAsSelector(&labelSelector); err != nil {
+		return err
+	} else if !selector.Matches(labels.Set(wh.GetLabels())) {
 		return nil
 	}
 
-	for _, wh := range whcs.Items {
-		level.Info(logger).Log("msg", "found validating webhook configuration", "name", wh.GetName())
-
-		changed := false
-		for i := range wh.Webhooks {
-			if !bytes.Equal(wh.Webhooks[i].ClientConfig.CABundle, caPEM) {
-				wh.Webhooks[i].ClientConfig.CABundle = caPEM
-				changed = true
-			}
+	changed := false
+	for i := range wh.Webhooks {
+		if !bytes.Equal(wh.Webhooks[i].ClientConfig.CABundle, caPEM) {
+			wh.Webhooks[i].ClientConfig.CABundle = caPEM
+			changed = true
 		}
-		if !changed {
-			level.Info(logger).Log("msg", "validating webhook configuration already has same CA bundle set, not patching", "name", wh.GetName())
-			continue
-		}
-
-		data, err := json.Marshal(wh)
-		if err != nil {
-			return fmt.Errorf("failed to marshal validating webhook configuration: %w", err)
-		}
-
-		res, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Patch(context.Background(), wh.GetName(), types.MergePatchType, data, metav1.PatchOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to patch validating webhook configuration: %w", err)
-		}
-		level.Info(logger).Log("msg", "patched validating webhook configuration with CA bundle", "name", res.GetName())
 	}
 
+	if !changed {
+		level.Info(logger).Log("msg", "validating webhook configuration already has same CA bundle set, not patching", "name", wh.GetName())
+		return nil
+	}
+
+	data, err := json.Marshal(wh)
+	if err != nil {
+		return fmt.Errorf("failed to marshal validating webhook configuration: %w", err)
+	}
+
+	res, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Patch(context.Background(), wh.GetName(), types.MergePatchType, data, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to patch validating webhook configuration: %w", err)
+	}
+	level.Info(logger).Log("msg", "patched validating webhook configuration with CA bundle", "name", res.GetName())
 	return nil
 }
 
@@ -69,49 +61,39 @@ func PatchCABundleOnValidatingWebhooks(ctx context.Context, logger log.Logger, k
 // Webhook configurations should have the following labels:
 // "grafana.com/inject-rollout-operator-ca": "true",
 // "grafana.com/namespace":                  <specified namespace>,
-func PatchCABundleOnMutatingWebhooks(ctx context.Context, logger log.Logger, kubeClient kubernetes.Interface, namespace string, caPEM []byte) error {
+func PatchCABundleOnMutatingWebhooks(logger log.Logger, kubeClient kubernetes.Interface, namespace string, caPEM []byte, wh *v1.MutatingWebhookConfiguration) error {
 	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{
 		"grafana.com/inject-rollout-operator-ca": "true",
 		"grafana.com/namespace":                  namespace,
 	}}
 
-	whcs, err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{
-		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to list mutating webhook configurations: %w", err)
-	}
-	if len(whcs.Items) == 0 {
-		level.Info(logger).Log("msg", "no mutating webhook configurations found")
+	if selector, err := metav1.LabelSelectorAsSelector(&labelSelector); err != nil {
+		return err
+	} else if !selector.Matches(labels.Set(wh.GetLabels())) {
 		return nil
 	}
 
-	for _, wh := range whcs.Items {
-		level.Info(logger).Log("msg", "found mutating webhook configuration", "name", wh.GetName())
-
-		changed := false
-		for i := range wh.Webhooks {
-			if !bytes.Equal(wh.Webhooks[i].ClientConfig.CABundle, caPEM) {
-				wh.Webhooks[i].ClientConfig.CABundle = caPEM
-				changed = true
-			}
+	changed := false
+	for i := range wh.Webhooks {
+		if !bytes.Equal(wh.Webhooks[i].ClientConfig.CABundle, caPEM) {
+			wh.Webhooks[i].ClientConfig.CABundle = caPEM
+			changed = true
 		}
-		if !changed {
-			level.Info(logger).Log("msg", "mutating webhook configuration already has same CA bundle set, not patching", "name", wh.GetName())
-			continue
-		}
-
-		data, err := json.Marshal(wh)
-		if err != nil {
-			return fmt.Errorf("failed to marshal mutating webhook configuration: %w", err)
-		}
-
-		res, err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Patch(ctx, wh.GetName(), types.MergePatchType, data, metav1.PatchOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to patch mutating webhook configuration: %w", err)
-		}
-		level.Info(logger).Log("msg", "patched mutating webhook configuration with CA bundle", "name", res.GetName())
+	}
+	if !changed {
+		level.Info(logger).Log("msg", "mutating webhook configuration already has same CA bundle set, not patching", "name", wh.GetName())
+		return nil
 	}
 
+	data, err := json.Marshal(wh)
+	if err != nil {
+		return fmt.Errorf("failed to marshal mutating webhook configuration: %w", err)
+	}
+
+	res, err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Patch(context.Background(), wh.GetName(), types.MergePatchType, data, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to patch mutating webhook configuration: %w", err)
+	}
+	level.Info(logger).Log("msg", "patched mutating webhook configuration with CA bundle", "name", res.GetName())
 	return nil
 }

--- a/pkg/tlscert/webhookconfig.go
+++ b/pkg/tlscert/webhookconfig.go
@@ -15,11 +15,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// PatchCABundleOnValidatingWebhooks patches the CA bundle of all validating webhook configurations that have the specified labels in the cluster.
+// PatchCABundleOnValidatingWebhook patches the CA bundle of all validating webhook configurations that have the specified labels in the cluster.
 // Webhook configurations should have the following labels:
 // "grafana.com/inject-rollout-operator-ca": "true",
 // "grafana.com/namespace":                  <specified namespace>,
-func PatchCABundleOnValidatingWebhooks(logger log.Logger, kubeClient kubernetes.Interface, namespace string, caPEM []byte, wh *v1.ValidatingWebhookConfiguration) error {
+func PatchCABundleOnValidatingWebhook(logger log.Logger, kubeClient kubernetes.Interface, namespace string, caPEM []byte, wh *v1.ValidatingWebhookConfiguration) error {
 	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{
 		"grafana.com/inject-rollout-operator-ca": "true",
 		"grafana.com/namespace":                  namespace,
@@ -57,11 +57,11 @@ func PatchCABundleOnValidatingWebhooks(logger log.Logger, kubeClient kubernetes.
 	return nil
 }
 
-// PatchCABundleOnMutatingWebhooks patches the CA bundle of all mutating webhook configurations that have the specified labels in the cluster.
+// PatchCABundleOnMutatingWebhook patches the CA bundle of all mutating webhook configurations that have the specified labels in the cluster.
 // Webhook configurations should have the following labels:
 // "grafana.com/inject-rollout-operator-ca": "true",
 // "grafana.com/namespace":                  <specified namespace>,
-func PatchCABundleOnMutatingWebhooks(logger log.Logger, kubeClient kubernetes.Interface, namespace string, caPEM []byte, wh *v1.MutatingWebhookConfiguration) error {
+func PatchCABundleOnMutatingWebhook(logger log.Logger, kubeClient kubernetes.Interface, namespace string, caPEM []byte, wh *v1.MutatingWebhookConfiguration) error {
 	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{
 		"grafana.com/inject-rollout-operator-ca": "true",
 		"grafana.com/namespace":                  namespace,


### PR DESCRIPTION
Modify the rollout-operator to use an informer to monitor for new webhook configurations.

Webhook configurations need to be patched with a self signed CA, and previously this was only checked and applied on rollout-operator startup.

This change allows for new webhooks to be created once the rollout-operator is running and have the CA patch applied.

There is a matching jsonnet update in https://github.com/grafana/mimir/pull/12360

There is a matching r355.libsonnet to enable the additional watch permission in https://github.com/grafana/deployment_tools/pull/321550