### PR TITLE
Support a non-default cluster domain

### DIFF
--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -52,6 +52,7 @@ type config struct {
 	serverPort           int
 	kubeAPIURL           string
 	kubeConfigFile       string
+	kubeClusterDomain    string
 	kubeNamespace        string
 	kubeClientTimeout    time.Duration
 	reconcileInterval    time.Duration
@@ -81,6 +82,7 @@ func (cfg *config) register(fs *flag.FlagSet) {
 	fs.StringVar(&cfg.kubeAPIURL, "kubernetes.api-url", "", "The Kubernetes server API URL. If not specified, it will be auto-detected when running within a Kubernetes cluster.")
 	fs.StringVar(&cfg.kubeConfigFile, "kubernetes.config-file", "", "The Kubernetes config file path. If not specified, it will be auto-detected when running within a Kubernetes cluster.")
 	fs.DurationVar(&cfg.kubeClientTimeout, "kubernetes.client-timeout", 5*time.Minute, "HTTP client timeout. This applies to requests issued to both the Kubernetes API and Kubernetes resource endpoints.")
+	fs.StringVar(&cfg.kubeClusterDomain, "kubernetes.cluster-domain", "cluster.local", "The Kubernetes cluster domain.")
 	fs.StringVar(&cfg.kubeNamespace, "kubernetes.namespace", "", "The Kubernetes namespace for which this operator is running.")
 	fs.DurationVar(&cfg.reconcileInterval, "reconcile.interval", 5*time.Second, "The minimum interval of reconciliation.")
 	cfg.clusterValidationCfg.RegisterFlagsWithPrefix("server.cluster-validation.http.", fs)
@@ -105,14 +107,17 @@ func (cfg *config) register(fs *flag.FlagSet) {
 
 func (cfg config) validate() error {
 	// Validate CLI flags.
+	if cfg.kubeClusterDomain == "" {
+		return errors.New("-kubernetes.cluster-domain can not be an empty string")
+	}
 	if cfg.kubeNamespace == "" {
-		return errors.New("the Kubernetes namespace has not been specified")
+		return errors.New("-kubernetes.namespace has not been specified")
 	}
 	if (cfg.kubeAPIURL == "") != (cfg.kubeConfigFile == "") {
-		return errors.New("either configure both Kubernetes API URL and config file or none of them")
+		return errors.New("either configure both -kubernetes.api-url and -kubernetes.config-file or neither")
 	}
 	if cfg.useZoneTracker && cfg.zoneTrackerConfigMapName == "" {
-		return errors.New("the zone tracker ConfigMap name has not been specified")
+		return errors.New("-use-zone-tracker is true, but -zone-tracker.config-map-name has not been specified")
 	}
 	if err := cfg.clusterValidationCfg.Validate("http", cfg.kubeNamespace); err != nil {
 		return err
@@ -212,7 +217,7 @@ func main() {
 	maybeStartTLSServer(cfg, httpRT, logger, kubeClient, restart, metrics, webhookObserver)
 
 	// Init the controller.
-	c := controller.NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, cfg.kubeNamespace, httpClient, cfg.reconcileInterval, reg, logger)
+	c := controller.NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, cfg.kubeClusterDomain, cfg.kubeNamespace, httpClient, cfg.reconcileInterval, reg, logger)
 	check(errors.Wrap(c.Init(), "failed to init controller"))
 
 	// Listen to sigterm, as well as for restart (like for certificate renewal).
@@ -286,7 +291,7 @@ func maybeStartTLSServer(cfg config, rt http.RoundTripper, logger log.Logger, ku
 	}
 
 	prepDownscaleAdmitFunc := func(ctx context.Context, logger log.Logger, ar v1.AdmissionReview, api *kubernetes.Clientset) *v1.AdmissionResponse {
-		return admission.PrepareDownscale(ctx, rt, logger, ar, api, cfg.useZoneTracker, cfg.zoneTrackerConfigMapName)
+		return admission.PrepareDownscale(ctx, rt, logger, ar, api, cfg.useZoneTracker, cfg.zoneTrackerConfigMapName, cfg.kubeClusterDomain)
 	}
 
 	tlsSrv, err := newTLSServer(cfg, logger, cert, metrics)

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -323,7 +323,7 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 			}, nil
 		})
 
-	admissionResponse := prepareDownscale(ctx, logger, ar, api, f)
+	admissionResponse := prepareDownscale(ctx, logger, ar, api, f, "cluster.local")
 	require.Equal(t, params.allowed, admissionResponse.Allowed, "Unexpected result for allowed: got %v, expected %v", admissionResponse.Allowed, params.allowed)
 
 	if params.stsAnnotated {
@@ -708,6 +708,7 @@ func testPrepDownscaleWebhookWithZoneTracker(t *testing.T, oldReplicas, newRepli
 	oldRawObject, err := statefulSetTemplate(oldParams)
 	require.NoError(t, err)
 
+	clusterDomain := "cluster.local"
 	namespace := "test"
 	stsName := "my-statefulset"
 	ar := admissionv1.AdmissionReview{
@@ -794,7 +795,7 @@ func testPrepDownscaleWebhookWithZoneTracker(t *testing.T, oldReplicas, newRepli
 		}, nil
 	})
 
-	zt := newZoneTracker(api, namespace, "zone-tracker-test-cm")
+	zt := newZoneTracker(api, clusterDomain, namespace, "zone-tracker-test-cm")
 
 	admissionResponse := zt.prepareDownscale(ctx, logger, ar, api, f)
 	require.Equal(t, params.allowed, admissionResponse.Allowed, "Unexpected result for allowed: got %v, expected %v", admissionResponse.Allowed, params.allowed)
@@ -940,13 +941,14 @@ func TestCreateEndpoints(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		oldInfo     *objectInfo
-		newInfo     *objectInfo
-		port        string
-		path        string
-		serviceName string
-		expected    []endpoint
+		name          string
+		oldInfo       *objectInfo
+		newInfo       *objectInfo
+		port          string
+		path          string
+		serviceName   string
+		clusterDomain string
+		expected      []endpoint
 	}{
 		{
 			name: "downscale by 2",
@@ -956,9 +958,10 @@ func TestCreateEndpoints(t *testing.T) {
 			newInfo: &objectInfo{
 				replicas: func() *int32 { i := int32(3); return &i }(),
 			},
-			port:        "8080",
-			path:        "prepare-downscale",
-			serviceName: "service-name",
+			port:          "8080",
+			path:          "prepare-downscale",
+			serviceName:   "service-name",
+			clusterDomain: "cluster.local",
 			expected: []endpoint{
 				{
 					url:   "test-4.service-name.default.svc.cluster.local.:8080/prepare-downscale",
@@ -974,7 +977,7 @@ func TestCreateEndpoints(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := createEndpoints(ar, tt.oldInfo, tt.newInfo, tt.port, tt.path, tt.serviceName)
+			actual := createEndpoints(ar, tt.oldInfo, tt.newInfo, tt.port, tt.path, tt.serviceName, tt.clusterDomain)
 			if len(actual) != len(tt.expected) {
 				t.Errorf("createEndpoints() = %v, want %v", actual, tt.expected)
 				return

--- a/pkg/admission/zone_tracker_test.go
+++ b/pkg/admission/zone_tracker_test.go
@@ -31,7 +31,7 @@ func TestZoneTracker(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
 	// Create a new zoneTracker with the fake client
-	zt := newZoneTracker(client, "testnamespace", "testconfigmap")
+	zt := newZoneTracker(client, "cluster.local", "testnamespace", "testconfigmap")
 
 	zones := []string{"testzone", "testzone2", "testzone3"}
 	stsList := &appsv1.StatefulSetList{
@@ -97,7 +97,7 @@ func TestZoneTrackerFindDownscalesDoneMinTimeAgo(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
 	// Create a new zoneTracker with the fake client
-	zt := newZoneTracker(client, "testnamespace", "testconfigmap")
+	zt := newZoneTracker(client, "cluster.local", "testnamespace", "testconfigmap")
 
 	stsList := &appsv1.StatefulSetList{
 		Items: []appsv1.StatefulSet{
@@ -148,7 +148,7 @@ func TestLoadZonesCreatesInitialZones(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
 	// Create a new zoneTracker with the fake client
-	zt := newZoneTracker(client, "testnamespace", "testconfigmap")
+	zt := newZoneTracker(client, "cluster.local", "testnamespace", "testconfigmap")
 
 	stsList := &appsv1.StatefulSetList{
 		Items: []appsv1.StatefulSet{
@@ -203,7 +203,7 @@ func TestLoadZonesEmptyConfigMap(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
 	// Create a new zoneTracker with the fake client
-	zt := newZoneTracker(client, "testnamespace", "testconfigmap")
+	zt := newZoneTracker(client, "cluster.local", "testnamespace", "testconfigmap")
 
 	stsList := &appsv1.StatefulSetList{}
 
@@ -238,7 +238,7 @@ func TestSetDownscaled(t *testing.T) {
 	}
 
 	// Create a new zoneTracker with the fake client
-	zt := newZoneTracker(client, "testnamespace", "testconfigmap")
+	zt := newZoneTracker(client, "cluster.local", "testnamespace", "testconfigmap")
 
 	// Test when zone does not exist in the map
 	zone := "nonexistentzone"
@@ -287,7 +287,7 @@ func TestLastDownscaledNonExistentZone(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
 	// Create a new zoneTracker with the fake client
-	zt := newZoneTracker(client, "testnamespace", "testconfigmap")
+	zt := newZoneTracker(client, "cluster.local", "testnamespace", "testconfigmap")
 
 	time, _ := zt.lastDownscaled("nonexistentzone")
 	fmt.Printf("time: %v\n", time)
@@ -322,6 +322,7 @@ func TestZoneTrackerConcurrentDownscale(t *testing.T) {
 	rolloutGroupIndexGateway := "index-gateway"
 	indexGatewayZoneA := "index-gateway-zone-a"
 
+	clusterDomain := "cluster.local"
 	namespace := "test"
 	dryRun := false
 	buildAdmissionRequest := func(rolloutGroup string, stsName string) admissionv1.AdmissionReview {
@@ -378,7 +379,7 @@ func TestZoneTrackerConcurrentDownscale(t *testing.T) {
 
 	api := fake.NewSimpleClientset()
 
-	zt := newZoneTracker(api, namespace, "testconfigmap")
+	zt := newZoneTracker(api, clusterDomain, namespace, "testconfigmap")
 
 	// block the ingester-zone-a downscale request for rollout group ingester
 	ingesterZoneAPrepDownscaleDone := make(chan struct{})

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -48,6 +48,7 @@ type httpClient interface {
 
 type RolloutController struct {
 	kubeClient           kubernetes.Interface
+	clusterDomain        string
 	namespace            string
 	reconcileInterval    time.Duration
 	statefulSetsFactory  informers.SharedInformerFactory
@@ -79,7 +80,7 @@ type RolloutController struct {
 	discoveredGroups map[string]struct{}
 }
 
-func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTMapper, scaleClient scale.ScalesGetter, dynamic dynamic.Interface, namespace string, client httpClient, reconcileInterval time.Duration, reg prometheus.Registerer, logger log.Logger) *RolloutController {
+func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTMapper, scaleClient scale.ScalesGetter, dynamic dynamic.Interface, clusterDomain string, namespace string, client httpClient, reconcileInterval time.Duration, reg prometheus.Registerer, logger log.Logger) *RolloutController {
 	namespaceOpt := informers.WithNamespace(namespace)
 
 	// Initialise the StatefulSet informer to restrict the returned StatefulSets to only the ones
@@ -96,6 +97,7 @@ func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTM
 
 	c := &RolloutController{
 		kubeClient:           kubeClient,
+		clusterDomain:        clusterDomain,
 		namespace:            namespace,
 		reconcileInterval:    reconcileInterval,
 		statefulSetsFactory:  statefulSetsFactory,
@@ -376,7 +378,7 @@ func (c *RolloutController) adjustStatefulSetsGroupReplicas(ctx context.Context,
 		return updated, err
 	}
 
-	return c.adjustStatefulSetsGroupReplicasToMirrorResource(ctx, groupName, sets, c.httpClient)
+	return c.adjustStatefulSetsGroupReplicasToMirrorResource(ctx, groupName, sets, c.clusterDomain, c.httpClient)
 }
 
 // adjustStatefulSetsGroupReplicasToFollowLeader examines each StatefulSet and adjusts the number of replicas if desired,

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 const (
+	testClusterDomain    = "cluster.local"
 	testNamespace        = "test"
 	testMaxUnavailable   = 2
 	testPrevRevisionHash = "prev-hash"
@@ -616,7 +617,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 
 			// Create the controller and start informers.
 			reg := prometheus.NewPedanticRegistry()
-			c := NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger())
+			c := NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, testClusterDomain, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger())
 			require.NoError(t, c.Init())
 			defer c.Stop()
 
@@ -925,7 +926,7 @@ func TestRolloutController_ReconcileStatefulsetWithDownscaleDelay(t *testing.T) 
 
 			// Create the controller and start informers.
 			reg := prometheus.NewPedanticRegistry()
-			c := NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, testNamespace, httpClient, 5*time.Second, reg, log.NewNopLogger())
+			c := NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, testClusterDomain, testNamespace, httpClient, 5*time.Second, reg, log.NewNopLogger())
 			require.NoError(t, c.Init())
 			defer c.Stop()
 
@@ -1028,7 +1029,7 @@ func TestRolloutController_ReconcileShouldDeleteMetricsForDecommissionedRolloutG
 
 	// Create the controller and start informers.
 	reg := prometheus.NewPedanticRegistry()
-	c := NewRolloutController(kubeClient, nil, nil, nil, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger())
+	c := NewRolloutController(kubeClient, nil, nil, nil, testClusterDomain, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger())
 	require.NoError(t, c.Init())
 	defer c.Stop()
 

--- a/pkg/controller/delay.go
+++ b/pkg/controller/delay.go
@@ -21,7 +21,7 @@ import (
 	"github.com/grafana/rollout-operator/pkg/util"
 )
 
-func cancelDelayedDownscaleIfConfigured(ctx context.Context, logger log.Logger, sts *v1.StatefulSet, httpClient httpClient, replicas int32) {
+func cancelDelayedDownscaleIfConfigured(ctx context.Context, logger log.Logger, sts *v1.StatefulSet, clusterDomain string, httpClient httpClient, replicas int32) {
 	delay, prepareURL, err := parseDelayedDownscaleAnnotations(sts.GetAnnotations())
 	if delay == 0 || prepareURL == nil {
 		return
@@ -32,7 +32,7 @@ func cancelDelayedDownscaleIfConfigured(ctx context.Context, logger log.Logger, 
 		return
 	}
 
-	endpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), sts.Spec.ServiceName, 0, int(replicas), prepareURL)
+	endpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), sts.Spec.ServiceName, clusterDomain, 0, int(replicas), prepareURL)
 
 	callCancelDelayedDownscale(ctx, logger, httpClient, endpoints)
 }
@@ -40,7 +40,7 @@ func cancelDelayedDownscaleIfConfigured(ctx context.Context, logger log.Logger, 
 // Checks if downscale delay has been reached on replicas in [desiredReplicas, currentReplicas) range.
 // If there is a range of replicas at the end of statefulset for which delay has been reached, this function
 // returns updated desired replicas that statefulset can be scaled to.
-func checkScalingDelay(ctx context.Context, logger log.Logger, sts *v1.StatefulSet, httpClient httpClient, currentReplicas, desiredReplicas int32) (updatedDesiredReplicas int32, _ error) {
+func checkScalingDelay(ctx context.Context, logger log.Logger, sts *v1.StatefulSet, clusterDomain string, httpClient httpClient, currentReplicas, desiredReplicas int32) (updatedDesiredReplicas int32, _ error) {
 	if currentReplicas == desiredReplicas {
 		// should not happen
 		return currentReplicas, nil
@@ -55,19 +55,19 @@ func checkScalingDelay(ctx context.Context, logger log.Logger, sts *v1.StatefulS
 	}
 
 	if desiredReplicas >= currentReplicas {
-		callCancelDelayedDownscale(ctx, logger, httpClient, createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), sts.Spec.ServiceName, 0, int(currentReplicas), prepareURL))
+		callCancelDelayedDownscale(ctx, logger, httpClient, createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), sts.Spec.ServiceName, clusterDomain, 0, int(currentReplicas), prepareURL))
 		// Proceed even if calling cancel of delayed downscale fails. We call cancellation repeatedly, so it will happen during next reconcile.
 		return desiredReplicas, nil
 	}
 
 	{
 		// Replicas in [0, desired) interval should cancel any delayed downscale, if they have any.
-		cancelEndpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), sts.Spec.ServiceName, 0, int(desiredReplicas), prepareURL)
+		cancelEndpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), sts.Spec.ServiceName, clusterDomain, 0, int(desiredReplicas), prepareURL)
 		callCancelDelayedDownscale(ctx, logger, httpClient, cancelEndpoints)
 	}
 
 	// Replicas in [desired, current) interval are going to be stopped.
-	downscaleEndpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), sts.Spec.ServiceName, int(desiredReplicas), int(currentReplicas), prepareURL)
+	downscaleEndpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), sts.Spec.ServiceName, clusterDomain, int(desiredReplicas), int(currentReplicas), prepareURL)
 	elapsedTimeSinceDownscaleInitiated, err := callPrepareDownscaleAndReturnElapsedDurationsSinceInitiatedDownscale(ctx, logger, httpClient, downscaleEndpoints)
 	if err != nil {
 		return currentReplicas, fmt.Errorf("failed prepare pods for delayed downscale: %v", err)
@@ -132,7 +132,7 @@ type endpoint struct {
 }
 
 // Create prepare-downscale endpoints for pods with index in [from, to) range. URL is fully reused except for host, which is replaced with pod's FQDN.
-func createPrepareDownscaleEndpoints(namespace, statefulSetName, serviceName string, from, to int, url *url.URL) []endpoint {
+func createPrepareDownscaleEndpoints(namespace, statefulSetName, serviceName, clusterDomain string, from, to int, url *url.URL) []endpoint {
 	eps := make([]endpoint, 0, to-from)
 
 	for index := from; index < to; index++ {
@@ -143,7 +143,7 @@ func createPrepareDownscaleEndpoints(namespace, statefulSetName, serviceName str
 		}
 
 		ep.url = *url
-		newHost := util.StatefulSetPodFQDN(namespace, statefulSetName, index, serviceName)
+		newHost := util.StatefulSetPodFQDN(namespace, statefulSetName, index, serviceName, clusterDomain)
 		if url.Port() != "" {
 			newHost = fmt.Sprintf("%s:%s", newHost, url.Port())
 		}

--- a/pkg/controller/delay_test.go
+++ b/pkg/controller/delay_test.go
@@ -14,6 +14,7 @@ func TestCreatePrepareDownscaleEndpoints(t *testing.T) {
 		namespace       string
 		statefulSetName string
 		serviceName     string
+		clusterDomain   string
 		from            int
 		to              int
 		inputURL        string
@@ -24,6 +25,7 @@ func TestCreatePrepareDownscaleEndpoints(t *testing.T) {
 			namespace:       "test-namespace",
 			statefulSetName: "test-statefulset",
 			serviceName:     "test-service",
+			clusterDomain:   "cluster.local",
 			from:            0,
 			to:              2,
 			inputURL:        "http://example.com/api/prepare",
@@ -47,6 +49,7 @@ func TestCreatePrepareDownscaleEndpoints(t *testing.T) {
 			namespace:       "prod-namespace",
 			statefulSetName: "prod-statefulset",
 			serviceName:     "prod-service",
+			clusterDomain:   "cluster.local",
 			from:            1,
 			to:              3,
 			inputURL:        "http://example.com:8080/api/prepare",
@@ -72,7 +75,7 @@ func TestCreatePrepareDownscaleEndpoints(t *testing.T) {
 			inputURL, err := url.Parse(tc.inputURL)
 			require.NoError(t, err)
 
-			result := createPrepareDownscaleEndpoints(tc.namespace, tc.statefulSetName, tc.serviceName, tc.from, tc.to, inputURL)
+			result := createPrepareDownscaleEndpoints(tc.namespace, tc.statefulSetName, tc.serviceName, tc.clusterDomain, tc.from, tc.to, inputURL)
 
 			assert.Equal(t, tc.expected, result)
 		})

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -104,17 +104,18 @@ func Now() *metav1.Time {
 	return &ts
 }
 
-func StatefulSetPodFQDN(namespace, statefulSetName string, ordinal int, serviceName string) string {
+func StatefulSetPodFQDN(namespace, statefulSetName string, ordinal int, serviceName, clusterDomain string) string {
 	// The DNS entry for a pod of a stateful set is
-	// $(statefulset name)-(ordinal).$(service name).$(namespace).svc.cluster.local
+	// $(statefulset name)-(ordinal).$(service name).$(namespace).svc.$(cluster domain)
 	// https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id
 	//
 	// Ending that with a trailing "." to signify an absolute domain name
 	// https://datatracker.ietf.org/doc/html/rfc1034#section-3.1
-	return fmt.Sprintf("%v-%v.%v.%v.svc.cluster.local.",
+	return fmt.Sprintf("%v-%v.%v.%v.svc.%s.",
 		statefulSetName,
 		ordinal,
 		serviceName,
 		namespace,
+		clusterDomain,
 	)
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -194,3 +194,8 @@ func TestMin(t *testing.T) {
 	assert.Equal(t, 1, min(1))
 	assert.Equal(t, 3, min(4, 3, 5))
 }
+
+func TestStatefulSetPodFQDN(t *testing.T) {
+	assert.Equal(t, "statefulset-1.service.namespace.svc.cluster.local.", StatefulSetPodFQDN("namespace", "statefulset", 1, "service", "cluster.local"))
+	assert.Equal(t, "sts-0.example-service.ns.svc.cluster.example.", StatefulSetPodFQDN("ns", "sts", 0, "example-service", "cluster.example"))
+}


### PR DESCRIPTION
Fixes https://github.com/grafana/rollout-operator/issues/261

When building the endpoints for StatefulSet pods, the cluster domain was always assumed to be `cluster.local`. This change makes the cluster domain configurable (with a default of `cluster.local`) and does the required plumbing to get the configured value to where it used.

Opening in draft because I'd rather wait on this until after the next release is cut.
