### PR TITLE
Fix issues building multi-platform images in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,10 @@ jobs:
           cache: false
       - name: Log in to Docker Hub
         uses: grafana/shared-workflows/actions/dockerhub-login@c6d954f7cd9c0022018982e01268de6cb75b913c # dockerhub-login/v1.0.2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Generate image tag
         id: image_tag
         run: |


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/grafana/rollout-operator/pull/269 where Docker image builds fail because the runner is not configured for multi-platform image builds ([example](https://github.com/grafana/rollout-operator/actions/runs/17055089992/job/48351399908)).