### PR TITLE
renovate: group github action updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,6 +19,11 @@
              "groupName": "go dependencies"
          },
          {
+             "description": "Group all github action dependencies together to reduce noise",
+             "matchManagers": ["github-actions"],
+             "groupName": "github actions"
+         },
+         {
              "description": "Disable Docker updates",
              "matchManagers": ["dockerfile"],
              "enabled": false


### PR DESCRIPTION
Every Monday in this repository renovate automatically opens PRs for updates, but currently it opens a PR for each github action individually. I'd like to group them like Go dependencies are to reduce PR noise.

The manager used for the match is documented here: https://docs.renovatebot.com/modules/manager/github-actions/