### PR TITLE
Fix issue where publishing GitHub release for tags fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,3 +128,4 @@ jobs:
         run: make release-notes | gh release create "$IMAGE_TAG" --notes-file -
         env:
           IMAGE_TAG: ${{ steps.image_tag.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Fixes https://github.com/grafana/rollout-operator/issues/276