### PR TITLE
Only automatically build images for pushed tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
       - integration
       - integration-boringcrypto
       - lint
-    if: github.event_name == 'push' # We want this job to run for both pushes to main, as well as new tags.
+    if: github.event_name == 'push' && github.ref_type == 'tag' # Only run for tag pushes
     permissions:
       contents: write # Needed to be able to create releases.
       id-token: write


### PR DESCRIPTION
Image builds in CI are taking 50m+ each on every commit to `main`. This happens even for changes that don't touch the code like github action updates. It would be nice to make the image builds faster, but for now I think restricting the image builds to tag pushes makes sense. If someone needs an image between releases they can still build one manually.