### PR TITLE
Re-order the rollout-operator role rules

### DIFF
--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -124,19 +124,19 @@ rules:
 - apiGroups:
   - rollout-operator.grafana.com
   resources:
-  - zoneawarepoddisruptionbudgets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - rollout-operator.grafana.com
-  resources:
   - replicatemplates/scale
   - replicatemplates/status
   verbs:
   - get
   - patch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -193,19 +193,19 @@ rules:
 - apiGroups:
   - rollout-operator.grafana.com
   resources:
-  - zoneawarepoddisruptionbudgets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - rollout-operator.grafana.com
-  resources:
   - replicatemplates/scale
   - replicatemplates/status
   verbs:
   - get
   - patch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/operations/rollout-operator/rollout-operator.libsonnet
+++ b/operations/rollout-operator/rollout-operator.libsonnet
@@ -134,18 +134,18 @@
         policyRule.withApiGroups('') +
         policyRule.withResources(['configmaps']) +
         policyRule.withVerbs(['get', 'update', 'create']),
-      ] + (
-        if enableWebhooks then [
-          policyRule.withApiGroups($.zpdb_template.spec.group) +
-          policyRule.withResources([$.zpdb_template.spec.names.plural]) +
-          policyRule.withVerbs(['get', 'list', 'watch']),
-        ] else []
-      ) +
+      ] +
       (
         if $._config.rollout_operator_replica_template_access_enabled then [
           policyRule.withApiGroups($.replica_template.spec.group) +
           policyRule.withResources(['%s/scale' % $.replica_template.spec.names.plural, '%s/status' % $.replica_template.spec.names.plural]) +
           policyRule.withVerbs(['get', 'patch']),
+        ] else []
+      ) + (
+        if enableWebhooks then [
+          policyRule.withApiGroups($.zpdb_template.spec.group) +
+          policyRule.withResources([$.zpdb_template.spec.names.plural]) +
+          policyRule.withVerbs(['get', 'list', 'watch']),
         ] else []
       )
     ),


### PR DESCRIPTION
This PR changes the ordering of some rules in the rollout-operator role manifest.

As this new rollout-operator jsonnet is vendored into other repositories, this ordering is resulting in no-op differences in the generated manifests.

This PR changes the ordering to avoid these differences.