### PR TITLE
Add dashboard links option and fix dashboard_title config

### DIFF
--- a/operations/rollout-operator-mixin-compiled/dashboards/rollout-operator.json
+++ b/operations/rollout-operator-mixin-compiled/dashboards/rollout-operator.json
@@ -1335,7 +1335,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Rollout operator",
+      "title": "rollout-operator",
       "uid": "f40e8042a6be71a98444a29b2c4e9421",
       "version": 0
    }

--- a/operations/rollout-operator-mixin/config.libsonnet
+++ b/operations/rollout-operator-mixin/config.libsonnet
@@ -13,7 +13,7 @@
 
     // the name for the rollout-operator. This is also used as the container name
     rollout_operator_name: 'rollout-operator',
-    rollout_operator_dashboard_title: 'Rollout operator',
+    rollout_operator_dashboard_title: 'rollout-operator',
     rollout_operator_dashboard_links: [],
     rollout_operator_container_name: $._config.rollout_operator_name,
     rollout_operator_instance_matcher:

--- a/operations/rollout-operator-mixin/config.libsonnet
+++ b/operations/rollout-operator-mixin/config.libsonnet
@@ -13,7 +13,8 @@
 
     // the name for the rollout-operator. This is also used as the container name
     rollout_operator_name: 'rollout-operator',
-    rollout_operator_dashoard_title: 'Rollout operator',
+    rollout_operator_dashboard_title: 'Rollout operator',
+    rollout_operator_dashboard_links: [],
     rollout_operator_container_name: $._config.rollout_operator_name,
     rollout_operator_instance_matcher:
       if $._config.helm == '' then $._config.rollout_operator_container_name + '.*' else '(.*%g-)?%g.*' % [$._config.helm, $._config.rollout_operator_container_name],

--- a/operations/rollout-operator-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/rollout-operator-mixin/dashboards/dashboard-utils.libsonnet
@@ -51,6 +51,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       addClusterSelectorTemplates()::
         local d = self {
           tags: $._config.tags,
+          links: std.get($._config, 'rollout_operator_dashboard_links', []),
         };
 
         d

--- a/operations/rollout-operator-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/rollout-operator-mixin/dashboards/dashboard-utils.libsonnet
@@ -51,7 +51,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       addClusterSelectorTemplates()::
         local d = self {
           tags: $._config.tags,
-          links: std.get($._config, 'rollout_operator_dashboard_links', []),
+          links: $._config.rollout_operator_dashboard_links,
         };
 
         d

--- a/operations/rollout-operator-mixin/dashboards/rollout-operator.libsonnet
+++ b/operations/rollout-operator-mixin/dashboards/rollout-operator.libsonnet
@@ -10,7 +10,7 @@ function(cfg)
 
     [filename]:
       assert cfg.rollout_operator_dashboard_uid == '' || std.md5(filename) == cfg.rollout_operator_dashboard_uid : 'UID of the dashboard has changed, please update references to dashboard. filename is now ' + filename + '. Set rollout_operator_dashboard_uid=' + std.md5(filename);
-      (utils.dashboard(cfg.rollout_operator_dashoard_title) + { uid: std.md5(filename) })
+      (utils.dashboard(cfg.rollout_operator_dashboard_title) + { uid: std.md5(filename) })
       .addClusterSelectorTemplates()
       .addRow(
         utils.row('Incoming webhook requests')


### PR DESCRIPTION
This PR introduces a configuration option to pass in dashboard links for use on the rollout-operator dashboard.

This will allow those vendoring in this dashboard to include their custom links.

This PR also addresses a typo in the dashboard title name. Note that this will be used by https://github.com/grafana/deployment_tools/pull/349215 and https://github.com/grafana/mimir/pull/12688, so it can be safely changed at this time.