### PR TITLE
Fix SPDX license on recently moved files

### DIFF
--- a/integration/jsonnet-integration/build.sh
+++ b/integration/jsonnet-integration/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: AGPL-3.0-only
+# SPDX-License-Identifier: Apache-2.0
 
 usage() {
   echo "Usage: $0 <test_name>"

--- a/operations/rollout-operator-mixin-tools/serve/run.sh
+++ b/operations/rollout-operator-mixin-tools/serve/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: AGPL-3.0-only
+# SPDX-License-Identifier: Apache-2.0
 
 set -e
 

--- a/operations/rollout-operator-tests/build.sh
+++ b/operations/rollout-operator-tests/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: AGPL-3.0-only
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 

--- a/operations/rollout-operator-tests/run-conftest.sh
+++ b/operations/rollout-operator-tests/run-conftest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-License-Identifier: AGPL-3.0-only
+# SPDX-License-Identifier: Apache-2.0
 
 set -e
 set -o errexit

--- a/tools/find-diff-or-untracked.sh
+++ b/tools/find-diff-or-untracked.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: AGPL-3.0-only
+# SPDX-License-Identifier: Apache-2.0
 
 set -eu -o pipefail
 


### PR DESCRIPTION
The license in this repository is Apache 2.0. Some files are being moved from the Mimir repository (like in #282 and #288), but the SPDX licenses weren't updated from AGPL 3.0.

SPDX isn't used in this repository elsewhere where it likely should be. I can take a look at that separately.