### PR TITLE
Prep release of v0.31.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+## v0.31.1
+
 * [ENHANCEMENT] Updated dependencies, including: #314, #315
   * `github.com/prometheus/common` from `v0.66.1` to `v0.67.1`
   * `sigs.k8s.io/controller-runtime` from `v0.22.0` to `v0.22.3`

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -290,7 +290,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.31.0
+        image: grafana/rollout-operator:v0.31.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -83,7 +83,7 @@ spec:
         - -kubernetes.namespace=default
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.31.0
+        image: grafana/rollout-operator:v0.31.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -290,7 +290,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.31.0
+        image: grafana/rollout-operator:v0.31.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -229,7 +229,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.31.0
+        image: grafana/rollout-operator:v0.31.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -298,7 +298,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.31.0
+        image: grafana/rollout-operator:v0.31.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -221,7 +221,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.31.0
+        image: grafana/rollout-operator:v0.31.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -221,7 +221,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.31.0
+        image: grafana/rollout-operator:v0.31.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -221,7 +221,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.31.0
+        image: grafana/rollout-operator:v0.31.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -221,7 +221,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.31.0
+        image: grafana/rollout-operator:v0.31.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -221,7 +221,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.31.0
+        image: grafana/rollout-operator:v0.31.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator/images.libsonnet
+++ b/operations/rollout-operator/images.libsonnet
@@ -1,5 +1,5 @@
 {
   _images+:: {
-    rollout_operator: 'grafana/rollout-operator:v0.31.0',
+    rollout_operator: 'grafana/rollout-operator:v0.31.1',
   },
 }


### PR DESCRIPTION
v0.31.1 includes both dependency updates, but also includes https://github.com/grafana/rollout-operator/pull/317 with a fix for flakey integration tests. 