### PR TITLE
Fix missing boringcrypto images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,6 +199,7 @@ jobs:
             make publish-standard-image
           fi
         env:
+          REF_TYPE: ${{ github.ref_type }}
           IMAGE_TAG: ${{ steps.image_tag.outputs.tag }}
       - name: Publish release
         if: github.ref_type == 'tag'


### PR DESCRIPTION
`REF_TYPE` is checked in `if [[ "$REF_TYPE" == "tag" ]]; then`, but wasn't being defined. This bug was introduced by me in https://github.com/grafana/rollout-operator/pull/279