### PR TITLE
dashboards: add native histograms toggle; adjust queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main / unreleased
 
+* [ENHANCEMENT] Dashboard: Support native histograms. #338 
 * [ENHANCEMENT] Updated dependencies, including: #329 #335
   * `github.com/prometheus/common` from `v0.67.1` to `v0.67.3`
   * `golang.org/x/sync` from `v0.17.0` to `v0.18.0`

--- a/operations/rollout-operator-mixin-compiled/dashboards/rollout-operator.json
+++ b/operations/rollout-operator-mixin-compiled/dashboards/rollout-operator.json
@@ -214,7 +214,13 @@
                   "stack": true,
                   "targets": [
                      {
-                        "expr": "sum by (status) (\n  label_replace(label_replace(rate(rollout_operator_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval]),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z]+)\"))\n",
+                        "expr": "(sum by (status) (\n  label_replace(label_replace(rate(rollout_operator_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval]),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z_]+)\"))\n) and on() (vector($latency_metrics) == 1)",
+                        "format": "time_series",
+                        "legendFormat": "{{status}}",
+                        "refId": "A_classic"
+                     },
+                     {
+                        "expr": "(sum by (status) (\n  label_replace(label_replace(histogram_count(rate(rollout_operator_request_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval])),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z_]+)\"))\n) and on() (vector($latency_metrics) == -1)",
                         "format": "time_series",
                         "legendFormat": "{{status}}",
                         "refId": "A"
@@ -262,7 +268,13 @@
                   "span": 3,
                   "targets": [
                      {
-                        "expr": "sum by (route) (rate(rollout_operator_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval]))",
+                        "expr": "(sum by (route) (rate(rollout_operator_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval]))) and on() (vector($latency_metrics) == 1)",
+                        "format": "time_series",
+                        "legendFormat": "__auto",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "(sum by (route) (histogram_count(rate(rollout_operator_request_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
                         "format": "time_series",
                         "legendFormat": "__auto",
                         "legendLink": null
@@ -277,7 +289,7 @@
                      "defaults": {
                         "custom": {
                            "drawStyle": "line",
-                           "fillOpacity": 1,
+                           "fillOpacity": 10,
                            "lineWidth": 1,
                            "pointSize": 5,
                            "showPoints": "never",
@@ -311,22 +323,40 @@
                   "span": 3,
                   "targets": [
                      {
-                        "expr": "histogram_quantile(0.99, sum(rate(rollout_operator_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval])) by (le)) * 1e3",
+                        "expr": "(histogram_quantile(0.99, sum (rate(rollout_operator_request_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval]))) * 1e3) and on() (vector($latency_metrics) == -1)",
                         "format": "time_series",
-                        "legendFormat": "99th Percentile",
+                        "legendFormat": "99th percentile",
                         "refId": "A"
                      },
                      {
-                        "expr": "histogram_quantile(0.50, sum(rate(rollout_operator_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval])) by (le)) * 1e3",
+                        "expr": "(histogram_quantile(0.99, sum by (le) (rate(rollout_operator_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval]))) * 1e3) and on() (vector($latency_metrics) == 1)",
                         "format": "time_series",
-                        "legendFormat": "50th Percentile",
+                        "legendFormat": "99th percentile",
+                        "refId": "A_classic"
+                     },
+                     {
+                        "expr": "(histogram_quantile(0.50, sum (rate(rollout_operator_request_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval]))) * 1e3) and on() (vector($latency_metrics) == -1)",
+                        "format": "time_series",
+                        "legendFormat": "50th percentile",
                         "refId": "B"
                      },
                      {
-                        "expr": "sum(rate(rollout_operator_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval])) * 1e3 / sum(rate(rollout_operator_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval]))",
+                        "expr": "(histogram_quantile(0.50, sum by (le) (rate(rollout_operator_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval]))) * 1e3) and on() (vector($latency_metrics) == 1)",
+                        "format": "time_series",
+                        "legendFormat": "50th percentile",
+                        "refId": "B_classic"
+                     },
+                     {
+                        "expr": "(1e3 * sum(histogram_sum(rate(rollout_operator_request_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval]))) /\nsum(histogram_count(rate(rollout_operator_request_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval])))\n) and on() (vector($latency_metrics) == -1)",
                         "format": "time_series",
                         "legendFormat": "Average",
                         "refId": "C"
+                     },
+                     {
+                        "expr": "(1e3 * sum(rate(rollout_operator_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval])) /\nsum(rate(rollout_operator_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval]))\n) and on() (vector($latency_metrics) == 1)",
+                        "format": "time_series",
+                        "legendFormat": "Average",
+                        "refId": "C_classic"
                      }
                   ],
                   "title": "Latency (all webhooks)",
@@ -389,7 +419,13 @@
                   "span": 3,
                   "targets": [
                      {
-                        "expr": "histogram_quantile(0.99, sum by (le, route) (rate(rollout_operator_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval]))) * 1e3",
+                        "expr": "(histogram_quantile(0.99, sum by (le,route) (rate(rollout_operator_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval]))) * 1e3) and on() (vector($latency_metrics) == 1)",
+                        "format": "time_series",
+                        "legendFormat": "__auto",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "(histogram_quantile(0.99, sum by (route) (rate(rollout_operator_request_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\", route=~\"admission.*\"}[$__rate_interval]))) * 1e3) and on() (vector($latency_metrics) == -1)",
                         "format": "time_series",
                         "legendFormat": "__auto",
                         "legendLink": null
@@ -546,7 +582,13 @@
                   "span": 3,
                   "targets": [
                      {
-                        "expr": "1e3 * sum by (namespace, rollout_group) (rate(rollout_operator_group_reconcile_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval])) / sum by (namespace, rollout_group) (rate(rollout_operator_group_reconcile_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval]))",
+                        "expr": "(1e3 * sum by (namespace, rollout_group) (rate(rollout_operator_group_reconcile_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval])) /\nsum by (namespace, rollout_group) (rate(rollout_operator_group_reconcile_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval]))\n) and on() (vector($latency_metrics) == 1)",
+                        "format": "time_series",
+                        "legendFormat": "{{namespace}}/{{rollout_group}}",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "(1e3 * sum by (namespace, rollout_group) (histogram_sum(rate(rollout_operator_group_reconcile_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval]))) /\nsum by (namespace, rollout_group) (histogram_count(rate(rollout_operator_group_reconcile_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval])))\n) and on() (vector($latency_metrics) == -1)",
                         "format": "time_series",
                         "legendFormat": "{{namespace}}/{{rollout_group}}",
                         "legendLink": null
@@ -808,7 +850,13 @@
                   "stack": true,
                   "targets": [
                      {
-                        "expr": "sum by (status) (\n  label_replace(label_replace(rate(rollout_operator_kubernetes_api_client_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval]),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z]+)\"))\n",
+                        "expr": "(sum by (status) (\n  label_replace(label_replace(rate(rollout_operator_kubernetes_api_client_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval]),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z_]+)\"))\n) and on() (vector($latency_metrics) == 1)",
+                        "format": "time_series",
+                        "legendFormat": "{{status}}",
+                        "refId": "A_classic"
+                     },
+                     {
+                        "expr": "(sum by (status) (\n  label_replace(label_replace(histogram_count(rate(rollout_operator_kubernetes_api_client_request_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval])),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z_]+)\"))\n) and on() (vector($latency_metrics) == -1)",
                         "format": "time_series",
                         "legendFormat": "{{status}}",
                         "refId": "A"
@@ -856,7 +904,13 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by (method, path) (rate(rollout_operator_kubernetes_api_client_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval]))",
+                        "expr": "(sum by (method, path) (rate(rollout_operator_kubernetes_api_client_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval]))) and on() (vector($latency_metrics) == 1)",
+                        "format": "time_series",
+                        "legendFormat": "{{method}} {{path}}",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "(sum by (method, path) (histogram_count(rate(rollout_operator_kubernetes_api_client_request_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
                         "format": "time_series",
                         "legendFormat": "{{method}} {{path}}",
                         "legendLink": null
@@ -930,13 +984,25 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by (method, path) (rate(rollout_operator_kubernetes_api_client_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval])) / sum by (method, path) (rate(rollout_operator_kubernetes_api_client_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval])) * 1e3",
+                        "expr": "(1e3 * sum by (method, path) (rate(rollout_operator_kubernetes_api_client_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval])) /\nsum by (method, path) (rate(rollout_operator_kubernetes_api_client_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval]))\n) and on() (vector($latency_metrics) == 1)",
                         "format": "time_series",
                         "legendFormat": "{{method}} {{path}}",
                         "legendLink": null
                      },
                      {
-                        "expr": "sum(rate(rollout_operator_kubernetes_api_client_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval])) / sum(rate(rollout_operator_kubernetes_api_client_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval])) * 1e3",
+                        "expr": "(1e3 * sum by (method, path) (histogram_sum(rate(rollout_operator_kubernetes_api_client_request_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval]))) /\nsum by (method, path) (histogram_count(rate(rollout_operator_kubernetes_api_client_request_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval])))\n) and on() (vector($latency_metrics) == -1)",
+                        "format": "time_series",
+                        "legendFormat": "{{method}} {{path}}",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "(1e3 * sum(rate(rollout_operator_kubernetes_api_client_request_duration_seconds_sum{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval])) /\nsum(rate(rollout_operator_kubernetes_api_client_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval]))\n) and on() (vector($latency_metrics) == 1)",
+                        "format": "time_series",
+                        "legendFormat": "All routes",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "(1e3 * sum(histogram_sum(rate(rollout_operator_kubernetes_api_client_request_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval]))) /\nsum(histogram_count(rate(rollout_operator_kubernetes_api_client_request_duration_seconds{cluster=~\"$cluster\", job=~\"($namespace)/(rollout-operator)\"}[$__rate_interval])))\n) and on() (vector($latency_metrics) == -1)",
                         "format": "time_series",
                         "legendFormat": "All routes",
                         "legendLink": null
@@ -1301,6 +1367,35 @@
                "tags": [ ],
                "tagsQuery": "",
                "type": "query",
+               "useTags": false
+            },
+            {
+               "current": {
+                  "selected": true,
+                  "text": "classic",
+                  "value": "1"
+               },
+               "description": "Choose between showing latencies based on low precision classic or high precision native histogram metrics.",
+               "hide": 0,
+               "includeAll": false,
+               "label": "Latency metrics",
+               "multi": false,
+               "name": "latency_metrics",
+               "options": [
+                  {
+                     "selected": false,
+                     "text": "native",
+                     "value": "-1"
+                  },
+                  {
+                     "selected": true,
+                     "text": "classic",
+                     "value": "1"
+                  }
+               ],
+               "query": "native : -1,classic : 1",
+               "skipUrlSync": false,
+               "type": "custom",
                "useTags": false
             }
          ]

--- a/operations/rollout-operator-mixin/jsonnetfile.lock.json
+++ b/operations/rollout-operator-mixin/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "fa93000bce5394179d4884b8ff757691199aaa81",
-      "sum": "G7B6E5sqWirDbMWRhifbLRfGgRFbIh9WCYa6X3kMh6g="
+      "version": "addd7cd3f1b7c4c4890a13037bc4454ebafd7e4b",
+      "sum": "d8iL8gbyQxspZJ8mDGsqHRR/JF3cu+YOaV50vao93Nw="
     },
     {
       "source": {
@@ -18,8 +18,8 @@
           "subdir": "mixin-utils"
         }
       },
-      "version": "fa93000bce5394179d4884b8ff757691199aaa81",
-      "sum": "VAik6Sh5MD5H1Km1gSIXG4rwQ4m4zyw7odP5TKu3bGo="
+      "version": "addd7cd3f1b7c4c4890a13037bc4454ebafd7e4b",
+      "sum": "J9Hf1U5jhg5k2HxMUR9n0nzu8bbuDUtsybXrvf6CUm4="
     }
   ],
   "legacyImports": false

--- a/operations/rollout-operator-mixin/vendor/github.com/grafana/jsonnet-libs/mixin-utils/test/test_native-classic-histogram.libsonnet
+++ b/operations/rollout-operator-mixin/vendor/github.com/grafana/jsonnet-libs/mixin-utils/test/test_native-classic-histogram.libsonnet
@@ -117,6 +117,16 @@ test.new(std.thisFile)
   )
 )
 + test.case.new(
+  name='rate of average with sum_by labels',
+  test=test.expect.eq(
+    actual=utils.ncHistogramAverageRate('request_duration_seconds', 'cluster="cluster1", job="job1"', sum_by=['namespace']),
+    expected={
+      classic: 'sum by (namespace) (rate(request_duration_seconds_sum{cluster="cluster1", job="job1"}[$__rate_interval])) /\nsum by (namespace) (rate(request_duration_seconds_count{cluster="cluster1", job="job1"}[$__rate_interval]))\n',
+      native: 'sum by (namespace) (histogram_sum(rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))) /\nsum by (namespace) (histogram_count(rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval])))\n',
+    },
+  )
+)
++ test.case.new(
   name='rate of average in recording rule with different interval, multiplier',
   test=test.expect.eq(
     actual=utils.ncHistogramAverageRate('request_duration_seconds', 'cluster="cluster1", job="job1"', '5m', '42', true),

--- a/operations/rollout-operator-mixin/vendor/github.com/grafana/jsonnet-libs/mixin-utils/utils.libsonnet
+++ b/operations/rollout-operator-mixin/vendor/github.com/grafana/jsonnet-libs/mixin-utils/utils.libsonnet
@@ -100,24 +100,27 @@ local g = import 'grafana-builder/grafana.libsonnet';
   // classic histograms.
   // If from_recording is true, the function will assume :sum_rate metric
   // suffix and no rate needed.
-  ncHistogramAverageRate(metric, selector, rate_interval='$__rate_interval', multiplier='', from_recording=false)::
+  ncHistogramAverageRate(metric, selector, rate_interval='$__rate_interval', multiplier='', from_recording=false, sum_by=[])::
+    local sumBy = if std.length(sum_by) > 0 then ' by (%s) ' % std.join(', ', sum_by) else '';
     local multiplierStr = if multiplier == '' then '' else '%s * ' % multiplier;
     {
       classic: |||
-        %(multiplier)ssum(%(sumMetricQuery)s) /
-        sum(%(countMetricQuery)s)
+        %(multiplier)ssum%(sumBy)s(%(sumMetricQuery)s) /
+        sum%(sumBy)s(%(countMetricQuery)s)
       ||| % {
         sumMetricQuery: $.ncHistogramSumRate(metric, selector, rate_interval, from_recording).classic,
         countMetricQuery: $.ncHistogramCountRate(metric, selector, rate_interval, from_recording).classic,
         multiplier: multiplierStr,
+        sumBy: sumBy,
       },
       native: |||
-        %(multiplier)ssum(%(sumMetricQuery)s) /
-        sum(%(countMetricQuery)s)
+        %(multiplier)ssum%(sumBy)s(%(sumMetricQuery)s) /
+        sum%(sumBy)s(%(countMetricQuery)s)
       ||| % {
         sumMetricQuery: $.ncHistogramSumRate(metric, selector, rate_interval, from_recording).native,
         countMetricQuery: $.ncHistogramCountRate(metric, selector, rate_interval, from_recording).native,
         multiplier: multiplierStr,
+        sumBy: sumBy,
       },
     },
 


### PR DESCRIPTION
Adds native histogram toggle and classic/native queries.

Migrated histograms:
- rollout_operator_request_duration_seconds
- rollout_operator_group_reconcile_duration_seconds
- rollout_operator_kubernetes_api_client_request_duration_seconds
