### PR TITLE
fix: typo in log message when failing to call downscale endpoint

### DIFF
--- a/pkg/controller/delay.go
+++ b/pkg/controller/delay.go
@@ -200,8 +200,8 @@ func callPrepareDownscaleAndReturnElapsedDurationsSinceInitiatedDownscale(ctx co
 			}
 
 			if resp.StatusCode/100 != 2 {
-				level.Error(epLogger).Log("msg", "unexpected status code returned when calling DELETE on endpoint", "status", resp.StatusCode, "response_body", string(body))
-				return fmt.Errorf("HTTP DELETE request returned non-2xx status code: %v", resp.StatusCode)
+				level.Error(epLogger).Log("msg", "unexpected status code returned when calling POST on endpoint", "status", resp.StatusCode, "response_body", string(body))
+				return fmt.Errorf("HTTP POST request returned non-2xx status code: %v", resp.StatusCode)
 			}
 
 			r := expectedResponse{}


### PR DESCRIPTION
The log mention we are failing to handle the `DELETE` http request when we are sending `POST` instead. I guess this was a typo. 