### PR TITLE
Add optional per-pod rollout delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ For each **rollout group**, the operator **guarantees**:
    - `1`: pods are rolled out sequentially
    - `> 1`: pods are rolled out in parallel (honoring the configured number of max unavailable pods)
 
+Additionally, each StatefulSet can optionally configure a per-pod rollout delay with the `rollout-delay` label:
+
+- The value is parsed as a Go duration (for example: `10s`, `5m`, `1h`).
+- If the label is unset, empty, or cannot be parsed, no delay is applied and behavior is unchanged.
+- When set on a StatefulSet, the operator waits for the configured duration between deleting each pod during a rollout, while still respecting the `rollout-max-unavailable` limit and any configured `ZoneAwarePodDisruptionBudget`.
+
 ## How scaling up and down works
 
 The operator can also optionally coordinate scaling up and down of `StatefulSets` that are part of the same `rollout-group` based on the `grafana.com/rollout-downscale-leader` annotation. When using this feature, the `grafana.com/min-time-between-zones-downscale` label must also be set on each `StatefulSet`.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,4 +45,7 @@ const (
 
 	// RolloutDelayedDownscalePrepareUrlAnnotationKey is a full URL to prepare-downscale endpoint. Hostname will be replaced with pod's fully qualified domain name.
 	RolloutDelayedDownscalePrepareUrlAnnotationKey = "grafana.com/rollout-prepare-delayed-downscale-url"
+
+	// RolloutDelayKey is the delay before starting next rollout.
+	RolloutDelayKey = "rollout-delay"
 )

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1188,6 +1188,50 @@ func TestRolloutController_ReconcileShouldDeleteMetricsForDecommissionedRolloutG
 	}
 }
 
+func TestRolloutController_RolloutDelayForStatefulSet(t *testing.T) {
+	c := &RolloutController{logger: log.NewNopLogger()}
+
+	tests := []struct {
+		name      string
+		sts       *v1.StatefulSet
+		wantDelay time.Duration
+	}{
+		{
+			name:      "no label returns zero delay",
+			sts:       mockStatefulSet("ingester-zone-a"),
+			wantDelay: 0,
+		},
+		{
+			name: "empty label returns zero delay",
+			sts: mockStatefulSet("ingester-zone-a", withLabels(map[string]string{
+				config.RolloutDelayKey: "",
+			})),
+			wantDelay: 0,
+		},
+		{
+			name: "invalid duration returns zero delay",
+			sts: mockStatefulSet("ingester-zone-a", withLabels(map[string]string{
+				config.RolloutDelayKey: "not-a-duration",
+			})),
+			wantDelay: 0,
+		},
+		{
+			name: "valid duration is parsed",
+			sts: mockStatefulSet("ingester-zone-a", withLabels(map[string]string{
+				config.RolloutDelayKey: "10s",
+			})),
+			wantDelay: 10 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := c.rolloutDelayForStatefulSet(tt.sts)
+			assert.Equal(t, tt.wantDelay, got)
+		})
+	}
+}
+
 func mockStatefulSet(name string, overrides ...func(sts *v1.StatefulSet)) *v1.StatefulSet {
 	replicas := int32(3)
 


### PR DESCRIPTION
# Add optional per-pod rollout delay for StatefulSets

### Summary

This PR adds an optional, per-StatefulSet rollout delay that slows down pod restarts within a single StatefulSet, without changing maxUnavailable semantics or the existing rollout safety guarantees.

### Background / Problem

This feature is motivated by issues we’ve seen running rollout-operator in a large, multi‑AZ Mimir deployment which affects  Memcached, but it is not specific to Mimir or  Memcached. Any workload that depends heavily on a cache (or other warm‑up–sensitive service) can suffer when many pods restart too quickly, even if maxUnavailable/PDB settings are respected.

As we know Memcached pods run with a sidecar that scrapes Memcached metrics; that sidecar is sometimes updated as part of broader changes to the Mimir/Loki/Traces stack. When that sidecar (or other shared components) is updated, the Memcached StatefulSet can be rolled, causing its pods to restart.

Each restart wipes in‑memory cache state, so pods come back “cold”. If several Memcached pods restart in rapid succession, we see a prolonged low cache‑hit period, and significant slowdowns in all components that rely on Memcached during cache warm‑up.

rollout-operator already ensures we stay within a safe number of unavailable pods, but it doesn’t control how quickly pods within that budget are recycled. For cache-heavy workloads, having a configurable delay between pod restarts allows existing pods to serve traffic and warm newly restarted ones before the next disruption, smoothing out the rollout impact.

### Usage

To enable the feature for a particular StatefulSet (e.g. Memcached):

```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: memcached
  labels:
    rollout-group: mimir
    rollout-delay: "30s"   # new label
```

### Expected behaviour

- Without the label (or with an invalid value), rollouts behave exactly as before.
- With the label, the operator will:
  - Still respect maxUnavailable and/or other constraints and strategies.
  - Introduce a 30s delay between pod terminations in the same StatefulSet.