### PR TITLE
Update base images to Debian 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [CHANGE] Update base images from distroless Debian 12 to Debian 13. #355
+
 ## v0.32.2
 
 * [BUGFIX] Limit webhook metrics to validating and mutating webhook configurations which have a matching grafana.com/namespace label. #347

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.25-trixie AS build
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -7,10 +7,10 @@ COPY . /src/rollout-operator
 WORKDIR /src/rollout-operator
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make rollout-operator
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian13:nonroot
 
-COPY --from=build /src/rollout-operator/rollout-operator /bin/rollout-operator
-ENTRYPOINT [ "/bin/rollout-operator" ]
+COPY --from=build /src/rollout-operator/rollout-operator /usr/bin/rollout-operator
+ENTRYPOINT [ "/usr/bin/rollout-operator" ]
 
 ARG revision
 LABEL org.opencontainers.image.title="rollout-operator" \

--- a/Dockerfile.boringcrypto
+++ b/Dockerfile.boringcrypto
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS build
+FROM golang:1.25-trixie AS build
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -7,10 +7,10 @@ COPY . /src/rollout-operator
 WORKDIR /src/rollout-operator
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make rollout-operator-boringcrypto
 
-FROM gcr.io/distroless/base-nossl-debian12:nonroot
+FROM gcr.io/distroless/base-nossl-debian13:nonroot
 
-COPY --from=build /src/rollout-operator/rollout-operator /bin/rollout-operator
-ENTRYPOINT [ "/bin/rollout-operator" ]
+COPY --from=build /src/rollout-operator/rollout-operator /usr/bin/rollout-operator
+ENTRYPOINT [ "/usr/bin/rollout-operator" ]
 
 ARG revision
 LABEL org.opencontainers.image.title="rollout-operator" \

--- a/integration/mock-service/Dockerfile
+++ b/integration/mock-service/Dockerfile
@@ -1,7 +1,7 @@
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian13:nonroot
 
-COPY       mock-service /bin/mock-service
-ENTRYPOINT [ "/bin/mock-service" ]
+COPY       mock-service /usr/bin/mock-service
+ENTRYPOINT [ "/usr/bin/mock-service" ]
 
 ARG revision
 LABEL org.opencontainers.image.title="mock-service" \


### PR DESCRIPTION
Updates Dockerfiles to use Debian 13 distroless images since they are now available ([reference](https://github.com/GoogleContainerTools/distroless?tab=readme-ov-file#debian-13)).

Since `/bin/` now symlinks to `/usr/bin/` I chose to use `/usr/bin/` directly for clarity as well.

