### PR TITLE
Update Tanka Kubernetes version from 1.29 to 1.35

### DIFF
--- a/integration/jsonnet-integration/build.sh
+++ b/integration/jsonnet-integration/build.sh
@@ -35,7 +35,7 @@ if [ ! -d "$OUTPUT_DIR" ]; then
     cd "$OUTPUT_DIR"
 
     # Initialise the Tanka.
-    tk init --k8s=1.29
+    tk init --k8s=1.35
 
     # Install rollout-operator from this branch.
     jb install ../../operations/rollout-operator

--- a/operations/rollout-operator-tests/build.sh
+++ b/operations/rollout-operator-tests/build.sh
@@ -8,7 +8,7 @@ rm -rf jsonnet-tests && mkdir jsonnet-tests
 cd jsonnet-tests
 
 # Initialise the Tanka.
-tk init --k8s=1.29
+tk init --k8s=1.35
 
 # Install rollout-operator from this branch.
 jb install ../operations/rollout-operator


### PR DESCRIPTION
## Summary
- Update the Kubernetes version used by Tanka in build scripts from 1.29 to 1.35
- Aligns with the current k8s.io dependency version (v0.35.0)

## Test plan
- [ ] CI passes

Made with [Cursor](https://cursor.com)