### PR TITLE
Update Go to 1.26 to cut v0.28.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
       - run: make rollout-operator
 
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
       - run: make test
       - run: make test-boringcrypto
@@ -41,7 +41,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
       - name: Install kind
         uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1
@@ -58,7 +58,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
       - name: Install kind
         uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1
@@ -75,9 +75,9 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9 
         with:
-          version: v2.4.0
+          version: v2.9.0
           args: --timeout=5m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,22 @@
 
 ## main / unreleased
 
+## v0.28.4
+
+* [ENHANCEMENT] Update to Go `1.26`. #382
+* [ENHANCEMENT] Updated dependencies, including: #381
+  * `k8s.io/api` from `v0.33.1` to `v0.35.1`
+  * `k8s.io/apimachinery` from `v0.33.1` to `v0.35.1`
+  * `k8s.io/client-go` from `v0.33.1` to `v0.35.1`
+  * `sigs.k8s.io/controller-runtime` from `v0.21.0` to `v0.23.1`
+
 ## v0.28.3
 
 * [ENHANCEMENT] Update some indirect dependencies and build a new image with Go `1.25.6` to resolve CVEs. #368
 
 ## v0.28.2
 
-* [ENHANCEMENT] Update to Go `1.25` and Debian 13.
+* [ENHANCEMENT] Update to Go `1.25` and Debian 13. #357
 
 ## v0.28.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASEIMAGE=gcr.io/distroless/static-debian13:nonroot
 
-FROM golang:1.25-trixie AS build
+FROM golang:1.26-trixie AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/rollout-operator
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb


### PR DESCRIPTION
Updates Go to 1.26 to resolve CVE-2025-68121 and cuts v0.28.4. This is an older branch of rollout-operator that is still being maintained for security patches.