### PR TITLE
Add Renovate custom managers

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,69 @@
     "postUpdateOptions": [
         "gomodTidy"
     ],
+    "customManagers": [
+      {
+        "customType": "regex",
+        "description": "Update kind image used in integration tests",
+        "managerFilePatterns": ["^integration/util_test\\.go$"],
+        "matchStrings": [
+          "kindest/node:(?<currentValue>v[\\d.]+)"
+        ],
+        "depNameTemplate": "kindest/node",
+        "datasourceTemplate": "docker"
+      },
+      {
+        "customType": "regex",
+        "description": "Update Kubernetes version in test Tanka init",
+        "managerFilePatterns": ["^(integration/jsonnet-integration|operations/rollout-operator-tests)/build\\.sh$"],
+        "matchStrings": [
+          "tk init --k8s=\"(?<currentValue>[\\d.]+)\""
+        ],
+        "depNameTemplate": "kubernetes",
+        "datasourceTemplate": "endoflife-date",
+        "versioningTemplate": "semver-coerced"
+      },
+      {
+        "customType": "regex",
+        "description": "Update go-jsonnet version in CI workflow",
+        "managerFilePatterns": ["^\\.github/workflows/ci\\.yaml$"],
+        "matchStrings": [
+          "JSONNET_VERSION=\"(?<currentValue>[\\d.]+)\""
+        ],
+        "depNameTemplate": "google/go-jsonnet",
+        "datasourceTemplate": "github-releases"
+      },
+      {
+        "customType": "regex",
+        "description": "Update Tanka version in CI workflow",
+        "managerFilePatterns": ["^\\.github/workflows/ci\\.yaml$"],
+        "matchStrings": [
+          "TANKA_VERSION=\"(?<currentValue>[\\d.]+)\""
+        ],
+        "depNameTemplate": "grafana/tanka",
+        "datasourceTemplate": "github-releases"
+      },
+      {
+        "customType": "regex",
+        "description": "Update jsonnet-bundler version in CI workflow",
+        "managerFilePatterns": ["^\\.github/workflows/ci\\.yaml$"],
+        "matchStrings": [
+          "JSONNET_BUNDLER_VERSION=\"(?<currentValue>[\\d.]+)\""
+        ],
+        "depNameTemplate": "jsonnet-bundler/jsonnet-bundler",
+        "datasourceTemplate": "github-releases"
+      },
+      {
+        "customType": "regex",
+        "description": "Update conftest version in CI workflow",
+        "managerFilePatterns": ["^\\.github/workflows/ci\\.yaml$"],
+        "matchStrings": [
+          "CONFTEST_VERSION=\"(?<currentValue>[\\d.]+)\""
+        ],
+        "depNameTemplate": "open-policy-agent/conftest",
+        "datasourceTemplate": "github-releases"
+      }
+    ],
     "branchPrefix": "grafanarenovatebot/",
     "platformCommit": "enabled",
     "dependencyDashboard": false,
@@ -26,6 +89,13 @@
                 "github-actions"
             ],
             "groupName": "github actions"
+        },
+        {
+            "description": "Group all custom manager dependencies together to reduce noise",
+            "matchManagers": [
+                "custom.regex"
+            ],
+            "groupName": "custom manager dependencies"
         },
         {
             "description": "Disable Docker updates",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
           install_only: true
       - name: Install jsonnet
         run: |
-          JSONNET_VERSION=0.21.0
+          JSONNET_VERSION="0.21.0"
           curl -sL "https://github.com/google/go-jsonnet/releases/download/v${JSONNET_VERSION}/go-jsonnet_Linux_x86_64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin
       - name: Install tk
@@ -86,7 +86,7 @@ jobs:
           install_only: true
       - name: Install jsonnet
         run: |
-          JSONNET_VERSION=0.21.0
+          JSONNET_VERSION="0.21.0"
           curl -sL "https://github.com/google/go-jsonnet/releases/download/v${JSONNET_VERSION}/go-jsonnet_Linux_x86_64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin
       - name: Install tk
@@ -131,13 +131,13 @@ jobs:
           cache: ${{ github.event_name != 'push' }} # zizmor: ignore[cache-poisoning] Zizmor doesn't understand that this disables caching for release builds
       - name: Install jsonnet
         run: |
-          JSONNET_VERSION=0.21.0
+          JSONNET_VERSION="0.21.0"
           curl -sL "https://github.com/google/go-jsonnet/releases/download/v${JSONNET_VERSION}/go-jsonnet_Linux_x86_64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin
       - name: Install conftest
         run: |
-          CONTEST_VERSION="0.62.0"
-          curl -sL "https://github.com/open-policy-agent/conftest/releases/download/v${CONTEST_VERSION}/conftest_${CONTEST_VERSION}_Linux_x86_64.tar.gz" \
+          CONFTEST_VERSION="0.62.0"
+          curl -sL "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin
       - name: Install tk
         run: |

--- a/integration/jsonnet-integration/build.sh
+++ b/integration/jsonnet-integration/build.sh
@@ -35,7 +35,7 @@ if [ ! -d "$OUTPUT_DIR" ]; then
     cd "$OUTPUT_DIR"
 
     # Initialise the Tanka.
-    tk init --k8s=1.35
+    tk init --k8s="1.35"
 
     # Install rollout-operator from this branch.
     jb install ../../operations/rollout-operator

--- a/operations/rollout-operator-tests/build.sh
+++ b/operations/rollout-operator-tests/build.sh
@@ -8,7 +8,7 @@ rm -rf jsonnet-tests && mkdir jsonnet-tests
 cd jsonnet-tests
 
 # Initialise the Tanka.
-tk init --k8s=1.35
+tk init --k8s="1.35"
 
 # Install rollout-operator from this branch.
 jb install ../operations/rollout-operator


### PR DESCRIPTION
This adds renovate custom managers to update dependency values that are easy to miss and forget about in the repository. Prevents having to make corrections like https://github.com/grafana/rollout-operator/pull/372.

For transparency I used AI to help with this.

One minor detail that's non-obvious here is that the `Update Kubernetes version in test Tanka init` uses a version like `1.35` and not `1.35.0`, so the `endoflife-date` datasource got used to match that pattern for the update.