### PR TITLE
Replace usage of pkg/errors with stdlib

### DIFF
--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -18,7 +19,6 @@ import (
 	"github.com/grafana/dskit/clusterutil"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/tracing"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/model"
@@ -181,7 +181,9 @@ func main() {
 
 	// Build the Kubernetes client config.
 	kubeConfig, err := buildKubeConfig(cfg.kubeAPIURL, cfg.kubeConfigFile)
-	check(errors.Wrap(err, "failed to build Kubernetes client config"))
+	if err != nil {
+		fatal(fmt.Errorf("failed to build Kubernetes client config: %w", err))
+	}
 	instrumentation.InstrumentKubernetesAPIClient(kubeConfig, reg)
 
 	if kubeConfig.Timeout == 0 {
@@ -211,22 +213,32 @@ func main() {
 
 	// share the transport between all clients
 	httpClient, err := rest.HTTPClientFor(kubeConfig)
-	check(errors.Wrap(err, "failed to create Kubernetes client"))
+	if err != nil {
+		fatal(fmt.Errorf("failed to create Kubernetes HTTP client: %w", err))
+	}
 
 	kubeClient, err := kubernetes.NewForConfigAndClient(kubeConfig, httpClient)
-	check(errors.Wrap(err, "failed to create Kubernetes client"))
+	if err != nil {
+		fatal(fmt.Errorf("failed to create Kubernetes client: %w", err))
+	}
 
 	restMapper, err := apiutil.NewDynamicRESTMapper(kubeConfig, httpClient)
-	check(errors.Wrap(err, "failed to create REST Mapper"))
+	if err != nil {
+		fatal(fmt.Errorf("failed to create REST Mapper: %w", err))
+	}
 
 	// we don't use cached discovery because DiscoveryScaleKindResolver does its own caching,
 	// so we want to re-fetch every time when we actually ask for it
 	scaleKindResolver := scale.NewDiscoveryScaleKindResolver(kubeClient.Discovery())
 	scaleClient, err := scale.NewForConfig(kubeConfig, restMapper, dynamic.LegacyAPIPathResolverFunc, scaleKindResolver)
-	check(errors.Wrap(err, "failed to init scaleClient"))
+	if err != nil {
+		fatal(fmt.Errorf("failed to init scaleClient: %w", err))
+	}
 
 	dynamicClient, err := dynamic.NewForConfigAndClient(kubeConfig, httpClient)
-	check(errors.Wrap(err, "failed to init dynamicClient"))
+	if err != nil {
+		fatal(fmt.Errorf("failed to init dynamicClient: %w", err))
+	}
 
 	// watches for validating webhooks being added - this is only started if the TLS server is started
 	webhookObserver := tlscert.NewWebhookObserver(kubeClient, cfg.kubeNamespace, logger)
@@ -245,13 +257,17 @@ func main() {
 	var webhookCollector *webhooks.WebhookCollector
 	if cfg.serverTLSEnabled {
 		webhookCollector = webhooks.NewWebhookCollector(kubeClient, cfg.kubeNamespace, logger)
-		check(errors.Wrap(webhookCollector.Start(), "failed to start webhook collector"))
+		if err := webhookCollector.Start(); err != nil {
+			fatal(fmt.Errorf("failed to start webhook collector: %w", err))
+		}
 		check(reg.Register(webhookCollector))
 	}
 
 	// Init the controller
 	c := controller.NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, cfg.kubeClusterDomain, cfg.kubeNamespace, httpClient, cfg.reconcileInterval, reg, logger, evictionController)
-	check(errors.Wrap(c.Init(), "failed to init controller"))
+	if err := c.Init(); err != nil {
+		fatal(fmt.Errorf("failed to init controller: %w", err))
+	}
 
 	// Listen to sigterm, as well as for restart (like for certificate renewal).
 	go func() {
@@ -299,13 +315,17 @@ func maybeStartTLSServer(cfg config, rt http.RoundTripper, logger log.Logger, ku
 		certProvider = tlscert.NewKubeSecretPersistedCertProvider(selfSignedProvider, logger, kubeClient, cfg.kubeNamespace, cfg.serverSelfSignedCertSecretName)
 	} else if cfg.serverCertFile != "" && cfg.serverKeyFile != "" {
 		certProvider, err = tlscert.NewFileCertProvider(cfg.serverCertFile, cfg.serverKeyFile)
-		check(errors.Wrap(err, "failed to create file cert provider"))
+		if err != nil {
+			fatal(fmt.Errorf("failed to create file cert provider: %w", err))
+		}
 	} else {
 		fatal(errors.New("either self-signed certificate should be enabled or path to the certificate and key should be provided"))
 	}
 
 	cert, err := certProvider.Certificate(context.Background())
-	check(errors.Wrap(err, "failed to get certificate"))
+	if err != nil {
+		fatal(fmt.Errorf("failed to get certificate: %w", err))
+	}
 
 	checkAndWatchCertificate(cert, logger, restart)
 
@@ -340,17 +360,23 @@ func maybeStartTLSServer(cfg config, rt http.RoundTripper, logger log.Logger, ku
 	}
 
 	tlsSrv, err := newTLSServer(cfg, logger, cert, metrics)
-	check(errors.Wrap(err, "failed to create tls server"))
+	if err != nil {
+		fatal(fmt.Errorf("failed to create tls server: %w", err))
+	}
 	tlsSrv.Handle(admission.NoDownscaleWebhookPath, admission.Serve(admission.NoDownscale, logger, kubeClient))
 	tlsSrv.Handle(admission.PrepareDownscaleWebhookPath, admission.Serve(prepDownscaleAdmitFunc, logger, kubeClient))
 	tlsSrv.Handle(zpdb.PodEvictionWebhookPath, admission.Serve(podEvictionFunc, logger, kubeClient))
 	tlsSrv.Handle(admission.ZpdbValidatorWebhookPath, admission.Serve(zpdbValidationFunc, logger, kubeClient))
-	check(errors.Wrap(tlsSrv.Start(), "failed to start tls server"))
+	if err := tlsSrv.Start(); err != nil {
+		fatal(fmt.Errorf("failed to start tls server: %w", err))
+	}
 }
 
 func checkAndWatchCertificate(cert tlscert.Certificate, logger log.Logger, restart chan string) {
 	pair, err := tls.X509KeyPair(cert.Cert, cert.Key)
-	check(errors.Wrap(err, "failed to parse the provided certificate"))
+	if err != nil {
+		fatal(fmt.Errorf("failed to parse the provided certificate: %w", err))
+	}
 
 	for i, bytes := range pair.Certificate {
 		c, err := x509.ParseCertificate(bytes)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/grafana/dskit v0.0.0-20260413135140-f8fd8e188362
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5
 	github.com/stretchr/testify v1.11.1
@@ -61,6 +60,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opentracing-contrib/go-stdlib v1.1.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
@@ -337,7 +337,7 @@ func (c *RolloutController) reconcileStatefulSetsGroup(ctx context.Context, grou
 	for _, sts := range sets {
 		hasNotReadyPods, err := c.hasStatefulSetNotReadyPods(sts)
 		if err != nil {
-			return errors.Wrapf(err, "unable to check if StatefulSet %s has not ready pods", sts.Name)
+			return fmt.Errorf("unable to check if StatefulSet %s has not ready pods: %w", sts.Name, err)
 		}
 
 		if hasNotReadyPods {
@@ -366,7 +366,7 @@ func (c *RolloutController) reconcileStatefulSetsGroup(ctx context.Context, grou
 		if err != nil {
 			// Do not continue with other StatefulSets because this StatefulSet
 			// is expected to be successfully updated before proceeding.
-			return errors.Wrapf(err, "failed to update StatefulSet %s", sts.Name)
+			return fmt.Errorf("failed to update StatefulSet %s: %w", sts.Name, err)
 		}
 
 		if ongoing {
@@ -446,7 +446,7 @@ func (c *RolloutController) listStatefulSetsWithRolloutGroup() ([]*v1.StatefulSe
 	// the StatefulSets having a rollout group label).
 	sets, err := c.statefulSetLister.StatefulSets(c.namespace).List(labels.Everything())
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list StatefulSets")
+		return nil, fmt.Errorf("failed to list StatefulSets: %w", err)
 	} else if len(sets) == 0 {
 		return nil, nil
 	}
@@ -540,7 +540,7 @@ func notRunningAndReady(pods []*corev1.Pod) []*corev1.Pod {
 func (c *RolloutController) listPods(sel labels.Selector) ([]*corev1.Pod, error) {
 	pods, err := c.podLister.Pods(c.namespace).List(sel)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list Pods")
+		return nil, fmt.Errorf("failed to list Pods: %w", err)
 	}
 
 	return pods, nil
@@ -556,7 +556,7 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 
 	podsToUpdate, err := c.podsNotMatchingUpdateRevision(sts)
 	if err != nil {
-		return false, errors.Wrap(err, "failed to get pods to update")
+		return false, fmt.Errorf("failed to get pods to update: %w", err)
 	}
 
 	if len(podsToUpdate) > 0 {
@@ -589,7 +589,7 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 		hasPartitionAwarePdb, err := c.zpdbController.HasPartitionAwarePdb(podsToUpdate[0])
 		if err != nil {
 			// Note if we ignored this error and continued processing, the same error would be raised from the MarkPodAsDeleted() below.
-			return false, errors.Wrapf(err, "failed to determine pod zpdb configuration %s", podsToUpdate[0].Name)
+			return false, fmt.Errorf("failed to determine pod zpdb configuration %s: %w", podsToUpdate[0].Name, err)
 		}
 
 		// If the pods are covered by a partition aware ZPDB then the override is set to 1
@@ -634,7 +634,7 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 
 			level.Info(c.logger).Log("msg", "terminating pod (does not violate any relevant ZPDBs)", "pod", pod.Name)
 			if err := c.kubeClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
-				return false, errors.Wrapf(err, "failed to delete pod %s", pod.Name)
+				return false, fmt.Errorf("failed to delete pod %s: %w", pod.Name, err)
 			}
 		}
 
@@ -644,7 +644,7 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 	// Ensure all pods in this StatefulSet are Ready, otherwise we consider a rollout is in progress
 	// (in any case, it's not safe to proceed with other StatefulSets).
 	if hasNotReadyPods, err := c.hasStatefulSetNotReadyPods(sts); err != nil {
-		return true, errors.Wrapf(err, "unable to check if StatefulSet %s has not ready pods", sts.Name)
+		return true, fmt.Errorf("unable to check if StatefulSet %s has not ready pods: %w", sts.Name, err)
 	} else if hasNotReadyPods {
 		level.Info(c.logger).Log(
 			"msg", "StatefulSet pods are all updated but StatefulSet has some not-Ready replicas",
@@ -662,7 +662,7 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 
 		level.Debug(c.logger).Log("msg", "updating StatefulSet current revision", "old_current_revision", oldRev, "new_current_revision", sts.Status.UpdateRevision)
 		if sts, err = c.kubeClient.AppsV1().StatefulSets(sts.Namespace).UpdateStatus(ctx, sts, metav1.UpdateOptions{}); err != nil {
-			return false, errors.Wrapf(err, "failed to update StatefulSet %s", sts.Name)
+			return false, fmt.Errorf("failed to update StatefulSet %s: %w", sts.Name, err)
 		}
 		level.Info(c.logger).Log("msg", "updated StatefulSet current revision", "old_current_revision", oldRev, "new_current_revision", sts.Status.UpdateRevision)
 	}

--- a/pkg/tlscert/webhook_observer.go
+++ b/pkg/tlscert/webhook_observer.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -88,7 +87,7 @@ func (c *WebhookObserver) Init(onEvent *WebhookConfigurationListener) error {
 				c.onWebHookConfigurationObserved(new)
 			},
 		}); err != nil {
-			return errors.Wrap(err, "failed to add webhook listener")
+			return fmt.Errorf("failed to add webhook listener: %w", err)
 		}
 	}
 

--- a/pkg/zpdb/eviction_controller.go
+++ b/pkg/zpdb/eviction_controller.go
@@ -2,6 +2,7 @@ package zpdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -9,7 +10,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/spanlogger"
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -81,10 +81,10 @@ func NewEvictionController(kubeClient kubernetes.Interface, dynamicClient dynami
 
 func (c *EvictionController) Start() error {
 	if err := c.cfgObserver.start(); err != nil {
-		return errors.Wrap(err, "failed to start zpdb config observer")
+		return fmt.Errorf("failed to start zpdb config observer: %w", err)
 	}
 	if err := c.podObserver.start(); err != nil {
-		return errors.Wrap(err, "failed to start zpdb pod observer")
+		return fmt.Errorf("failed to start zpdb pod observer: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Removes all direct usage of `github.com/pkg/errors` to prefer using the standard library instead. Similar to the work done in Mimir like https://github.com/grafana/mimir/pull/13535