### PR TITLE
Prepare 0.37.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+## v0.37.0
+
 * [ENHANCEMENT] Add support for zone-aware PDB to enforce a fixed delay between evictions within the same partition. #422
 
 ## v0.36.2

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -299,7 +299,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.36.2
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -93,7 +93,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.36.2
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -299,7 +299,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.36.2
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -231,7 +231,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.36.2
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -307,7 +307,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.36.2
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.36.2
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.36.2
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.36.2
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.36.2
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.36.2
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.36.2
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator/images.libsonnet
+++ b/operations/rollout-operator/images.libsonnet
@@ -1,5 +1,5 @@
 {
   _images+:: {
-    rollout_operator: 'grafana/rollout-operator:v0.36.2',
+    rollout_operator: 'grafana/rollout-operator:v0.37.0',
   },
 }


### PR DESCRIPTION
Prepare to release v0.37.0 per https://github.com/grafana/rollout-operator/blob/main/RELEASE.md

This release introduces the fixed delay zpdb option - https://github.com/grafana/rollout-operator/pull/422 