### PR TITLE
Fix data race in prepare-shutdown tests under -race

### DIFF
--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -403,24 +403,22 @@ func TestSendPrepareShutdown(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			var postCalls atomic.Int32
 
-			errResponse := &http.Response{
-				StatusCode: http.StatusInternalServerError,
-				Body:       io.NopCloser(strings.NewReader("we've had a problem")),
-			}
-			successResponse := &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader("good")),
-			}
-
 			httpClient := newFakeHttpClient(
 				func(r *http.Request) (*http.Response, error) {
 					if r.Method == http.MethodPost {
 						calls := postCalls.Add(1)
+						// Build a fresh response (with its own body) per call, since
+						// these handlers run concurrently and the response body is read.
 						if calls > int32(c.numEndpoints-c.lastPostsFail) {
-							return errResponse, nil
-						} else {
-							return successResponse, nil
+							return &http.Response{
+								StatusCode: http.StatusInternalServerError,
+								Body:       io.NopCloser(strings.NewReader("we've had a problem")),
+							}, nil
 						}
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       io.NopCloser(strings.NewReader("good")),
+						}, nil
 					}
 					panic("unexpected method")
 				},
@@ -471,23 +469,21 @@ func TestUndoPrepareShutdown(t *testing.T) {
 
 	for n, c := range cases {
 		t.Run(n, func(t *testing.T) {
-			errResponse := &http.Response{
-				StatusCode: http.StatusInternalServerError,
-				Body:       io.NopCloser(strings.NewReader("we've had a problem")),
-			}
-			successResponse := &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader("good")),
-			}
-
 			httpClient := newFakeHttpClient(
 				func(r *http.Request) (*http.Response, error) {
 					if r.Method == http.MethodDelete {
+						// Build a fresh response (with its own body) per call, since
+						// these handlers run concurrently and the response body is read.
 						if c.deletesFail {
-							return errResponse, nil
-						} else {
-							return successResponse, nil
+							return &http.Response{
+								StatusCode: http.StatusInternalServerError,
+								Body:       io.NopCloser(strings.NewReader("we've had a problem")),
+							}, nil
 						}
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       io.NopCloser(strings.NewReader("good")),
+						}, nil
 					}
 					panic("unexpected method")
 				},


### PR DESCRIPTION
`TestSendPrepareShutdown/all_posts_fail` and `TestUndoPrepareShutdown/delete_failures_should_still_call_all_deletes` fail under `go test -race` on `main`. This is a latent test bug unrelated to any production behavior.

Each subtest built a single `*http.Response` and returned that same object (with its single `strings.Reader` body) to all of the concurrent goroutines spawned by the errgroup. On the failure paths, `invokePrepareShutdown` reads the response body via `io.ReadAll`, so multiple goroutines read the same reader concurrently and mutate its offset — a data race.

In production this never happens: a real HTTP client returns a fresh response (with its own body) per request. The fix mirrors that by constructing the fake response inside the handler, so each call gets its own body. No production code is changed.

Verified with `go test -race -count=3` on the two tests and `go test -race ./pkg/admission/` for the full package.
