### PR TITLE
Prep for v0.38.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+## v0.38.0
+
 * [CHANGE] Client-side rate limiting to the Kubernetes API is now enforced with an independent token bucket per API group (e.g. `core/v1`, `apps/v1`, `policy/v1`), and each admission webhook gets its own dedicated client so an overloaded webhook cannot throttle the others or the core controller. As a result, the meaning of `-kubernetes.client-qps=0` changed: it previously fell back to the client-go default (~5 QPS / 10 burst per API group), but now disables client-side rate limiting entirely. The defaults of `-kubernetes.client-qps` (now `5`) and `-kubernetes.client-burst` (now `10`) preserve the previous effective throttling. #441
 * [FEATURE] Added `-server-tls.request-timeout` to configure the request timeout of the TLS server that serves the admission webhooks (used as the read and write timeouts). Defaults to `10s`, matching the previous hardcoded value. #441
 * [FEATURE] Added `-pods.client-timeout` to configure the timeout of HTTP requests issued directly to pod endpoints (e.g. prepare-downscale). Defaults to `5s`, matching the previous hardcoded value. #441

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -299,7 +299,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -93,7 +93,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -299,7 +299,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -231,7 +231,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -307,7 +307,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator/images.libsonnet
+++ b/operations/rollout-operator/images.libsonnet
@@ -1,5 +1,5 @@
 {
   _images+:: {
-    rollout_operator: 'grafana/rollout-operator:v0.37.0',
+    rollout_operator: 'grafana/rollout-operator:v0.38.0',
   },
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Diff is version and documentation only; operational risk comes from upgrading to v0.38.0 itself (API client rate limiting and webhook timeout behavior), not from these packaging edits.
> 
> **Overview**
> Release prep for **v0.38.0**: adds a `## v0.38.0` section in `CHANGELOG.md` (the listed fixes/features remain the same notes already on main) and bumps the default container image from `grafana/rollout-operator:v0.37.0` to **`v0.38.0`** in `operations/rollout-operator/images.libsonnet`, with matching updates in generated rollout-operator test manifests.
> 
> Reviewers should treat the changelog block as the shipped behavior for this tag—per-API-group client QPS, dedicated webhook clients, new timeout flags, webhook context deadlines, and the **`-kubernetes.client-qps=0`** semantics change—even though those code changes are not part of this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fed05aa382b3a7009f40743798e94820ac7e7f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->