### PR TITLE
Disable indirect go dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,6 +77,12 @@
     "rebaseWhen": "behind-base-branch",
     "packageRules": [
         {
+            "description": "Disable updates for indirect go dependencies",
+            "matchManagers": ["gomod"],
+            "matchDepTypes": ["indirect"],
+            "enabled": false
+        },
+        {
             "description": "Group all go dependencies together to reduce noise",
             "matchDatasources": [
                 "go"


### PR DESCRIPTION
Renovate PRs (like https://github.com/grafana/rollout-operator/pull/453) have been failing to update Go dependencies in this repository. This attempts to fix it by preventing Renovate from proactively updating indirect dependencies. I'm guessing some behavior changed because this wasn't necessary before.