### PR TITLE
Prepare v0.38.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+## v0.38.1
+
 * [ENHANCEMENT] Updated dependencies, including: #443 #447 #455 #457
   * `github.com/grafana/dskit` from `v0.0.0-20260601123808-0d4540e255b4` to `v0.0.0-20260703122047-de1ec7541c44`
   * `github.com/prometheus/common` from `v0.68.0` to `v0.70.0`

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -299,7 +299,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.0
+        image: grafana/rollout-operator:v0.38.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -93,7 +93,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.0
+        image: grafana/rollout-operator:v0.38.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -299,7 +299,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.0
+        image: grafana/rollout-operator:v0.38.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -231,7 +231,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.0
+        image: grafana/rollout-operator:v0.38.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -307,7 +307,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.0
+        image: grafana/rollout-operator:v0.38.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.0
+        image: grafana/rollout-operator:v0.38.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.0
+        image: grafana/rollout-operator:v0.38.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.0
+        image: grafana/rollout-operator:v0.38.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.0
+        image: grafana/rollout-operator:v0.38.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.0
+        image: grafana/rollout-operator:v0.38.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -223,7 +223,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.38.0
+        image: grafana/rollout-operator:v0.38.1
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator/images.libsonnet
+++ b/operations/rollout-operator/images.libsonnet
@@ -1,5 +1,5 @@
 {
   _images+:: {
-    rollout_operator: 'grafana/rollout-operator:v0.38.0',
+    rollout_operator: 'grafana/rollout-operator:v0.38.1',
   },
 }


### PR DESCRIPTION
## Summary
- promote the unreleased dependency updates into the v0.38.1 changelog
- update the default rollout-operator image and generated Jsonnet fixtures to v0.38.1

Made with [Cursor](https://cursor.com)