### PR TITLE
Add phased Deployment rollouts with canary gating

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Rollout Operator
 
-Coordinates zone-aware rollouts and scaling of StatefulSets within a namespace, for multi-AZ deployments where each AZ is managed by a dedicated StatefulSet.
+Coordinates zone-aware rollouts and scaling of StatefulSets within a namespace, for multi-AZ deployments where each AZ is managed by a dedicated StatefulSet. Also supports opt-in phased rollouts of Deployments (dependency chaining with soak and restart gating).
 
 For full documentation (webhooks, ZPDB, TLS, scaling details, YAML examples), see [README.md](README.md).
 
@@ -8,7 +8,8 @@ For full documentation (webhooks, ZPDB, TLS, scaling details, YAML examples), se
 
 - **Rollout groups**: StatefulSets with `rollout-group` label and `OnDelete` strategy are rolled one zone at a time.
 - **Scaling**: Leader/follower pattern via `grafana.com/rollout-downscale-leader` annotation, or mirror-replicas from a reference resource.
-- **Webhooks**: `/admission/no-downscale` (blocks downscale), `/admission/prepare-downscale` (calls prepare-shutdown endpoint before downscale).
+- **Webhooks**: `/admission/no-downscale` (blocks downscale), `/admission/prepare-downscale` (calls prepare-shutdown endpoint before downscale), `/admission/phased-deployment` (pauses dependent Deployments during soak gates).
+- **Phased Deployments**: Opt-in via `grafana.com/rollout-phased`; followers use `grafana.com/rollout-depends-on` and a shared `grafana.com/rollout-revision`.
 - **ZPDB**: Custom `ZoneAwarePodDisruptionBudget` CRD evaluates eviction budgets per-zone (with optional partition awareness for ingest-storage).
 
 ## Development

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Rollout Operator
 
-Coordinates zone-aware rollouts and scaling of StatefulSets within a namespace, for multi-AZ deployments where each AZ is managed by a dedicated StatefulSet. Also supports opt-in phased rollouts of Deployments (dependency chaining with soak and restart gating).
+Coordinates zone-aware rollouts and scaling of StatefulSets within a namespace, for multi-AZ deployments where each AZ is managed by a dedicated StatefulSet. Also supports opt-in phased rollouts of Deployments (canary gating via explicit Git-defined Deployments).
 
 For full documentation (webhooks, ZPDB, TLS, scaling details, YAML examples), see [README.md](README.md).
 
@@ -8,8 +8,8 @@ For full documentation (webhooks, ZPDB, TLS, scaling details, YAML examples), se
 
 - **Rollout groups**: StatefulSets with `rollout-group` label and `OnDelete` strategy are rolled one zone at a time.
 - **Scaling**: Leader/follower pattern via `grafana.com/rollout-downscale-leader` annotation, or mirror-replicas from a reference resource.
-- **Webhooks**: `/admission/no-downscale` (blocks downscale), `/admission/prepare-downscale` (calls prepare-shutdown endpoint before downscale), `/admission/phased-deployment` (pauses dependent Deployments during soak gates).
-- **Phased Deployments**: Opt-in via `grafana.com/rollout-phased`; followers use `grafana.com/rollout-depends-on` and a shared `grafana.com/rollout-revision`.
+- **Webhooks**: `/admission/no-downscale` (blocks downscale), `/admission/prepare-downscale` (calls prepare-shutdown endpoint before downscale), `/admission/phased-deployment` (pauses main Deployments until canaries converge).
+- **Phased Deployments**: Opt-in via `grafana.com/rollout-phased`; mains use `grafana.com/rollout-canary` (comma-separated) and a shared `grafana.com/rollout-revision`. Incident bypass via `grafana.com/rollout-bypass-until`.
 - **ZPDB**: Custom `ZoneAwarePodDisruptionBudget` CRD evaluates eviction budgets per-zone (with optional partition awareness for ingest-storage).
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -156,6 +156,52 @@ spec:
 
 To resume normal rollout behavior, remove the annotation or set it to any value other than `true`.
 
+## Phased Deployment rollouts
+
+Opt-in sequencing for Kubernetes Deployments. A dependent Deployment stays paused until its upstream Deployment finishes rolling, soaks for a configurable period (default `5m`), and passes a restart check (default: container restart deltas divided by upstream pod count must be below `10%`).
+
+### Enablement
+
+Label opted-in Deployments and stamp a shared revision from Git/jsonnet. Point followers at their upstream with `grafana.com/rollout-depends-on`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-frontend-zone-a
+  labels:
+    grafana.com/rollout-phased: "true"
+  annotations:
+    grafana.com/rollout-revision: "r388"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-frontend-zone-b
+  labels:
+    grafana.com/rollout-phased: "true"
+  annotations:
+    grafana.com/rollout-depends-on: query-frontend-zone-a
+    grafana.com/rollout-revision: "r388"
+    # Optional overrides:
+    # grafana.com/rollout-soak-duration: "5m"
+    # grafana.com/rollout-restart-threshold: "10%"
+```
+
+The mutating webhook `/admission/phased-deployment` (scoped to `grafana.com/rollout-phased: "true"`) pauses the follower when the revision changes and re-applies `spec.paused: true` on later applies while the gate is active (including Flux server-side apply).
+
+Chains such as zone-a → zone-b → zone-c are supported by setting `depends-on` on each follower. Disable by removing `grafana.com/rollout-depends-on` (the webhook clears gate state and restores the prior pause intent) and optionally the `grafana.com/rollout-phased` label. If you remove only the label while the Deployment is still paused by the operator, unpause it manually.
+
+### Resume after a failed soak
+
+If the restart check fails, the follower stays paused with phase `blocked`. Resume for that revision:
+
+```bash
+kubectl annotate deployment query-frontend-zone-b grafana.com/rollout-resume=r388 --overwrite
+```
+
+The operator then marks the gate complete and unpauses immediately (no fresh soak).
+
 ## Operations
 
 ### HTTP endpoints
@@ -174,7 +220,11 @@ Prometheus metrics endpoint.
 
 #### `/admission/no-downscale`
 
-Offers a `ValidatingAdmissionWebhook` that rejects the requests that decrease the number of replicas in objects labeled as `grafana.com/no-downscale: true`. See [Webhooks](#webhooks) section below. 
+Offers a `ValidatingAdmissionWebhook` that rejects the requests that decrease the number of replicas in objects labeled as `grafana.com/no-downscale: true`. See [Webhooks](#webhooks) section below.
+
+#### `/admission/phased-deployment`
+
+Offers a `MutatingAdmissionWebhook` that pauses opted-in dependent Deployments while an upstream soak gate is active. See [Phased Deployment rollouts](#phased-deployment-rollouts).
 
 #### `/pods/eviction`
 
@@ -216,6 +266,15 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
 - apiGroups:
   - rollout-operator.grafana.com
   resources:

--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ To resume normal rollout behavior, remove the annotation or set it to any value 
 
 ## Phased Deployment rollouts
 
-Opt-in sequencing for Kubernetes Deployments. A dependent Deployment stays paused until its upstream Deployment finishes rolling, soaks for a configurable period (default `5m`), and passes a restart check (default: container restart deltas divided by upstream pod count must be below `10%`).
+Opt-in sequencing for Kubernetes Deployments (proposal 4c). A main Deployment stays paused until its canary Deployment(s) finish rolling and become ready. Batches are explicit Deployments in Git; the operator only toggles `spec.paused` and never manages ReplicaSets. Prometheus health gating is a separate feature (proposal 4b) and is not part of this gate.
 
 ### Enablement
 
-Label opted-in Deployments and stamp a shared revision from Git/jsonnet. Point followers at their upstream with `grafana.com/rollout-depends-on`:
+Label opted-in Deployments and stamp a shared revision from Git/jsonnet. Point the main Deployment at its canary with `grafana.com/rollout-canary` (comma-separated for coordinated groups):
 
 ```yaml
 apiVersion: apps/v1
@@ -181,26 +181,33 @@ metadata:
   labels:
     grafana.com/rollout-phased: "true"
   annotations:
-    grafana.com/rollout-depends-on: query-frontend-zone-a
+    grafana.com/rollout-canary: query-frontend-zone-a
     grafana.com/rollout-revision: "r388"
-    # Optional overrides:
-    # grafana.com/rollout-soak-duration: "5m"
-    # grafana.com/rollout-restart-threshold: "10%"
 ```
 
-The mutating webhook `/admission/phased-deployment` (scoped to `grafana.com/rollout-phased: "true"`) pauses the follower when the revision changes and re-applies `spec.paused: true` on later applies while the gate is active (including Flux server-side apply).
+Coordinated canary groups (for example querier zone-b waiting on both querier and query-frontend zone-a):
 
-Chains such as zone-a → zone-b → zone-c are supported by setting `depends-on` on each follower. Disable by removing `grafana.com/rollout-depends-on` (the webhook clears gate state and restores the prior pause intent) and optionally the `grafana.com/rollout-phased` label. If you remove only the label while the Deployment is still paused by the operator, unpause it manually.
+```yaml
+metadata:
+  annotations:
+    grafana.com/rollout-canary: querier-zone-a,query-frontend-zone-a
+    grafana.com/rollout-revision: "r388"
+```
 
-### Resume after a failed soak
+The mutating webhook `/admission/phased-deployment` (scoped to `grafana.com/rollout-phased: "true"`) pauses the main Deployment when the revision changes and re-applies `spec.paused: true` on later applies while the gate is active (including Flux server-side apply).
 
-If the restart check fails, the follower stays paused with phase `blocked`. Resume for that revision:
+Disable by removing `grafana.com/rollout-canary` (the webhook clears gate state and restores the prior pause intent) and optionally the `grafana.com/rollout-phased` label. If you remove only the label while the Deployment is still paused by the operator, unpause it manually.
+
+### Incident bypass
+
+During an incident, apply a time-limited bypass so the Deployment uses native Kubernetes rolling updates:
 
 ```bash
-kubectl annotate deployment query-frontend-zone-b grafana.com/rollout-resume=r388 --overwrite
+kubectl annotate deployment query-frontend-zone-b \
+  grafana.com/rollout-bypass-until="2026-07-24T16:00:00Z" --overwrite
 ```
 
-The operator then marks the gate complete and unpauses immediately (no fresh soak).
+While the bypass is active, the operator does not pause new updates and unpauses an already-gated Deployment. It emits a Warning event (`RolloutBypass`) and increments `rollout_operator_phased_deployment_bypass_total`. Existing readiness checks and the native Deployment strategy still apply.
 
 ## Operations
 
@@ -224,7 +231,7 @@ Offers a `ValidatingAdmissionWebhook` that rejects the requests that decrease th
 
 #### `/admission/phased-deployment`
 
-Offers a `MutatingAdmissionWebhook` that pauses opted-in dependent Deployments while an upstream soak gate is active. See [Phased Deployment rollouts](#phased-deployment-rollouts).
+Offers a `MutatingAdmissionWebhook` that pauses opted-in main Deployments while a canary gate is active. See [Phased Deployment rollouts](#phased-deployment-rollouts).
 
 #### `/pods/eviction`
 
@@ -275,6 +282,12 @@ rules:
   - get
   - watch
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
 - apiGroups:
   - rollout-operator.grafana.com
   resources:

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ To resume normal rollout behavior, remove the annotation or set it to any value 
 
 ## Phased Deployment rollouts
 
-Opt-in sequencing for Kubernetes Deployments (proposal 4c). A main Deployment stays paused until its canary Deployment(s) finish rolling and become ready. Batches are explicit Deployments in Git; the operator only toggles `spec.paused` and never manages ReplicaSets. Prometheus health gating is a separate feature (proposal 4b) and is not part of this gate.
+Opt-in sequencing for Kubernetes Deployments (proposal 4c). A main Deployment stays paused until its canary Deployment(s) finish rolling and become ready. Readiness is latched for the current shared revision once every canary is fully rolled, so routine pod evictions or autoscaling do not return an active gate to its initial readiness check. A canary must continue to report the target revision. Batches are explicit Deployments in Git; the operator only toggles `spec.paused` and never manages ReplicaSets. Prometheus health gating is a separate feature (proposal 4b) and is not part of this gate.
 
 ### Enablement
 

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -44,7 +44,7 @@ import (
 const defaultServerSelfSignedCertExpiration = model.Duration(365 * 24 * time.Hour)
 
 var (
-	defaultClusterValidationExcludePaths = []string{"admission/no-downscale", "admission/prepare-downscale"}
+	defaultClusterValidationExcludePaths = []string{"admission/no-downscale", "admission/prepare-downscale", "admission/phased-deployment"}
 )
 
 type config struct {
@@ -312,10 +312,16 @@ func main() {
 		fatal(fmt.Errorf("failed to init controller: %w", err))
 	}
 
+	phasedController := controller.NewPhasedDeploymentController(coreKubeClient, cfg.kubeNamespace, cfg.reconcileInterval, reg, logger)
+	if err := phasedController.Init(); err != nil {
+		fatal(fmt.Errorf("failed to init phased deployment controller: %w", err))
+	}
+
 	// Listen to sigterm, as well as for restart (like for certificate renewal).
 	go func() {
 		waitForSignalOrRestart(logger, restart)
 		c.Stop()
+		phasedController.Stop()
 		evictionController.Stop()
 		webhookObserver.Stop()
 		if webhookCollector != nil {
@@ -326,6 +332,8 @@ func main() {
 
 	// The operator is ready once the controller successfully initialised.
 	ready.Store(true)
+
+	go phasedController.Run()
 
 	// Run and block until stopped.
 	c.Run()
@@ -429,6 +437,7 @@ func maybeStartTLSServer(cfg config, wireComponentConfig func(component string) 
 
 	tlsSrv.Handle(admission.NoDownscaleWebhookPath, admission.Serve(admission.NoDownscale, logger, noDownscaleKubeClient, webhookHandlerTimeout))
 	tlsSrv.Handle(admission.PrepareDownscaleWebhookPath, admission.Serve(prepDownscaleAdmitFunc, logger, prepareDownscaleKubeClient, webhookHandlerTimeout))
+	tlsSrv.Handle(admission.PhasedDeploymentWebhookPath, admission.Serve(admission.PhasedDeployment, logger, nil, webhookHandlerTimeout))
 	tlsSrv.Handle(zpdb.PodEvictionWebhookPath, admission.Serve(podEvictionFunc, logger, nil, webhookHandlerTimeout))
 	tlsSrv.Handle(admission.ZpdbValidatorWebhookPath, admission.Serve(zpdbValidationFunc, logger, nil, webhookHandlerTimeout))
 	if err := tlsSrv.Start(); err != nil {

--- a/development/phased-deployment-webhook.yaml
+++ b/development/phased-deployment-webhook.yaml
@@ -1,0 +1,32 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: phased-deployment-rollout-operator-development
+  labels:
+    grafana.com/namespace: rollout-operator-development
+    grafana.com/inject-rollout-operator-ca: "true"
+webhooks:
+  - name: phased-deployment-rollout-operator-development.grafana.com
+    admissionReviewVersions: [v1]
+    clientConfig:
+      service:
+        name: rollout-operator
+        namespace: rollout-operator-development
+        path: /admission/phased-deployment
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: 10
+    objectSelector:
+      matchLabels:
+        grafana.com/rollout-phased: "true"
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: rollout-operator-development
+    rules:
+      - apiGroups: [apps]
+        apiVersions: [v1]
+        operations: [CREATE, UPDATE]
+        resources: [deployments]
+        scope: Namespaced

--- a/development/rollout-operator-role.yaml
+++ b/development/rollout-operator-role.yaml
@@ -29,6 +29,15 @@ rules:
     verbs:
       - update
   - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - list
+      - get
+      - watch
+      - patch
+  - apiGroups:
       - rollout-operator.grafana.com
     resources:
       - zoneawarepoddisruptionbudgets

--- a/development/rollout-operator-role.yaml
+++ b/development/rollout-operator-role.yaml
@@ -38,6 +38,12 @@ rules:
       - watch
       - patch
   - apiGroups:
+      -
+    resources:
+      - events
+    verbs:
+      - create
+  - apiGroups:
       - rollout-operator.grafana.com
     resources:
       - zoneawarepoddisruptionbudgets

--- a/integration/phased_deployment_test.go
+++ b/integration/phased_deployment_test.go
@@ -1,0 +1,242 @@
+//go:build requires_docker
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+func TestPhasedDeploymentHappyCase(t *testing.T) {
+	ctx := context.Background()
+	cluster := createKindCluster(t, "rollout-operator:latest", "mock-service:latest")
+	api := cluster.API()
+
+	path := initManifestFiles(t, "webhooks-enabled")
+	createRolloutOperator(t, ctx, api, cluster.ExtAPI(), path, true)
+	rolloutOperatorPod := eventuallyGetFirstPod(ctx, t, api, "name=rollout-operator")
+	requireEventuallyPod(t, api, ctx, rolloutOperatorPod, expectPodPhase(corev1.PodRunning), expectReady())
+
+	whPath := path + "admissionregistration.k8s.io-v1.MutatingWebhookConfiguration-phased-deployment-default.yaml"
+	createMutatingWebhookConfiguration(t, api, ctx, whPath)
+	require.Eventually(t, awaitCABundleAssignment(1, ctx, api), 30*time.Second, 50*time.Millisecond, "phased webhook has CABundle")
+
+	const rev1 = "r1"
+	const rev2 = "r2"
+	createPhasedMockDeployment(t, ctx, api, "frontend-zone-a", "", rev1, 1)
+	createPhasedMockDeployment(t, ctx, api, "frontend-zone-b", "frontend-zone-a", rev1, 1)
+	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-a")
+	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-b")
+
+	updatePhasedMockDeployment(t, ctx, api, "frontend-zone-a", "", rev2)
+	updatePhasedMockDeployment(t, ctx, api, "frontend-zone-b", "frontend-zone-a", rev2)
+
+	require.Eventually(t, func() bool {
+		b, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, "frontend-zone-b", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return b.Spec.Paused && b.Annotations[config.RolloutDependencyPhaseAnnotationKey] != ""
+	}, 30*time.Second, 200*time.Millisecond, "zone-b should be paused by phased gate")
+
+	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-a")
+
+	// Still paused during short soak (3s configured on the Deployment).
+	time.Sleep(1 * time.Second)
+	b, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, "frontend-zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.True(t, b.Spec.Paused, "zone-b should remain paused during soak")
+
+	require.Eventually(t, func() bool {
+		b, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, "frontend-zone-b", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return !b.Spec.Paused && b.Annotations[config.RolloutDependencyPhaseAnnotationKey] == config.RolloutDependencyPhaseComplete
+	}, 30*time.Second, 200*time.Millisecond, "zone-b should unpause after soak")
+
+	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-b")
+}
+
+func TestPhasedDeploymentResumeAfterBlock(t *testing.T) {
+	ctx := context.Background()
+	cluster := createKindCluster(t, "rollout-operator:latest", "mock-service:latest")
+	api := cluster.API()
+
+	path := initManifestFiles(t, "webhooks-not-enabled")
+	createRolloutOperator(t, ctx, api, cluster.ExtAPI(), path, false)
+	rolloutOperatorPod := eventuallyGetFirstPod(ctx, t, api, "name=rollout-operator")
+	requireEventuallyPod(t, api, ctx, rolloutOperatorPod, expectPodPhase(corev1.PodRunning), expectReady())
+
+	const rev = "r-block"
+	createPhasedMockDeployment(t, ctx, api, "frontend-zone-a", "", rev, 1)
+	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-a")
+
+	replicas := int32(1)
+	b := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "frontend-zone-b",
+			Labels: map[string]string{
+				config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue,
+				"name":                       "frontend-zone-b",
+			},
+			Annotations: map[string]string{
+				config.RolloutDependsOnAnnotationKey:          "frontend-zone-a",
+				config.RolloutRevisionAnnotationKey:           rev,
+				config.RolloutSoakDurationAnnotationKey:       "3s",
+				config.RolloutRestartThresholdAnnotationKey:   "10%",
+				config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseBlocked,
+				config.RolloutDependencyRevisionAnnotationKey: rev,
+				config.RolloutDependencyReasonAnnotationKey:   "test block",
+				config.RolloutHadPausedAnnotationKey:          "false",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Paused:   true,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": "frontend-zone-b"}},
+			Template: phasedMockPodTemplate("frontend-zone-b", "1"),
+		},
+	}
+	_, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, b, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = api.AppsV1().Deployments(corev1.NamespaceDefault).Patch(ctx, "frontend-zone-b",
+		types.MergePatchType,
+		[]byte(`{"metadata":{"annotations":{"grafana.com/rollout-resume":"r-block"}}}`),
+		metav1.PatchOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		cur, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, "frontend-zone-b", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return !cur.Spec.Paused && cur.Annotations[config.RolloutDependencyPhaseAnnotationKey] == config.RolloutDependencyPhaseComplete
+	}, 30*time.Second, 200*time.Millisecond, "resume should complete the gate")
+}
+
+func createPhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernetes.Clientset, name, dependsOn, revision string, replicas int32) {
+	t.Helper()
+	labels := map[string]string{
+		config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue,
+		"name":                       name,
+	}
+	ann := map[string]string{
+		config.RolloutRevisionAnnotationKey:     revision,
+		config.RolloutSoakDurationAnnotationKey: "3s",
+	}
+	if dependsOn != "" {
+		ann[config.RolloutDependsOnAnnotationKey] = dependsOn
+		// Treat the initial revision as already gated so CREATE does not pause the first rollout.
+		ann[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseComplete
+		ann[config.RolloutDependencyRevisionAnnotationKey] = revision
+	}
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      labels,
+			Annotations: ann,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": name}},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: intstrPtr(0),
+					MaxSurge:       intstrPtr(1),
+				},
+			},
+			Template: phasedMockPodTemplate(name, "1"),
+		},
+	}
+	_, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, d, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func updatePhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernetes.Clientset, name, dependsOn, revision string) {
+	t.Helper()
+	d, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, name, metav1.GetOptions{})
+	require.NoError(t, err)
+	if d.Annotations == nil {
+		d.Annotations = map[string]string{}
+	}
+	d.Annotations[config.RolloutRevisionAnnotationKey] = revision
+	if dependsOn != "" {
+		d.Annotations[config.RolloutDependsOnAnnotationKey] = dependsOn
+	}
+	d.Spec.Template = phasedMockPodTemplate(name, "2")
+	_, err = api.AppsV1().Deployments(corev1.NamespaceDefault).Update(ctx, d, metav1.UpdateOptions{})
+	require.NoError(t, err)
+}
+
+func phasedMockPodTemplate(name, version string) corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"name": name, "version": version},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:            "app",
+				Image:           "mock-service:latest",
+				ImagePullPolicy: corev1.PullNever,
+				Ports:           []corev1.ContainerPort{{ContainerPort: 8080}},
+				Env: []corev1.EnvVar{
+					{Name: "VERSION", Value: version},
+					{Name: "READY", Value: "true"},
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromInt(8080)},
+					},
+					InitialDelaySeconds: 1,
+					PeriodSeconds:       1,
+				},
+			}},
+		},
+	}
+}
+
+func awaitDeploymentRolledOut(t *testing.T, ctx context.Context, api *kubernetes.Clientset, name string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		d, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, name, metav1.GetOptions{})
+		if err != nil || d.Spec.Paused {
+			return false
+		}
+		desired := int32(1)
+		if d.Spec.Replicas != nil {
+			desired = *d.Spec.Replicas
+		}
+		return d.Status.ObservedGeneration >= d.Generation &&
+			d.Status.UpdatedReplicas == desired &&
+			d.Status.ReadyReplicas == desired &&
+			d.Status.AvailableReplicas == desired
+	}, 2*time.Minute, 500*time.Millisecond, "deployment %s should be fully rolled out", name)
+}
+
+func intstrPtr(v int) *intstr.IntOrString {
+	i := intstr.FromInt(v)
+	return &i
+}
+
+func createMutatingWebhookConfiguration(t *testing.T, api *kubernetes.Clientset, ctx context.Context, file string) *admissionregistrationv1.MutatingWebhookConfiguration {
+	t.Helper()
+	wh := loadFromDisk[admissionregistrationv1.MutatingWebhookConfiguration](t, file, &admissionregistrationv1.MutatingWebhookConfiguration{})
+	created, err := api.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(ctx, wh, metav1.CreateOptions{})
+	require.NoError(t, err)
+	return created
+}

--- a/integration/phased_deployment_test.go
+++ b/integration/phased_deployment_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -31,7 +32,20 @@ func TestPhasedDeploymentHappyCase(t *testing.T) {
 
 	whPath := path + "admissionregistration.k8s.io-v1.MutatingWebhookConfiguration-phased-deployment-default.yaml"
 	createMutatingWebhookConfiguration(t, api, ctx, whPath)
-	require.Eventually(t, awaitCABundleAssignment(1, ctx, api), 30*time.Second, 50*time.Millisecond, "phased webhook has CABundle")
+	require.Eventually(t, func() bool {
+		list, err := api.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{
+			LabelSelector: "grafana.com/inject-rollout-operator-ca=true,grafana.com/namespace=default",
+		})
+		if err != nil || len(list.Items) == 0 {
+			return false
+		}
+		for _, wh := range list.Items {
+			if strings.HasPrefix(wh.Name, "phased-deployment-") && len(wh.Webhooks) > 0 && len(wh.Webhooks[0].ClientConfig.CABundle) > 0 {
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 50*time.Millisecond, "phased webhook has CABundle")
 
 	const rev1 = "r1"
 	const rev2 = "r2"

--- a/integration/phased_deployment_test.go
+++ b/integration/phased_deployment_test.go
@@ -13,7 +13,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 
@@ -67,24 +66,18 @@ func TestPhasedDeploymentHappyCase(t *testing.T) {
 
 	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-a")
 
-	// Still paused during short soak (3s configured on the Deployment).
-	time.Sleep(1 * time.Second)
-	b, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, "frontend-zone-b", metav1.GetOptions{})
-	require.NoError(t, err)
-	require.True(t, b.Spec.Paused, "zone-b should remain paused during soak")
-
 	require.Eventually(t, func() bool {
 		b, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, "frontend-zone-b", metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
 		return !b.Spec.Paused && b.Annotations[config.RolloutDependencyPhaseAnnotationKey] == config.RolloutDependencyPhaseComplete
-	}, 30*time.Second, 200*time.Millisecond, "zone-b should unpause after soak")
+	}, 30*time.Second, 200*time.Millisecond, "zone-b should unpause after canary is ready")
 
 	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-b")
 }
 
-func TestPhasedDeploymentResumeAfterBlock(t *testing.T) {
+func TestPhasedDeploymentBypass(t *testing.T) {
 	ctx := context.Background()
 	cluster := createKindCluster(t, "rollout-operator:latest", "mock-service:latest")
 	api := cluster.API()
@@ -94,7 +87,7 @@ func TestPhasedDeploymentResumeAfterBlock(t *testing.T) {
 	rolloutOperatorPod := eventuallyGetFirstPod(ctx, t, api, "name=rollout-operator")
 	requireEventuallyPod(t, api, ctx, rolloutOperatorPod, expectPodPhase(corev1.PodRunning), expectReady())
 
-	const rev = "r-block"
+	const rev = "r-bypass"
 	createPhasedMockDeployment(t, ctx, api, "frontend-zone-a", "", rev, 1)
 	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-a")
 
@@ -107,14 +100,13 @@ func TestPhasedDeploymentResumeAfterBlock(t *testing.T) {
 				"name":                       "frontend-zone-b",
 			},
 			Annotations: map[string]string{
-				config.RolloutDependsOnAnnotationKey:          "frontend-zone-a",
+				config.RolloutCanaryAnnotationKey:             "frontend-zone-a",
 				config.RolloutRevisionAnnotationKey:           rev,
-				config.RolloutSoakDurationAnnotationKey:       "3s",
-				config.RolloutRestartThresholdAnnotationKey:   "10%",
-				config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseBlocked,
+				config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseWaiting,
 				config.RolloutDependencyRevisionAnnotationKey: rev,
-				config.RolloutDependencyReasonAnnotationKey:   "test block",
+				config.RolloutDependencyReasonAnnotationKey:   "test wait",
 				config.RolloutHadPausedAnnotationKey:          "false",
+				config.RolloutBypassUntilAnnotationKey:        time.Now().UTC().Add(time.Hour).Format(time.RFC3339),
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -127,33 +119,26 @@ func TestPhasedDeploymentResumeAfterBlock(t *testing.T) {
 	_, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, b, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	_, err = api.AppsV1().Deployments(corev1.NamespaceDefault).Patch(ctx, "frontend-zone-b",
-		types.MergePatchType,
-		[]byte(`{"metadata":{"annotations":{"grafana.com/rollout-resume":"r-block"}}}`),
-		metav1.PatchOptions{})
-	require.NoError(t, err)
-
 	require.Eventually(t, func() bool {
 		cur, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, "frontend-zone-b", metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
 		return !cur.Spec.Paused && cur.Annotations[config.RolloutDependencyPhaseAnnotationKey] == config.RolloutDependencyPhaseComplete
-	}, 30*time.Second, 200*time.Millisecond, "resume should complete the gate")
+	}, 30*time.Second, 200*time.Millisecond, "bypass should complete the gate")
 }
 
-func createPhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernetes.Clientset, name, dependsOn, revision string, replicas int32) {
+func createPhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernetes.Clientset, name, canary, revision string, replicas int32) {
 	t.Helper()
 	labels := map[string]string{
 		config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue,
 		"name":                       name,
 	}
 	ann := map[string]string{
-		config.RolloutRevisionAnnotationKey:     revision,
-		config.RolloutSoakDurationAnnotationKey: "3s",
+		config.RolloutRevisionAnnotationKey: revision,
 	}
-	if dependsOn != "" {
-		ann[config.RolloutDependsOnAnnotationKey] = dependsOn
+	if canary != "" {
+		ann[config.RolloutCanaryAnnotationKey] = canary
 		// Treat the initial revision as already gated so CREATE does not pause the first rollout.
 		ann[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseComplete
 		ann[config.RolloutDependencyRevisionAnnotationKey] = revision
@@ -181,7 +166,7 @@ func createPhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernet
 	require.NoError(t, err)
 }
 
-func updatePhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernetes.Clientset, name, dependsOn, revision string) {
+func updatePhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernetes.Clientset, name, canary, revision string) {
 	t.Helper()
 	d, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, name, metav1.GetOptions{})
 	require.NoError(t, err)
@@ -189,8 +174,8 @@ func updatePhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernet
 		d.Annotations = map[string]string{}
 	}
 	d.Annotations[config.RolloutRevisionAnnotationKey] = revision
-	if dependsOn != "" {
-		d.Annotations[config.RolloutDependsOnAnnotationKey] = dependsOn
+	if canary != "" {
+		d.Annotations[config.RolloutCanaryAnnotationKey] = canary
 	}
 	d.Spec.Template = phasedMockPodTemplate(name, "2")
 	_, err = api.AppsV1().Deployments(corev1.NamespaceDefault).Update(ctx, d, metav1.UpdateOptions{})

--- a/operations/policies/common.rego
+++ b/operations/policies/common.rego
@@ -145,6 +145,15 @@ is_prepare_downscale_webhook(obj) if {
     startswith(obj.metadata.name, "prepare-downscale-")
 }
 
+has_phased_deployment_webhook if {
+    is_phased_deployment_webhook(input[_].contents)
+}
+
+is_phased_deployment_webhook(obj) if {
+    obj.kind == "MutatingWebhookConfiguration"
+    startswith(obj.metadata.name, "phased-deployment-")
+}
+
 has_no_downscale_webhook if {
     is_no_downscale_webhook(input[_].contents)
 }

--- a/operations/policies/policies_expected_objects.rego
+++ b/operations/policies/policies_expected_objects.rego
@@ -61,6 +61,12 @@ deny contains msg if {
 
 deny contains msg if {
     has_webhooks_deployment
+    not has_phased_deployment_webhook
+    msg := "Missing phased_deployment webhook"
+}
+
+deny contains msg if {
+    has_webhooks_deployment
     not has_no_downscale_webhook
     msg := "Missing no_downscale webhook"
 }

--- a/operations/policies/policies_role.rego
+++ b/operations/policies/policies_role.rego
@@ -19,6 +19,11 @@ expected_rules = [
     "verbs": ["update"],
   },
   {
+    "apiGroups": ["apps"],
+    "resources": ["deployments"],
+    "verbs": ["list", "get", "watch", "patch"],
+  },
+  {
     "apiGroups": [""],
     "resources": ["configmaps"],
     "verbs": ["get", "update", "create"],

--- a/operations/policies/policies_role.rego
+++ b/operations/policies/policies_role.rego
@@ -25,6 +25,11 @@ expected_rules = [
   },
   {
     "apiGroups": [""],
+    "resources": ["events"],
+    "verbs": ["create"],
+  },
+  {
+    "apiGroups": [""],
     "resources": ["configmaps"],
     "verbs": ["get", "update", "create"],
   },

--- a/operations/policies/policies_webhooks.rego
+++ b/operations/policies/policies_webhooks.rego
@@ -83,6 +83,24 @@ deny contains msg if {
     msg := sprintf("MutatingWebhookConfiguration does not have expected rule, %v. Expected %v, got %v", [display_name(obj), rule, obj.webhooks[0].rules])
 }
 
+# Assert that the phased-deployment has expected path
+deny contains msg if {
+    path := "/admission/phased-deployment"
+	obj := input[_].contents
+	is_phased_deployment_webhook(obj)
+	obj.webhooks[0].clientConfig.service.path != path
+    msg := sprintf("MutatingWebhookConfiguration does not have expected path, %v. Expected %v, got %v", [display_name(obj), path, obj.webhooks[0].clientConfig.service.path])
+}
+
+# Assert that the phased-deployment has expected rule
+deny contains msg if {
+    rule := { "apiGroups": ["apps"], "apiVersions": ["v1"], "operations": ["CREATE", "UPDATE"], "resources": ["deployments"] }
+	obj := input[_].contents
+	is_phased_deployment_webhook(obj)
+	not webhook_rule_present(obj, rule)
+    msg := sprintf("MutatingWebhookConfiguration does not have expected rule, %v. Expected %v, got %v", [display_name(obj), rule, obj.webhooks[0].rules])
+}
+
 # Assert that the no-downscale has expected path
 deny contains msg if {
     path := "/admission/no-downscale"

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -191,6 +191,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -320,6 +329,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -202,6 +202,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -36,6 +36,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -47,6 +47,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -191,6 +191,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -320,6 +329,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -202,6 +202,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy.jsonnet
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy.jsonnet
@@ -5,6 +5,7 @@ rollout_operator {
     namespace: 'default',
     ignore_rollout_operator_no_downscale_webhook_failures: true,
     ignore_rollout_operator_prepare_downscale_webhook_failures: true,
+    ignore_rollout_operator_phased_deployment_webhook_failures: true,
     ignore_rollout_operator_zpdb_eviction_webhook_failures: true,
     ignore_rollout_operator_zpdb_validation_webhook_failures: true,
   },

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -115,6 +115,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -252,6 +261,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -126,6 +126,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -191,6 +191,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -328,6 +337,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -202,6 +202,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -115,6 +115,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -244,6 +253,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -126,6 +126,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -115,6 +115,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -244,6 +253,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -126,6 +126,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -115,6 +115,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -244,6 +253,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -126,6 +126,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -115,6 +115,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -244,6 +253,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -126,6 +126,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -115,6 +115,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -244,6 +253,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -126,6 +126,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -115,6 +115,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -244,6 +253,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -126,6 +126,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator/rollout-operator.libsonnet
+++ b/operations/rollout-operator/rollout-operator.libsonnet
@@ -50,6 +50,7 @@
     // block other operations that would block the service creation.
     ignore_rollout_operator_no_downscale_webhook_failures: false,
     ignore_rollout_operator_prepare_downscale_webhook_failures: false,
+    ignore_rollout_operator_phased_deployment_webhook_failures: false,
     ignore_rollout_operator_zpdb_eviction_webhook_failures: false,
     ignore_rollout_operator_zpdb_validation_webhook_failures: false,
   },
@@ -59,6 +60,7 @@
   assert !$._config.rollout_operator_webhooks_enabled || $._config.rollout_operator_enabled : 'rollout_operator_webhooks_enabled requires rollout_operator_enabled=true',
   assert !$._config.ignore_rollout_operator_no_downscale_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_no_downscale_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.ignore_rollout_operator_prepare_downscale_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_prepare_downscale_webhook_failures requires rollout_operator_webhooks_enabled=true',
+  assert !$._config.ignore_rollout_operator_phased_deployment_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_phased_deployment_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.ignore_rollout_operator_zpdb_eviction_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_zpdb_eviction_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.ignore_rollout_operator_zpdb_validation_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_zpdb_validation_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.replica_template_custom_resource_definition_enabled || $._config.rollout_operator_webhooks_enabled : 'replica_template_custom_resource_definition_enabled requires rollout_operator_webhooks_enabled=true',
@@ -131,6 +133,9 @@
         policyRule.withApiGroups('apps') +
         policyRule.withResources(['statefulsets/status']) +
         policyRule.withVerbs(['update']),
+        policyRule.withApiGroups('apps') +
+        policyRule.withResources(['deployments']) +
+        policyRule.withVerbs(['list', 'get', 'watch', 'patch']),
         policyRule.withApiGroups('') +
         policyRule.withResources(['configmaps']) +
         policyRule.withVerbs(['get', 'update', 'create']),
@@ -352,6 +357,50 @@
             name: 'rollout-operator',
             namespace: $._config.namespace,
             path: '/admission/prepare-downscale',
+            port: 443,
+          },
+        },
+      },
+    ]),
+
+  phased_deployment_webhook: if !enableWebhooks then null else
+    mutatingWebhookConfiguration.new('phased-deployment-%s' % $._config.namespace) +
+    mutatingWebhookConfiguration.mixin.metadata.withLabels({
+      'grafana.com/namespace': $._config.namespace,
+      'grafana.com/inject-rollout-operator-ca': 'true',
+    }) +
+    mutatingWebhookConfiguration.withWebhooksMixin([
+      mutatingWebhook.withName('phased-deployment-%s.grafana.com' % $._config.namespace)
+      + mutatingWebhook.withAdmissionReviewVersions(['v1'])
+      + mutatingWebhook.withFailurePolicy(if $._config.ignore_rollout_operator_phased_deployment_webhook_failures then 'Ignore' else 'Fail')
+      + mutatingWebhook.withMatchPolicy('Equivalent')
+      + mutatingWebhook.withSideEffects('NoneOnDryRun')
+      + mutatingWebhook.withTimeoutSeconds(10)
+      + mutatingWebhook.withRulesMixin([
+        {
+          apiGroups: ['apps'],
+          apiVersions: ['v1'],
+          operations: ['CREATE', 'UPDATE'],
+          resources: ['deployments'],
+          scope: 'Namespaced',
+        },
+      ])
+      + {
+        namespaceSelector: {
+          matchLabels: {
+            'kubernetes.io/metadata.name': $._config.namespace,
+          },
+        },
+        objectSelector: {
+          matchLabels: {
+            'grafana.com/rollout-phased': 'true',
+          },
+        },
+        clientConfig: {
+          service: {
+            name: 'rollout-operator',
+            namespace: $._config.namespace,
+            path: '/admission/phased-deployment',
             port: 443,
           },
         },

--- a/operations/rollout-operator/rollout-operator.libsonnet
+++ b/operations/rollout-operator/rollout-operator.libsonnet
@@ -137,6 +137,9 @@
         policyRule.withResources(['deployments']) +
         policyRule.withVerbs(['list', 'get', 'watch', 'patch']),
         policyRule.withApiGroups('') +
+        policyRule.withResources(['events']) +
+        policyRule.withVerbs(['create']),
+        policyRule.withApiGroups('') +
         policyRule.withResources(['configmaps']) +
         policyRule.withVerbs(['get', 'update', 'create']),
       ] +

--- a/pkg/admission/phased_deployment.go
+++ b/pkg/admission/phased_deployment.go
@@ -1,0 +1,253 @@
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/spanlogger"
+	v1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/phased"
+)
+
+const (
+	PhasedDeploymentWebhookPath = "/admission/phased-deployment"
+)
+
+type jsonPatchOp struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+// PhasedDeployment is a mutating webhook that pauses opted-in dependent Deployments
+// when their shared rollout revision changes, and re-applies pause while the gate is active.
+func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, _ *kubernetes.Clientset) *v1.AdmissionResponse {
+	logger, ctx := spanlogger.New(ctx, l, "admission.PhasedDeployment()", tenantResolver)
+	defer logger.Finish()
+	_ = ctx
+
+	if ar.Request == nil {
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	logger.SetSpanAndLogTag("object.name", ar.Request.Name)
+	logger.SetSpanAndLogTag("object.namespace", ar.Request.Namespace)
+	logger.SetSpanAndLogTag("object.operation", string(ar.Request.Operation))
+
+	if ar.Request.Kind.Kind != "Deployment" {
+		return allowWarn(logger, fmt.Sprintf("unsupported kind %s, allowing", ar.Request.Kind.Kind))
+	}
+
+	obj, _, err := codecs.UniversalDeserializer().Decode(ar.Request.Object.Raw, nil, nil)
+	if err != nil {
+		return allowErr(logger, "can't decode object, allowing the change", err)
+	}
+	dep, ok := obj.(*appsv1.Deployment)
+	if !ok {
+		return allowWarn(logger, fmt.Sprintf("unexpected type %T, allowing", obj))
+	}
+
+	if !phased.IsOptedIn(dep) {
+		level.Debug(logger).Log("msg", "deployment not opted into phased rollouts, allowing")
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	dependsOn := phased.DependsOn(dep)
+	if dependsOn == "" {
+		// Upstream / first Deployment in a chain: clear leftover gate state if present.
+		if patch := clearGateStatePatch(dep); patch != nil {
+			level.Info(logger).Log("msg", "clearing leftover phased gate state from non-dependent deployment")
+			return mutate(patch)
+		}
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	revision := phased.Revision(dep)
+	if revision == "" {
+		level.Warn(logger).Log("msg", "phased deployment missing rollout revision, allowing without gate")
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	// Gate already completed for this revision: allow (including unpause).
+	if phased.Phase(dep) == config.RolloutDependencyPhaseComplete && phased.DependencyRevision(dep) == revision {
+		level.Debug(logger).Log("msg", "phased gate complete for revision, allowing", "revision", revision)
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	var oldDep *appsv1.Deployment
+	if len(ar.Request.OldObject.Raw) > 0 {
+		oldObj, _, err := codecs.UniversalDeserializer().Decode(ar.Request.OldObject.Raw, nil, nil)
+		if err == nil {
+			oldDep, _ = oldObj.(*appsv1.Deployment)
+		}
+	}
+
+	patch, err := buildGatePatch(dep, oldDep, revision)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to build phased gate patch", "err", err)
+		return &v1.AdmissionResponse{
+			Allowed: false,
+			Result:  &metav1.Status{Message: err.Error()},
+		}
+	}
+	if patch == nil {
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	level.Info(logger).Log(
+		"msg", "pausing deployment for phased rollout gate",
+		"depends_on", dependsOn,
+		"revision", revision,
+		"phase", phased.Phase(dep),
+	)
+	return mutate(patch)
+}
+
+func mutate(patch []byte) *v1.AdmissionResponse {
+	pt := v1.PatchTypeJSONPatch
+	return &v1.AdmissionResponse{
+		Allowed:   true,
+		Patch:     patch,
+		PatchType: &pt,
+	}
+}
+
+func buildGatePatch(dep, oldDep *appsv1.Deployment, revision string) ([]byte, error) {
+	ops := []jsonPatchOp{}
+
+	if dep.Annotations == nil {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/metadata/annotations", Value: map[string]string{}})
+	}
+
+	needsNewGate := phased.NeedsNewGate(dep)
+	hadPaused := resolveHadPaused(dep, oldDep, needsNewGate)
+
+	if !dep.Spec.Paused {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+	}
+
+	setAnn := func(key, value string) {
+		cur := ""
+		if dep.Annotations != nil {
+			cur = dep.Annotations[key]
+		}
+		if cur == value {
+			return
+		}
+		ops = append(ops, jsonPatchOp{Op: "add", Path: phased.AnnotationJSONPointer(key), Value: value})
+	}
+
+	if needsNewGate {
+		setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseWaiting)
+		setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
+		setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for upstream deployment")
+		setAnn(config.RolloutHadPausedAnnotationKey, hadPaused)
+		if dep.Annotations != nil && dep.Annotations[config.RolloutSoakStartedAtAnnotationKey] != "" {
+			ops = append(ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(config.RolloutSoakStartedAtAnnotationKey)})
+		}
+		if dep.Annotations != nil && dep.Annotations[config.RolloutRestartBaselineAnnotationKey] != "" {
+			ops = append(ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(config.RolloutRestartBaselineAnnotationKey)})
+		}
+	} else {
+		setAnn(config.RolloutHadPausedAnnotationKey, hadPaused)
+		if phased.Phase(dep) == "" {
+			setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseWaiting)
+			setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
+			setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for upstream deployment")
+		}
+	}
+
+	if len(ops) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(ops)
+}
+
+func resolveHadPaused(dep, oldDep *appsv1.Deployment, needsNewGate bool) string {
+	if !needsNewGate {
+		if dep.Annotations != nil && dep.Annotations[config.RolloutHadPausedAnnotationKey] != "" {
+			return dep.Annotations[config.RolloutHadPausedAnnotationKey]
+		}
+		if oldDep != nil && oldDep.Annotations != nil && oldDep.Annotations[config.RolloutHadPausedAnnotationKey] != "" {
+			return oldDep.Annotations[config.RolloutHadPausedAnnotationKey]
+		}
+		return phased.HadPausedAnnotationFalse
+	}
+
+	// New gate: preserve prior user pause intent across revision changes.
+	if oldDep != nil {
+		if wasPausedByOurGate(oldDep) && oldDep.Annotations != nil && oldDep.Annotations[config.RolloutHadPausedAnnotationKey] != "" {
+			return oldDep.Annotations[config.RolloutHadPausedAnnotationKey]
+		}
+		if oldDep.Spec.Paused && !wasPausedByOurGate(oldDep) {
+			return phased.HadPausedAnnotationTrue
+		}
+		return phased.HadPausedAnnotationFalse
+	}
+	if dep.Spec.Paused {
+		return phased.HadPausedAnnotationTrue
+	}
+	return phased.HadPausedAnnotationFalse
+}
+
+func wasPausedByOurGate(d *appsv1.Deployment) bool {
+	if d == nil || !d.Spec.Paused {
+		return false
+	}
+	return phased.GateActive(d)
+}
+
+func clearGateStatePatch(dep *appsv1.Deployment) []byte {
+	if dep.Annotations == nil {
+		return nil
+	}
+	keys := []string{
+		config.RolloutDependencyPhaseAnnotationKey,
+		config.RolloutDependencyRevisionAnnotationKey,
+		config.RolloutDependencyReasonAnnotationKey,
+		config.RolloutSoakStartedAtAnnotationKey,
+		config.RolloutRestartBaselineAnnotationKey,
+		config.RolloutHadPausedAnnotationKey,
+		config.RolloutResumeAnnotationKey,
+	}
+	hasGateState := false
+	for _, key := range keys {
+		if dep.Annotations[key] != "" {
+			hasGateState = true
+			break
+		}
+	}
+	if !hasGateState {
+		return nil
+	}
+
+	ops := []jsonPatchOp{}
+	hadPaused := dep.Annotations[config.RolloutHadPausedAnnotationKey] == phased.HadPausedAnnotationTrue
+	phase := dep.Annotations[config.RolloutDependencyPhaseAnnotationKey]
+	gateWasActive := phase != "" && phase != config.RolloutDependencyPhaseComplete
+	for _, key := range keys {
+		if dep.Annotations[key] != "" {
+			ops = append(ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(key)})
+		}
+	}
+	// Only unpause when releasing an active gate that we owned.
+	if gateWasActive && dep.Spec.Paused && !hadPaused {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: false})
+	}
+	if len(ops) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(ops)
+	if err != nil {
+		return nil
+	}
+	return b
+}

--- a/pkg/admission/phased_deployment.go
+++ b/pkg/admission/phased_deployment.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -27,8 +29,9 @@ type jsonPatchOp struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
-// PhasedDeployment is a mutating webhook that pauses opted-in dependent Deployments
-// when their shared rollout revision changes, and re-applies pause while the gate is active.
+// PhasedDeployment is a mutating webhook that pauses opted-in Deployments with canary
+// dependencies when their shared rollout revision changes, and re-applies pause while
+// the gate is active. A time-limited bypass annotation skips gating.
 func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, _ *kubernetes.Clientset) *v1.AdmissionResponse {
 	logger, ctx := spanlogger.New(ctx, l, "admission.PhasedDeployment()", tenantResolver)
 	defer logger.Finish()
@@ -60,11 +63,21 @@ func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 		return &v1.AdmissionResponse{Allowed: true}
 	}
 
-	dependsOn := phased.DependsOn(dep)
-	if dependsOn == "" {
-		// Upstream / first Deployment in a chain: clear leftover gate state if present.
+	canaries := phased.Canaries(dep)
+	if len(canaries) == 0 {
+		// Canary / first Deployment in a chain: clear leftover gate state if present.
 		if patch := clearGateStatePatch(dep); patch != nil {
-			level.Info(logger).Log("msg", "clearing leftover phased gate state from non-dependent deployment")
+			level.Info(logger).Log("msg", "clearing leftover phased gate state from canary deployment")
+			return mutate(patch)
+		}
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	if _, ok, err := phased.BypassUntil(dep); err != nil {
+		level.Warn(logger).Log("msg", "invalid rollout-bypass-until, ignoring", "err", err)
+	} else if ok && phased.BypassActive(dep, time.Now()) {
+		level.Info(logger).Log("msg", "phased rollout bypass active, allowing without gate")
+		if patch := bypassReleasePatch(dep); patch != nil {
 			return mutate(patch)
 		}
 		return &v1.AdmissionResponse{Allowed: true}
@@ -104,7 +117,7 @@ func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 
 	level.Info(logger).Log(
 		"msg", "pausing deployment for phased rollout gate",
-		"depends_on", dependsOn,
+		"canaries", fmt.Sprintf("%v", canaries),
 		"revision", revision,
 		"phase", phased.Phase(dep),
 	)
@@ -148,20 +161,14 @@ func buildGatePatch(dep, oldDep *appsv1.Deployment, revision string) ([]byte, er
 	if needsNewGate {
 		setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseWaiting)
 		setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
-		setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for upstream deployment")
+		setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for canary deployment(s)")
 		setAnn(config.RolloutHadPausedAnnotationKey, hadPaused)
-		if dep.Annotations != nil && dep.Annotations[config.RolloutSoakStartedAtAnnotationKey] != "" {
-			ops = append(ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(config.RolloutSoakStartedAtAnnotationKey)})
-		}
-		if dep.Annotations != nil && dep.Annotations[config.RolloutRestartBaselineAnnotationKey] != "" {
-			ops = append(ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(config.RolloutRestartBaselineAnnotationKey)})
-		}
 	} else {
 		setAnn(config.RolloutHadPausedAnnotationKey, hadPaused)
 		if phased.Phase(dep) == "" {
 			setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseWaiting)
 			setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
-			setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for upstream deployment")
+			setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for canary deployment(s)")
 		}
 	}
 
@@ -213,10 +220,7 @@ func clearGateStatePatch(dep *appsv1.Deployment) []byte {
 		config.RolloutDependencyPhaseAnnotationKey,
 		config.RolloutDependencyRevisionAnnotationKey,
 		config.RolloutDependencyReasonAnnotationKey,
-		config.RolloutSoakStartedAtAnnotationKey,
-		config.RolloutRestartBaselineAnnotationKey,
 		config.RolloutHadPausedAnnotationKey,
-		config.RolloutResumeAnnotationKey,
 	}
 	hasGateState := false
 	for _, key := range keys {
@@ -240,6 +244,45 @@ func clearGateStatePatch(dep *appsv1.Deployment) []byte {
 	}
 	// Only unpause when releasing an active gate that we owned.
 	if gateWasActive && dep.Spec.Paused && !hadPaused {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: false})
+	}
+	if len(ops) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(ops)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// bypassReleasePatch unpauses a Deployment that is still held by an active gate when bypass is used.
+func bypassReleasePatch(dep *appsv1.Deployment) []byte {
+	if !phased.GateActive(dep) && !dep.Spec.Paused {
+		return nil
+	}
+	hadPaused := dep.Annotations != nil && dep.Annotations[config.RolloutHadPausedAnnotationKey] == phased.HadPausedAnnotationTrue
+	ops := []jsonPatchOp{}
+	if dep.Annotations == nil {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/metadata/annotations", Value: map[string]string{}})
+	}
+	revision := phased.Revision(dep)
+	setAnn := func(key, value string) {
+		cur := ""
+		if dep.Annotations != nil {
+			cur = dep.Annotations[key]
+		}
+		if cur == value {
+			return
+		}
+		ops = append(ops, jsonPatchOp{Op: "add", Path: phased.AnnotationJSONPointer(key), Value: value})
+	}
+	if revision != "" {
+		setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseComplete)
+		setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
+		setAnn(config.RolloutDependencyReasonAnnotationKey, "bypassed until "+strings.TrimSpace(dep.Annotations[config.RolloutBypassUntilAnnotationKey]))
+	}
+	if dep.Spec.Paused && !hadPaused {
 		ops = append(ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: false})
 	}
 	if len(ops) == 0 {

--- a/pkg/admission/phased_deployment.go
+++ b/pkg/admission/phased_deployment.go
@@ -197,12 +197,18 @@ func buildGatePatch(dep, oldDep *appsv1.Deployment, revision string) ([]byte, er
 		}
 		ops = append(ops, jsonPatchOp{Op: "add", Path: phased.AnnotationJSONPointer(key), Value: value})
 	}
+	removeAnn := func(key string) {
+		if dep.Annotations != nil && dep.Annotations[key] != "" {
+			ops = append(ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(key)})
+		}
+	}
 
 	if needsNewGate {
 		setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseWaiting)
 		setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
 		setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for canary deployment(s)")
 		setAnn(config.RolloutHadPausedAnnotationKey, hadPaused)
+		removeAnn(config.RolloutCanariesReadyRevisionAnnotationKey)
 	} else {
 		setAnn(config.RolloutHadPausedAnnotationKey, hadPaused)
 		if phased.Phase(dep) == "" {
@@ -261,6 +267,7 @@ func clearGateStatePatch(dep *appsv1.Deployment) []byte {
 		config.RolloutDependencyRevisionAnnotationKey,
 		config.RolloutDependencyReasonAnnotationKey,
 		config.RolloutHadPausedAnnotationKey,
+		config.RolloutCanariesReadyRevisionAnnotationKey,
 	}
 	hasGateState := false
 	for _, key := range keys {

--- a/pkg/admission/phased_deployment.go
+++ b/pkg/admission/phased_deployment.go
@@ -73,10 +73,16 @@ func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 		return &v1.AdmissionResponse{Allowed: true}
 	}
 
-	if _, ok, err := phased.BypassUntil(dep); err != nil {
+	if until, ok, err := phased.BypassUntil(dep); err != nil {
 		level.Warn(logger).Log("msg", "invalid rollout-bypass-until, ignoring", "err", err)
 	} else if ok && phased.BypassActive(dep, time.Now()) {
-		level.Info(logger).Log("msg", "phased rollout bypass active, allowing without gate")
+		level.Info(logger).Log(
+			"msg", "phased rollout bypass active, allowing without gate",
+			"revision", phased.Revision(dep),
+			"bypass_until", until.Format(time.RFC3339),
+			"gate_phase", phased.Phase(dep),
+			"paused", dep.Spec.Paused,
+		)
 		if patch := bypassReleasePatch(dep); patch != nil {
 			return mutate(patch)
 		}
@@ -91,7 +97,11 @@ func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 
 	// Gate already completed for this revision: allow (including unpause).
 	if phased.Phase(dep) == config.RolloutDependencyPhaseComplete && phased.DependencyRevision(dep) == revision {
-		level.Debug(logger).Log("msg", "phased gate complete for revision, allowing", "revision", revision)
+		level.Debug(logger).Log(
+			"msg", "phased gate complete for revision, allowing",
+			"revision", revision,
+			"paused", dep.Spec.Paused,
+		)
 		return &v1.AdmissionResponse{Allowed: true}
 	}
 
@@ -103,6 +113,20 @@ func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 		}
 	}
 
+	needsNewGate := phased.NeedsNewGate(dep)
+	if needsNewGate {
+		previousRevision := phased.DependencyRevision(dep)
+		if oldDep != nil && previousRevision == "" {
+			previousRevision = phased.Revision(oldDep)
+		}
+		level.Info(logger).Log(
+			"msg", "phased deployment revision change detected",
+			"previous_revision", previousRevision,
+			"target_revision", revision,
+			"canaries", strings.Join(canaries, ","),
+		)
+	}
+
 	patch, err := buildGatePatch(dep, oldDep, revision)
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to build phased gate patch", "err", err)
@@ -112,15 +136,31 @@ func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 		}
 	}
 	if patch == nil {
+		level.Debug(logger).Log(
+			"msg", "phased deployment gate already enforced",
+			"revision", revision,
+			"phase", phased.Phase(dep),
+			"paused", dep.Spec.Paused,
+		)
 		return &v1.AdmissionResponse{Allowed: true}
 	}
 
-	level.Info(logger).Log(
-		"msg", "pausing deployment for phased rollout gate",
-		"canaries", fmt.Sprintf("%v", canaries),
-		"revision", revision,
-		"phase", phased.Phase(dep),
-	)
+	if !needsNewGate && !dep.Spec.Paused {
+		level.Warn(logger).Log(
+			"msg", "re-pausing deployment while phased rollout gate is active",
+			"canaries", strings.Join(canaries, ","),
+			"revision", revision,
+			"phase", phased.Phase(dep),
+		)
+	} else {
+		level.Info(logger).Log(
+			"msg", "pausing deployment for phased rollout gate",
+			"canaries", strings.Join(canaries, ","),
+			"revision", revision,
+			"phase", phased.Phase(dep),
+			"had_paused", resolveHadPaused(dep, oldDep, needsNewGate),
+		)
+	}
 	return mutate(patch)
 }
 

--- a/pkg/admission/phased_deployment_test.go
+++ b/pkg/admission/phased_deployment_test.go
@@ -1,0 +1,143 @@
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+func TestPhasedDeployment_PausesOnRevisionChange(t *testing.T) {
+	newDep := phasedDeployment("query-frontend-zone-b", "query-frontend-zone-a", "r2", false, "", "")
+	oldDep := phasedDeployment("query-frontend-zone-b", "query-frontend-zone-a", "r1", false, config.RolloutDependencyPhaseComplete, "r1")
+
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(oldDep, newDep), nil)
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.PatchType)
+	require.NotEmpty(t, resp.Patch)
+
+	var ops []jsonPatchOp
+	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
+	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+}
+
+func TestPhasedDeployment_RePausesWhileGateActive(t *testing.T) {
+	newDep := phasedDeployment("b", "a", "r1", false, config.RolloutDependencyPhaseSoaking, "r1")
+	oldDep := phasedDeployment("b", "a", "r1", true, config.RolloutDependencyPhaseSoaking, "r1")
+	oldDep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
+	newDep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
+
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(oldDep, newDep), nil)
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patch)
+
+	var ops []jsonPatchOp
+	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
+	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+}
+
+func TestPhasedDeployment_AllowsWhenComplete(t *testing.T) {
+	dep := phasedDeployment("b", "a", "r1", false, config.RolloutDependencyPhaseComplete, "r1")
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(dep, dep), nil)
+	require.True(t, resp.Allowed)
+	require.Nil(t, resp.Patch)
+}
+
+func TestPhasedDeployment_AllowsWithoutDependsOn(t *testing.T) {
+	dep := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "a",
+			Labels: map[string]string{config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue},
+			Annotations: map[string]string{
+				config.RolloutRevisionAnnotationKey: "r1",
+			},
+		},
+	}
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(nil, dep), nil)
+	require.True(t, resp.Allowed)
+	require.Nil(t, resp.Patch)
+}
+
+func TestPhasedDeployment_PreservesPreExistingPause(t *testing.T) {
+	oldDep := phasedDeployment("b", "a", "r1", true, "", "")
+	newDep := phasedDeployment("b", "a", "r2", true, "", "")
+
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(oldDep, newDep), nil)
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patch)
+
+	var ops []jsonPatchOp
+	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
+	found := false
+	for _, op := range ops {
+		if op.Path == "/metadata/annotations/grafana.com~1rollout-had-paused" {
+			require.Equal(t, "true", op.Value)
+			found = true
+		}
+	}
+	require.True(t, found, "expected had-paused annotation in patch")
+}
+
+func phasedDeployment(name, dependsOn, revision string, paused bool, phase, depRevision string) *appsv1.Deployment {
+	ann := map[string]string{
+		config.RolloutDependsOnAnnotationKey: dependsOn,
+		config.RolloutRevisionAnnotationKey:  revision,
+	}
+	if phase != "" {
+		ann[config.RolloutDependencyPhaseAnnotationKey] = phase
+	}
+	if depRevision != "" {
+		ann[config.RolloutDependencyRevisionAnnotationKey] = depRevision
+	}
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "default",
+			Labels:      map[string]string{config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue},
+			Annotations: ann,
+		},
+		Spec: appsv1.DeploymentSpec{Paused: paused},
+	}
+}
+
+func admissionReview(oldDep, newDep *appsv1.Deployment) admissionv1.AdmissionReview {
+	rawNew, err := json.Marshal(newDep)
+	if err != nil {
+		panic(err)
+	}
+	ar := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID:       "test",
+			Kind:      metav1.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			Resource:  metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			Name:      newDep.Name,
+			Namespace: newDep.Namespace,
+			Operation: admissionv1.Update,
+			Object:    runtime.RawExtension{Raw: rawNew},
+		},
+	}
+	if oldDep != nil {
+		rawOld, err := json.Marshal(oldDep)
+		if err != nil {
+			panic(err)
+		}
+		ar.Request.OldObject = runtime.RawExtension{Raw: rawOld}
+	}
+	return ar
+}

--- a/pkg/admission/phased_deployment_test.go
+++ b/pkg/admission/phased_deployment_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
@@ -30,8 +31,8 @@ func TestPhasedDeployment_PausesOnRevisionChange(t *testing.T) {
 }
 
 func TestPhasedDeployment_RePausesWhileGateActive(t *testing.T) {
-	newDep := phasedDeployment("b", "a", "r1", false, config.RolloutDependencyPhaseSoaking, "r1")
-	oldDep := phasedDeployment("b", "a", "r1", true, config.RolloutDependencyPhaseSoaking, "r1")
+	newDep := phasedDeployment("b", "a", "r1", false, config.RolloutDependencyPhaseWaiting, "r1")
+	oldDep := phasedDeployment("b", "a", "r1", true, config.RolloutDependencyPhaseWaiting, "r1")
 	oldDep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
 	newDep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
 
@@ -51,7 +52,7 @@ func TestPhasedDeployment_AllowsWhenComplete(t *testing.T) {
 	require.Nil(t, resp.Patch)
 }
 
-func TestPhasedDeployment_AllowsWithoutDependsOn(t *testing.T) {
+func TestPhasedDeployment_AllowsWithoutCanary(t *testing.T) {
 	dep := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -68,6 +69,20 @@ func TestPhasedDeployment_AllowsWithoutDependsOn(t *testing.T) {
 	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(nil, dep), nil)
 	require.True(t, resp.Allowed)
 	require.Nil(t, resp.Patch)
+}
+
+func TestPhasedDeployment_AllowsWhenBypassActive(t *testing.T) {
+	dep := phasedDeployment("b", "a", "r2", true, config.RolloutDependencyPhaseWaiting, "r2")
+	dep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
+	dep.Annotations[config.RolloutBypassUntilAnnotationKey] = time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(nil, dep), nil)
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patch)
+
+	var ops []jsonPatchOp
+	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
+	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: false})
 }
 
 func TestPhasedDeployment_PreservesPreExistingPause(t *testing.T) {
@@ -90,10 +105,10 @@ func TestPhasedDeployment_PreservesPreExistingPause(t *testing.T) {
 	require.True(t, found, "expected had-paused annotation in patch")
 }
 
-func phasedDeployment(name, dependsOn, revision string, paused bool, phase, depRevision string) *appsv1.Deployment {
+func phasedDeployment(name, canary, revision string, paused bool, phase, depRevision string) *appsv1.Deployment {
 	ann := map[string]string{
-		config.RolloutDependsOnAnnotationKey: dependsOn,
-		config.RolloutRevisionAnnotationKey:  revision,
+		config.RolloutCanaryAnnotationKey:   canary,
+		config.RolloutRevisionAnnotationKey: revision,
 	}
 	if phase != "" {
 		ann[config.RolloutDependencyPhaseAnnotationKey] = phase

--- a/pkg/admission/phased_deployment_test.go
+++ b/pkg/admission/phased_deployment_test.go
@@ -1,8 +1,10 @@
 package admission
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,8 +21,9 @@ import (
 func TestPhasedDeployment_PausesOnRevisionChange(t *testing.T) {
 	newDep := phasedDeployment("query-frontend-zone-b", "query-frontend-zone-a", "r2", false, "", "")
 	oldDep := phasedDeployment("query-frontend-zone-b", "query-frontend-zone-a", "r1", false, config.RolloutDependencyPhaseComplete, "r1")
+	var logs bytes.Buffer
 
-	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(oldDep, newDep), nil)
+	resp := PhasedDeployment(context.Background(), log.NewLogfmtLogger(&logs), admissionReview(oldDep, newDep), nil)
 	require.True(t, resp.Allowed)
 	require.NotNil(t, resp.PatchType)
 	require.NotEmpty(t, resp.Patch)
@@ -28,6 +31,9 @@ func TestPhasedDeployment_PausesOnRevisionChange(t *testing.T) {
 	var ops []jsonPatchOp
 	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
 	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+	require.True(t, strings.Contains(logs.String(), `msg="phased deployment revision change detected"`))
+	require.Contains(t, logs.String(), "previous_revision=r1")
+	require.Contains(t, logs.String(), "target_revision=r2")
 }
 
 func TestPhasedDeployment_RePausesWhileGateActive(t *testing.T) {
@@ -35,14 +41,17 @@ func TestPhasedDeployment_RePausesWhileGateActive(t *testing.T) {
 	oldDep := phasedDeployment("b", "a", "r1", true, config.RolloutDependencyPhaseWaiting, "r1")
 	oldDep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
 	newDep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
+	var logs bytes.Buffer
 
-	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(oldDep, newDep), nil)
+	resp := PhasedDeployment(context.Background(), log.NewLogfmtLogger(&logs), admissionReview(oldDep, newDep), nil)
 	require.True(t, resp.Allowed)
 	require.NotEmpty(t, resp.Patch)
 
 	var ops []jsonPatchOp
 	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
 	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+	require.Contains(t, logs.String(), `msg="re-pausing deployment while phased rollout gate is active"`)
+	require.Contains(t, logs.String(), "revision=r1")
 }
 
 func TestPhasedDeployment_AllowsWhenComplete(t *testing.T) {

--- a/pkg/admission/phased_deployment_test.go
+++ b/pkg/admission/phased_deployment_test.go
@@ -16,11 +16,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/phased"
 )
 
 func TestPhasedDeployment_PausesOnRevisionChange(t *testing.T) {
 	newDep := phasedDeployment("query-frontend-zone-b", "query-frontend-zone-a", "r2", false, "", "")
 	oldDep := phasedDeployment("query-frontend-zone-b", "query-frontend-zone-a", "r1", false, config.RolloutDependencyPhaseComplete, "r1")
+	newDep.Annotations[config.RolloutCanariesReadyRevisionAnnotationKey] = "r1"
+	oldDep.Annotations[config.RolloutCanariesReadyRevisionAnnotationKey] = "r1"
 	var logs bytes.Buffer
 
 	resp := PhasedDeployment(context.Background(), log.NewLogfmtLogger(&logs), admissionReview(oldDep, newDep), nil)
@@ -31,6 +34,7 @@ func TestPhasedDeployment_PausesOnRevisionChange(t *testing.T) {
 	var ops []jsonPatchOp
 	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
 	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+	require.Contains(t, ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(config.RolloutCanariesReadyRevisionAnnotationKey)})
 	require.True(t, strings.Contains(logs.String(), `msg="phased deployment revision change detected"`))
 	require.Contains(t, logs.String(), "previous_revision=r1")
 	require.Contains(t, logs.String(), "target_revision=r2")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,4 +61,41 @@ const (
 	// StatefulSets in the same rollout group to continue rolling out.
 	RolloutPausedAnnotationKey   = "grafana.com/rollout-paused"
 	RolloutPausedAnnotationValue = "true"
+
+	// RolloutPhasedLabelKey opts a Deployment into phased (dependency-chained) rollouts.
+	RolloutPhasedLabelKey   = "grafana.com/rollout-phased"
+	RolloutPhasedLabelValue = "true"
+
+	// RolloutDependsOnAnnotationKey names the upstream Deployment that must finish and soak
+	// before this Deployment is allowed to roll.
+	RolloutDependsOnAnnotationKey = "grafana.com/rollout-depends-on"
+
+	// RolloutRevisionAnnotationKey is a shared revision stamp set by Git/jsonnet. The operator
+	// only gates when this value changes, so zone-local template differences are ignored.
+	RolloutRevisionAnnotationKey = "grafana.com/rollout-revision"
+
+	// RolloutSoakDurationAnnotationKey overrides the default soak duration (Prometheus duration, e.g. "5m").
+	RolloutSoakDurationAnnotationKey = "grafana.com/rollout-soak-duration"
+
+	// RolloutRestartThresholdAnnotationKey overrides the default restart ratio threshold
+	// (e.g. "10%" or "0.1") evaluated at the end of the soak.
+	RolloutRestartThresholdAnnotationKey = "grafana.com/rollout-restart-threshold"
+
+	// RolloutResumeAnnotationKey, when set to the gated revision, bypasses a failed soak gate
+	// and immediately unpauses the Deployment.
+	RolloutResumeAnnotationKey = "grafana.com/rollout-resume"
+
+	// Operator-owned state annotations written by the webhook and phased Deployment controller.
+	RolloutDependencyPhaseAnnotationKey    = "grafana.com/rollout-dependency-phase"
+	RolloutDependencyRevisionAnnotationKey = "grafana.com/rollout-dependency-revision"
+	RolloutDependencyReasonAnnotationKey   = "grafana.com/rollout-dependency-reason"
+	RolloutSoakStartedAtAnnotationKey      = "grafana.com/rollout-soak-started-at"
+	RolloutRestartBaselineAnnotationKey    = "grafana.com/rollout-restart-baseline"
+	RolloutHadPausedAnnotationKey          = "grafana.com/rollout-had-paused"
+
+	// Dependency phase values.
+	RolloutDependencyPhaseWaiting  = "waiting"
+	RolloutDependencyPhaseSoaking  = "soaking"
+	RolloutDependencyPhaseBlocked  = "blocked"
+	RolloutDependencyPhaseComplete = "complete"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,10 +79,11 @@ const (
 	RolloutBypassUntilAnnotationKey = "grafana.com/rollout-bypass-until"
 
 	// Operator-owned state annotations written by the webhook and phased Deployment controller.
-	RolloutDependencyPhaseAnnotationKey    = "grafana.com/rollout-dependency-phase"
-	RolloutDependencyRevisionAnnotationKey = "grafana.com/rollout-dependency-revision"
-	RolloutDependencyReasonAnnotationKey   = "grafana.com/rollout-dependency-reason"
-	RolloutHadPausedAnnotationKey          = "grafana.com/rollout-had-paused"
+	RolloutDependencyPhaseAnnotationKey       = "grafana.com/rollout-dependency-phase"
+	RolloutDependencyRevisionAnnotationKey    = "grafana.com/rollout-dependency-revision"
+	RolloutDependencyReasonAnnotationKey      = "grafana.com/rollout-dependency-reason"
+	RolloutHadPausedAnnotationKey             = "grafana.com/rollout-had-paused"
+	RolloutCanariesReadyRevisionAnnotationKey = "grafana.com/rollout-canaries-ready-revision"
 
 	// Dependency phase values.
 	RolloutDependencyPhaseWaiting  = "waiting"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,40 +62,29 @@ const (
 	RolloutPausedAnnotationKey   = "grafana.com/rollout-paused"
 	RolloutPausedAnnotationValue = "true"
 
-	// RolloutPhasedLabelKey opts a Deployment into phased (dependency-chained) rollouts.
+	// RolloutPhasedLabelKey opts a Deployment into phased (canary-gated) rollouts.
 	RolloutPhasedLabelKey   = "grafana.com/rollout-phased"
 	RolloutPhasedLabelValue = "true"
 
-	// RolloutDependsOnAnnotationKey names the upstream Deployment that must finish and soak
-	// before this Deployment is allowed to roll.
-	RolloutDependsOnAnnotationKey = "grafana.com/rollout-depends-on"
+	// RolloutCanaryAnnotationKey names one or more canary Deployments (comma-separated) that must
+	// finish rolling before this Deployment is allowed to proceed.
+	RolloutCanaryAnnotationKey = "grafana.com/rollout-canary"
 
 	// RolloutRevisionAnnotationKey is a shared revision stamp set by Git/jsonnet. The operator
 	// only gates when this value changes, so zone-local template differences are ignored.
 	RolloutRevisionAnnotationKey = "grafana.com/rollout-revision"
 
-	// RolloutSoakDurationAnnotationKey overrides the default soak duration (Prometheus duration, e.g. "5m").
-	RolloutSoakDurationAnnotationKey = "grafana.com/rollout-soak-duration"
-
-	// RolloutRestartThresholdAnnotationKey overrides the default restart ratio threshold
-	// (e.g. "10%" or "0.1") evaluated at the end of the soak.
-	RolloutRestartThresholdAnnotationKey = "grafana.com/rollout-restart-threshold"
-
-	// RolloutResumeAnnotationKey, when set to the gated revision, bypasses a failed soak gate
-	// and immediately unpauses the Deployment.
-	RolloutResumeAnnotationKey = "grafana.com/rollout-resume"
+	// RolloutBypassUntilAnnotationKey is an RFC3339 timestamp. While now is before that time,
+	// the operator skips pausing and unpauses an already-gated Deployment.
+	RolloutBypassUntilAnnotationKey = "grafana.com/rollout-bypass-until"
 
 	// Operator-owned state annotations written by the webhook and phased Deployment controller.
 	RolloutDependencyPhaseAnnotationKey    = "grafana.com/rollout-dependency-phase"
 	RolloutDependencyRevisionAnnotationKey = "grafana.com/rollout-dependency-revision"
 	RolloutDependencyReasonAnnotationKey   = "grafana.com/rollout-dependency-reason"
-	RolloutSoakStartedAtAnnotationKey      = "grafana.com/rollout-soak-started-at"
-	RolloutRestartBaselineAnnotationKey    = "grafana.com/rollout-restart-baseline"
 	RolloutHadPausedAnnotationKey          = "grafana.com/rollout-had-paused"
 
 	// Dependency phase values.
 	RolloutDependencyPhaseWaiting  = "waiting"
-	RolloutDependencyPhaseSoaking  = "soaking"
-	RolloutDependencyPhaseBlocked  = "blocked"
 	RolloutDependencyPhaseComplete = "complete"
 )

--- a/pkg/controller/phased_deployment.go
+++ b/pkg/controller/phased_deployment.go
@@ -471,18 +471,6 @@ func (c *PhasedDeploymentController) ensurePaused(ctx context.Context, dep *apps
 	})
 }
 
-func (c *PhasedDeploymentController) patchAnnotations(ctx context.Context, name string, annotations map[string]string) error {
-	payload := make(map[string]interface{}, len(annotations))
-	for k, v := range annotations {
-		payload[k] = v
-	}
-	return c.patchDeployment(ctx, name, map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"annotations": payload,
-		},
-	})
-}
-
 func (c *PhasedDeploymentController) patchDeployment(ctx context.Context, name string, patch map[string]interface{}) error {
 	b, err := json.Marshal(patch)
 	if err != nil {

--- a/pkg/controller/phased_deployment.go
+++ b/pkg/controller/phased_deployment.go
@@ -1,0 +1,560 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/hashicorp/go-multierror"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/atomic"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	listersv1 "k8s.io/client-go/listers/apps/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/phased"
+	"github.com/grafana/rollout-operator/pkg/util"
+)
+
+// PhasedDeploymentController sequences opted-in Deployments that declare a depends-on relationship.
+type PhasedDeploymentController struct {
+	kubeClient          kubernetes.Interface
+	namespace           string
+	reconcileInterval   time.Duration
+	deploymentsFactory  informers.SharedInformerFactory
+	deploymentLister    listersv1.DeploymentLister
+	deploymentsInformer cache.SharedIndexInformer
+	podsFactory         informers.SharedInformerFactory
+	podLister           corelisters.PodLister
+	podsInformer        cache.SharedIndexInformer
+	logger              log.Logger
+
+	shouldReconcile atomic.Bool
+	stopCh          chan struct{}
+
+	phase             *prometheus.GaugeVec
+	blocked           *prometheus.GaugeVec
+	restartRatio      *prometheus.GaugeVec
+	soakRemaining     *prometheus.GaugeVec
+	reconcileTotal    prometheus.Counter
+	reconcileFailed   prometheus.Counter
+	reconcileDuration prometheus.Histogram
+}
+
+func NewPhasedDeploymentController(kubeClient kubernetes.Interface, namespace string, reconcileInterval time.Duration, reg prometheus.Registerer, logger log.Logger) *PhasedDeploymentController {
+	namespaceOpt := informers.WithNamespace(namespace)
+	deploymentsSel := labels.NewSelector().Add(util.MustNewLabelsRequirement(config.RolloutPhasedLabelKey, selection.Equals, []string{config.RolloutPhasedLabelValue})).String()
+	deploymentsSelOpt := informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+		options.LabelSelector = deploymentsSel
+	})
+
+	deploymentsFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, informerSyncInterval, namespaceOpt, deploymentsSelOpt)
+	deploymentsInformer := deploymentsFactory.Apps().V1().Deployments()
+	podsFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, informerSyncInterval, namespaceOpt)
+	podsInformer := podsFactory.Core().V1().Pods()
+
+	c := &PhasedDeploymentController{
+		kubeClient:          kubeClient,
+		namespace:           namespace,
+		reconcileInterval:   reconcileInterval,
+		deploymentsFactory:  deploymentsFactory,
+		deploymentLister:    deploymentsInformer.Lister(),
+		deploymentsInformer: deploymentsInformer.Informer(),
+		podsFactory:         podsFactory,
+		podLister:           podsInformer.Lister(),
+		podsInformer:        podsInformer.Informer(),
+		logger:              logger,
+		stopCh:              make(chan struct{}),
+		phase: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_phased_deployment_phase",
+			Help: "Current phased Deployment gate phase (1=active for labeled phase).",
+		}, []string{"deployment", "phase"}),
+		blocked: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_phased_deployment_blocked",
+			Help: "Whether a phased Deployment is blocked (1) awaiting resume.",
+		}, []string{"deployment", "reason"}),
+		restartRatio: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_phased_deployment_restart_ratio",
+			Help: "Measured container-restart ratio at the end of the last soak evaluation.",
+		}, []string{"deployment"}),
+		soakRemaining: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_phased_deployment_soak_remaining_seconds",
+			Help: "Seconds remaining in the current soak window, if soaking.",
+		}, []string{"deployment"}),
+		reconcileTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "rollout_operator_phased_deployment_reconciles_total",
+			Help: "Total number of phased Deployment reconciles started.",
+		}),
+		reconcileFailed: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "rollout_operator_phased_deployment_reconciles_failed_total",
+			Help: "Total number of phased Deployment reconciles that failed.",
+		}),
+		reconcileDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:    "rollout_operator_phased_deployment_reconcile_duration_seconds",
+			Help:    "Time spent reconciling phased Deployments.",
+			Buckets: prometheus.DefBuckets,
+		}),
+	}
+	return c
+}
+
+func (c *PhasedDeploymentController) Init() error {
+	_, err := c.deploymentsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.enqueueReconcile() },
+		UpdateFunc: func(old, new interface{}) { c.enqueueReconcile() },
+		DeleteFunc: func(obj interface{}) { c.enqueueReconcile() },
+	})
+	if err != nil {
+		return err
+	}
+	_, err = c.podsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(old, new interface{}) { c.enqueueReconcile() },
+		AddFunc:    func(obj interface{}) { c.enqueueReconcile() },
+		DeleteFunc: func(obj interface{}) { c.enqueueReconcile() },
+	})
+	if err != nil {
+		return err
+	}
+
+	go c.deploymentsFactory.Start(c.stopCh)
+	go c.podsFactory.Start(c.stopCh)
+
+	level.Info(c.logger).Log("msg", "phased deployment informer caches are syncing")
+	if ok := cache.WaitForCacheSync(c.stopCh, c.deploymentsInformer.HasSynced, c.podsInformer.HasSynced); !ok {
+		return errors.New("phased deployment informer caches failed to sync")
+	}
+	level.Info(c.logger).Log("msg", "phased deployment informer caches have synced")
+	return nil
+}
+
+func (c *PhasedDeploymentController) Run() {
+	ctx := context.Background()
+	for {
+		if c.shouldReconcile.CompareAndSwap(true, false) {
+			if err := c.reconcile(ctx); err != nil {
+				level.Warn(c.logger).Log("msg", "phased deployment reconcile failed", "err", err)
+				c.shouldReconcile.Store(true)
+			}
+		}
+		select {
+		case <-c.stopCh:
+			return
+		case <-time.After(c.reconcileInterval):
+		}
+	}
+}
+
+func (c *PhasedDeploymentController) Stop() {
+	close(c.stopCh)
+}
+
+func (c *PhasedDeploymentController) enqueueReconcile() {
+	c.shouldReconcile.Store(true)
+}
+
+func (c *PhasedDeploymentController) reconcile(ctx context.Context) error {
+	c.reconcileTotal.Inc()
+	timer := prometheus.NewTimer(c.reconcileDuration)
+	defer timer.ObserveDuration()
+
+	deps, err := c.deploymentLister.Deployments(c.namespace).List(labels.Everything())
+	if err != nil {
+		c.reconcileFailed.Inc()
+		return err
+	}
+
+	byName := make(map[string]*appsv1.Deployment, len(deps))
+	for _, d := range deps {
+		byName[d.Name] = d
+	}
+
+	var errs error
+	for _, d := range deps {
+		if err := c.reconcileDeployment(ctx, d, byName); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+	if errs != nil {
+		c.reconcileFailed.Inc()
+	}
+	return errs
+}
+
+func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, dep *appsv1.Deployment, byName map[string]*appsv1.Deployment) error {
+	dependsOn := phased.DependsOn(dep)
+	if dependsOn == "" {
+		c.clearMetrics(dep.Name)
+		return nil
+	}
+
+	revision := phased.Revision(dep)
+	if revision == "" {
+		c.setPhaseMetric(dep.Name, "missing_revision")
+		return nil
+	}
+
+	// Explicit resume for a blocked revision bypasses the failed soak immediately.
+	if phased.ResumeRevision(dep) == revision && phased.Phase(dep) == config.RolloutDependencyPhaseBlocked {
+		level.Info(c.logger).Log("msg", "resuming phased deployment after explicit resume annotation", "deployment", dep.Name, "revision", revision)
+		return c.completeGate(ctx, dep, "resumed by annotation")
+	}
+
+	if phased.Phase(dep) == config.RolloutDependencyPhaseComplete && phased.DependencyRevision(dep) == revision {
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
+		c.blocked.DeleteLabelValues(dep.Name, "restarts")
+		c.blocked.DeleteLabelValues(dep.Name, "config")
+		c.soakRemaining.DeleteLabelValues(dep.Name)
+		return nil
+	}
+
+	// Ensure gate annotations exist (webhook may not have run yet on CREATE-before-label cases).
+	if phased.NeedsNewGate(dep) || phased.Phase(dep) == "" {
+		hadPaused := phased.HadPausedAnnotationFalse
+		prevHad := annotationOrEmpty(dep, config.RolloutHadPausedAnnotationKey)
+		prevPhase := phased.Phase(dep)
+		if prevPhase != "" && prevPhase != config.RolloutDependencyPhaseComplete {
+			// Carry forward pause intent across revision changes while a gate was active.
+			if prevHad != "" {
+				hadPaused = prevHad
+			}
+		} else if dep.Spec.Paused {
+			hadPaused = phased.HadPausedAnnotationTrue
+		}
+		if err := c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseWaiting,
+					config.RolloutDependencyRevisionAnnotationKey: revision,
+					config.RolloutDependencyReasonAnnotationKey:   "waiting for upstream deployment",
+					config.RolloutHadPausedAnnotationKey:          hadPaused,
+				},
+			},
+			"spec": map[string]interface{}{
+				"paused": true,
+			},
+		}); err != nil {
+			return err
+		}
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
+		return nil
+	}
+
+	if phased.DetectDependencyCycle(dep.Name, byName) {
+		c.setPhaseMetric(dep.Name, "config_error")
+		c.blocked.WithLabelValues(dep.Name, "config").Set(1)
+		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, "dependency cycle detected")
+	}
+
+	upstream, ok := byName[dependsOn]
+	if !ok {
+		// Upstream may lack the phased label; fetch directly.
+		u, err := c.kubeClient.AppsV1().Deployments(c.namespace).Get(ctx, dependsOn, metav1.GetOptions{})
+		if err != nil {
+			c.setPhaseMetric(dep.Name, "config_error")
+			c.blocked.WithLabelValues(dep.Name, "config").Set(1)
+			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("upstream deployment %q not found", dependsOn))
+		}
+		upstream = u
+	}
+
+	if phased.Revision(upstream) != revision {
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
+		c.soakRemaining.WithLabelValues(dep.Name).Set(0)
+		c.blocked.DeleteLabelValues(dep.Name, "config")
+		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for upstream %q to reach revision %s", dependsOn, revision))
+	}
+
+	if !phased.IsFullyRolledOut(upstream) {
+		// Upstream became unhealthy during soak — reset soak when we next see it healthy.
+		if phased.Phase(dep) == config.RolloutDependencyPhaseSoaking {
+			level.Info(c.logger).Log("msg", "upstream no longer fully rolled out during soak; resetting soak", "deployment", dep.Name, "upstream", dependsOn)
+			return c.resetSoak(ctx, dep, fmt.Sprintf("waiting for upstream %q to become fully rolled out", dependsOn))
+		}
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
+		c.blocked.DeleteLabelValues(dep.Name, "config")
+		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for upstream %q to become fully rolled out", dependsOn))
+	}
+
+	soakDuration, err := phased.ParseSoakDuration(dep.Annotations)
+	if err != nil {
+		c.setPhaseMetric(dep.Name, "config_error")
+		c.blocked.WithLabelValues(dep.Name, "config").Set(1)
+		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, err.Error())
+	}
+	threshold, err := phased.ParseRestartThreshold(dep.Annotations)
+	if err != nil {
+		c.setPhaseMetric(dep.Name, "config_error")
+		c.blocked.WithLabelValues(dep.Name, "config").Set(1)
+		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, err.Error())
+	}
+
+	// Restart failures stay blocked until an explicit resume for this revision.
+	if phased.Phase(dep) == config.RolloutDependencyPhaseBlocked {
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseBlocked)
+		c.blocked.WithLabelValues(dep.Name, "restarts").Set(1)
+		c.blocked.DeleteLabelValues(dep.Name, "config")
+		c.soakRemaining.WithLabelValues(dep.Name).Set(0)
+		return c.ensurePaused(ctx, dep)
+	}
+
+	soakStartedAt, hasSoak := parseSoakStartedAt(dep)
+	if !hasSoak || phased.Phase(dep) != config.RolloutDependencyPhaseSoaking {
+		return c.startSoak(ctx, dep, upstream)
+	}
+
+	remaining := soakDuration - time.Since(soakStartedAt)
+	if remaining > 0 {
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseSoaking)
+		c.soakRemaining.WithLabelValues(dep.Name).Set(remaining.Seconds())
+		return c.ensurePaused(ctx, dep)
+	}
+	c.soakRemaining.WithLabelValues(dep.Name).Set(0)
+
+	// Soak finished: evaluate restart ratio once.
+	pods, err := c.listDeploymentPods(upstream)
+	if err != nil {
+		return err
+	}
+	baseline, err := phased.DecodeRestartBaseline(annotationOrEmpty(dep, config.RolloutRestartBaselineAnnotationKey))
+	if err != nil {
+		return fmt.Errorf("decode restart baseline for %s: %w", dep.Name, err)
+	}
+	ratio := phased.RestartRatio(pods, baseline)
+	c.restartRatio.WithLabelValues(dep.Name).Set(ratio)
+
+	if phased.ExceedsRestartThreshold(ratio, threshold) {
+		level.Warn(c.logger).Log(
+			"msg", "phased deployment blocked by restart threshold",
+			"deployment", dep.Name,
+			"upstream", dependsOn,
+			"restart_ratio", ratio,
+			"threshold", threshold,
+		)
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseBlocked)
+		c.blocked.WithLabelValues(dep.Name, "restarts").Set(1)
+		return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					config.RolloutDependencyPhaseAnnotationKey:  config.RolloutDependencyPhaseBlocked,
+					config.RolloutDependencyReasonAnnotationKey: fmt.Sprintf("restart ratio %.4f >= threshold %.4f", ratio, threshold),
+				},
+			},
+			"spec": map[string]interface{}{
+				"paused": true,
+			},
+		})
+	}
+
+	level.Info(c.logger).Log(
+		"msg", "phased deployment soak passed",
+		"deployment", dep.Name,
+		"upstream", dependsOn,
+		"restart_ratio", ratio,
+		"threshold", threshold,
+	)
+	c.blocked.DeleteLabelValues(dep.Name, "restarts")
+	return c.completeGate(ctx, dep, fmt.Sprintf("soak passed (restart ratio %.4f)", ratio))
+}
+
+func (c *PhasedDeploymentController) startSoak(ctx context.Context, dep, upstream *appsv1.Deployment) error {
+	pods, err := c.listDeploymentPods(upstream)
+	if err != nil {
+		return err
+	}
+	baseline, err := phased.EncodeRestartBaseline(phased.BuildRestartBaseline(pods))
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	level.Info(c.logger).Log("msg", "starting phased deployment soak", "deployment", dep.Name, "upstream", upstream.Name, "pods", len(pods))
+	c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseSoaking)
+	c.blocked.DeleteLabelValues(dep.Name, "config")
+	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				config.RolloutDependencyPhaseAnnotationKey:  config.RolloutDependencyPhaseSoaking,
+				config.RolloutDependencyReasonAnnotationKey: fmt.Sprintf("soaking upstream %q", upstream.Name),
+				config.RolloutSoakStartedAtAnnotationKey:    now,
+				config.RolloutRestartBaselineAnnotationKey:  baseline,
+			},
+		},
+		"spec": map[string]interface{}{
+			"paused": true,
+		},
+	})
+}
+
+func (c *PhasedDeploymentController) resetSoak(ctx context.Context, dep *appsv1.Deployment, reason string) error {
+	c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
+	c.soakRemaining.WithLabelValues(dep.Name).Set(0)
+	annotations := map[string]interface{}{
+		config.RolloutDependencyPhaseAnnotationKey:  config.RolloutDependencyPhaseWaiting,
+		config.RolloutDependencyReasonAnnotationKey: reason,
+		config.RolloutSoakStartedAtAnnotationKey:    nil,
+		config.RolloutRestartBaselineAnnotationKey:  nil,
+	}
+	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": annotations,
+		},
+		"spec": map[string]interface{}{
+			"paused": true,
+		},
+	})
+}
+
+func (c *PhasedDeploymentController) completeGate(ctx context.Context, dep *appsv1.Deployment, reason string) error {
+	hadPaused := annotationOrEmpty(dep, config.RolloutHadPausedAnnotationKey) == phased.HadPausedAnnotationTrue
+	paused := hadPaused
+	c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
+	c.blocked.DeleteLabelValues(dep.Name, "restarts")
+	c.blocked.DeleteLabelValues(dep.Name, "config")
+	c.soakRemaining.WithLabelValues(dep.Name).Set(0)
+
+	annotations := map[string]interface{}{
+		config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseComplete,
+		config.RolloutDependencyRevisionAnnotationKey: phased.Revision(dep),
+		config.RolloutDependencyReasonAnnotationKey:   reason,
+		config.RolloutSoakStartedAtAnnotationKey:      nil,
+		config.RolloutRestartBaselineAnnotationKey:    nil,
+		config.RolloutResumeAnnotationKey:             nil,
+	}
+	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": annotations,
+		},
+		"spec": map[string]interface{}{
+			"paused": paused,
+		},
+	})
+}
+
+func (c *PhasedDeploymentController) ensurePhase(ctx context.Context, dep *appsv1.Deployment, phase, reason string) error {
+	if phased.Phase(dep) == phase && annotationOrEmpty(dep, config.RolloutDependencyReasonAnnotationKey) == reason && dep.Spec.Paused {
+		return nil
+	}
+	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				config.RolloutDependencyPhaseAnnotationKey:  phase,
+				config.RolloutDependencyReasonAnnotationKey: reason,
+			},
+		},
+		"spec": map[string]interface{}{
+			"paused": true,
+		},
+	})
+}
+
+func (c *PhasedDeploymentController) ensurePaused(ctx context.Context, dep *appsv1.Deployment) error {
+	if dep.Spec.Paused {
+		return nil
+	}
+	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+		"spec": map[string]interface{}{
+			"paused": true,
+		},
+	})
+}
+
+func (c *PhasedDeploymentController) patchAnnotations(ctx context.Context, name string, annotations map[string]string) error {
+	payload := make(map[string]interface{}, len(annotations))
+	for k, v := range annotations {
+		payload[k] = v
+	}
+	return c.patchDeployment(ctx, name, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": payload,
+		},
+	})
+}
+
+func (c *PhasedDeploymentController) patchDeployment(ctx context.Context, name string, patch map[string]interface{}) error {
+	b, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+	_, err = c.kubeClient.AppsV1().Deployments(c.namespace).Patch(ctx, name, types.MergePatchType, b, metav1.PatchOptions{
+		FieldManager: "rollout-operator",
+	})
+	return err
+}
+
+func (c *PhasedDeploymentController) listDeploymentPods(dep *appsv1.Deployment) ([]*corev1.Pod, error) {
+	if dep.Spec.Selector == nil {
+		return nil, nil
+	}
+	selector, err := metav1.LabelSelectorAsSelector(dep.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+	pods, err := c.podLister.Pods(c.namespace).List(selector)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*corev1.Pod, 0, len(pods))
+	for _, p := range pods {
+		if p.DeletionTimestamp != nil {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+func (c *PhasedDeploymentController) setPhaseMetric(name, phase string) {
+	for _, p := range []string{
+		config.RolloutDependencyPhaseWaiting,
+		config.RolloutDependencyPhaseSoaking,
+		config.RolloutDependencyPhaseBlocked,
+		config.RolloutDependencyPhaseComplete,
+		"config_error",
+		"missing_revision",
+	} {
+		if p == phase {
+			c.phase.WithLabelValues(name, p).Set(1)
+		} else {
+			c.phase.WithLabelValues(name, p).Set(0)
+		}
+	}
+}
+
+func (c *PhasedDeploymentController) clearMetrics(name string) {
+	c.phase.DeletePartialMatch(prometheus.Labels{"deployment": name})
+	c.blocked.DeletePartialMatch(prometheus.Labels{"deployment": name})
+	c.restartRatio.DeleteLabelValues(name)
+	c.soakRemaining.DeleteLabelValues(name)
+}
+
+func annotationOrEmpty(dep *appsv1.Deployment, key string) string {
+	if dep.Annotations == nil {
+		return ""
+	}
+	return dep.Annotations[key]
+}
+
+func parseSoakStartedAt(dep *appsv1.Deployment) (time.Time, bool) {
+	raw := annotationOrEmpty(dep, config.RolloutSoakStartedAtAnnotationKey)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}

--- a/pkg/controller/phased_deployment.go
+++ b/pkg/controller/phased_deployment.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log"
@@ -22,7 +23,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/apps/v1"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/grafana/rollout-operator/pkg/config"
@@ -30,7 +30,12 @@ import (
 	"github.com/grafana/rollout-operator/pkg/util"
 )
 
-// PhasedDeploymentController sequences opted-in Deployments that declare a depends-on relationship.
+const (
+	bypassEventReason = "RolloutBypass"
+	bypassEventSource = "rollout-operator"
+)
+
+// PhasedDeploymentController sequences opted-in Deployments that declare canary dependencies.
 type PhasedDeploymentController struct {
 	kubeClient          kubernetes.Interface
 	namespace           string
@@ -38,18 +43,16 @@ type PhasedDeploymentController struct {
 	deploymentsFactory  informers.SharedInformerFactory
 	deploymentLister    listersv1.DeploymentLister
 	deploymentsInformer cache.SharedIndexInformer
-	podsFactory         informers.SharedInformerFactory
-	podLister           corelisters.PodLister
-	podsInformer        cache.SharedIndexInformer
 	logger              log.Logger
+	now                 func() time.Time
 
 	shouldReconcile atomic.Bool
 	stopCh          chan struct{}
 
 	phase             *prometheus.GaugeVec
 	blocked           *prometheus.GaugeVec
-	restartRatio      *prometheus.GaugeVec
-	soakRemaining     *prometheus.GaugeVec
+	bypassActive      *prometheus.GaugeVec
+	bypassTotal       *prometheus.CounterVec
 	reconcileTotal    prometheus.Counter
 	reconcileFailed   prometheus.Counter
 	reconcileDuration prometheus.Histogram
@@ -64,8 +67,6 @@ func NewPhasedDeploymentController(kubeClient kubernetes.Interface, namespace st
 
 	deploymentsFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, informerSyncInterval, namespaceOpt, deploymentsSelOpt)
 	deploymentsInformer := deploymentsFactory.Apps().V1().Deployments()
-	podsFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, informerSyncInterval, namespaceOpt)
-	podsInformer := podsFactory.Core().V1().Pods()
 
 	c := &PhasedDeploymentController{
 		kubeClient:          kubeClient,
@@ -74,10 +75,8 @@ func NewPhasedDeploymentController(kubeClient kubernetes.Interface, namespace st
 		deploymentsFactory:  deploymentsFactory,
 		deploymentLister:    deploymentsInformer.Lister(),
 		deploymentsInformer: deploymentsInformer.Informer(),
-		podsFactory:         podsFactory,
-		podLister:           podsInformer.Lister(),
-		podsInformer:        podsInformer.Informer(),
 		logger:              logger,
+		now:                 time.Now,
 		stopCh:              make(chan struct{}),
 		phase: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "rollout_operator_phased_deployment_phase",
@@ -85,15 +84,15 @@ func NewPhasedDeploymentController(kubeClient kubernetes.Interface, namespace st
 		}, []string{"deployment", "phase"}),
 		blocked: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "rollout_operator_phased_deployment_blocked",
-			Help: "Whether a phased Deployment is blocked (1) awaiting resume.",
+			Help: "Whether a phased Deployment is blocked (1) due to a config error.",
 		}, []string{"deployment", "reason"}),
-		restartRatio: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "rollout_operator_phased_deployment_restart_ratio",
-			Help: "Measured container-restart ratio at the end of the last soak evaluation.",
+		bypassActive: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_phased_deployment_bypass_active",
+			Help: "Whether a time-limited rollout bypass is currently active (1).",
 		}, []string{"deployment"}),
-		soakRemaining: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "rollout_operator_phased_deployment_soak_remaining_seconds",
-			Help: "Seconds remaining in the current soak window, if soaking.",
+		bypassTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "rollout_operator_phased_deployment_bypass_total",
+			Help: "Total number of times a phased Deployment used a time-limited rollout bypass.",
 		}, []string{"deployment"}),
 		reconcileTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "rollout_operator_phased_deployment_reconciles_total",
@@ -121,20 +120,11 @@ func (c *PhasedDeploymentController) Init() error {
 	if err != nil {
 		return err
 	}
-	_, err = c.podsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(old, new interface{}) { c.enqueueReconcile() },
-		AddFunc:    func(obj interface{}) { c.enqueueReconcile() },
-		DeleteFunc: func(obj interface{}) { c.enqueueReconcile() },
-	})
-	if err != nil {
-		return err
-	}
 
 	go c.deploymentsFactory.Start(c.stopCh)
-	go c.podsFactory.Start(c.stopCh)
 
 	level.Info(c.logger).Log("msg", "phased deployment informer caches are syncing")
-	if ok := cache.WaitForCacheSync(c.stopCh, c.deploymentsInformer.HasSynced, c.podsInformer.HasSynced); !ok {
+	if ok := cache.WaitForCacheSync(c.stopCh, c.deploymentsInformer.HasSynced); !ok {
 		return errors.New("phased deployment informer caches failed to sync")
 	}
 	level.Info(c.logger).Log("msg", "phased deployment informer caches have synced")
@@ -195,8 +185,8 @@ func (c *PhasedDeploymentController) reconcile(ctx context.Context) error {
 }
 
 func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, dep *appsv1.Deployment, byName map[string]*appsv1.Deployment) error {
-	dependsOn := phased.DependsOn(dep)
-	if dependsOn == "" {
+	canaries := phased.Canaries(dep)
+	if len(canaries) == 0 {
 		c.clearMetrics(dep.Name)
 		return nil
 	}
@@ -204,20 +194,37 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 	revision := phased.Revision(dep)
 	if revision == "" {
 		c.setPhaseMetric(dep.Name, "missing_revision")
+		c.bypassActive.WithLabelValues(dep.Name).Set(0)
 		return nil
 	}
 
-	// Explicit resume for a blocked revision bypasses the failed soak immediately.
-	if phased.ResumeRevision(dep) == revision && phased.Phase(dep) == config.RolloutDependencyPhaseBlocked {
-		level.Info(c.logger).Log("msg", "resuming phased deployment after explicit resume annotation", "deployment", dep.Name, "revision", revision)
-		return c.completeGate(ctx, dep, "resumed by annotation")
+	now := c.now()
+	if _, _, err := phased.BypassUntil(dep); err != nil {
+		level.Warn(c.logger).Log("msg", "invalid rollout-bypass-until, ignoring", "deployment", dep.Name, "err", err)
 	}
+	if phased.BypassActive(dep, now) {
+		c.bypassActive.WithLabelValues(dep.Name).Set(1)
+		needsBypassApply := phased.Phase(dep) != config.RolloutDependencyPhaseComplete ||
+			phased.DependencyRevision(dep) != revision ||
+			(dep.Spec.Paused && annotationOrEmpty(dep, config.RolloutHadPausedAnnotationKey) != phased.HadPausedAnnotationTrue)
+		if needsBypassApply {
+			level.Info(c.logger).Log("msg", "applying phased deployment bypass", "deployment", dep.Name, "revision", revision)
+			if err := c.completeGate(ctx, dep, fmt.Sprintf("bypassed until %s", annotationOrEmpty(dep, config.RolloutBypassUntilAnnotationKey))); err != nil {
+				return err
+			}
+			c.bypassTotal.WithLabelValues(dep.Name).Inc()
+			c.emitBypassEvent(ctx, dep, revision)
+			return nil
+		}
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
+		c.blocked.DeleteLabelValues(dep.Name, "config")
+		return nil
+	}
+	c.bypassActive.WithLabelValues(dep.Name).Set(0)
 
 	if phased.Phase(dep) == config.RolloutDependencyPhaseComplete && phased.DependencyRevision(dep) == revision {
 		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
-		c.blocked.DeleteLabelValues(dep.Name, "restarts")
 		c.blocked.DeleteLabelValues(dep.Name, "config")
-		c.soakRemaining.DeleteLabelValues(dep.Name)
 		return nil
 	}
 
@@ -239,7 +246,7 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 				"annotations": map[string]interface{}{
 					config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseWaiting,
 					config.RolloutDependencyRevisionAnnotationKey: revision,
-					config.RolloutDependencyReasonAnnotationKey:   "waiting for upstream deployment",
+					config.RolloutDependencyReasonAnnotationKey:   "waiting for canary deployment(s)",
 					config.RolloutHadPausedAnnotationKey:          hadPaused,
 				},
 			},
@@ -259,179 +266,57 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, "dependency cycle detected")
 	}
 
-	upstream, ok := byName[dependsOn]
-	if !ok {
-		// Upstream may lack the phased label; fetch directly.
-		u, err := c.kubeClient.AppsV1().Deployments(c.namespace).Get(ctx, dependsOn, metav1.GetOptions{})
+	for _, canaryName := range canaries {
+		canary, err := c.getCanary(ctx, canaryName, byName)
 		if err != nil {
 			c.setPhaseMetric(dep.Name, "config_error")
 			c.blocked.WithLabelValues(dep.Name, "config").Set(1)
-			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("upstream deployment %q not found", dependsOn))
+			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, err.Error())
 		}
-		upstream = u
-	}
-
-	if phased.Revision(upstream) != revision {
-		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
-		c.soakRemaining.WithLabelValues(dep.Name).Set(0)
-		c.blocked.DeleteLabelValues(dep.Name, "config")
-		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for upstream %q to reach revision %s", dependsOn, revision))
-	}
-
-	if !phased.IsFullyRolledOut(upstream) {
-		// Upstream became unhealthy during soak — reset soak when we next see it healthy.
-		if phased.Phase(dep) == config.RolloutDependencyPhaseSoaking {
-			level.Info(c.logger).Log("msg", "upstream no longer fully rolled out during soak; resetting soak", "deployment", dep.Name, "upstream", dependsOn)
-			return c.resetSoak(ctx, dep, fmt.Sprintf("waiting for upstream %q to become fully rolled out", dependsOn))
+		if phased.Revision(canary) != revision {
+			c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
+			c.blocked.DeleteLabelValues(dep.Name, "config")
+			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for canary %q to reach revision %s", canaryName, revision))
 		}
-		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
-		c.blocked.DeleteLabelValues(dep.Name, "config")
-		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for upstream %q to become fully rolled out", dependsOn))
-	}
-
-	soakDuration, err := phased.ParseSoakDuration(dep.Annotations)
-	if err != nil {
-		c.setPhaseMetric(dep.Name, "config_error")
-		c.blocked.WithLabelValues(dep.Name, "config").Set(1)
-		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, err.Error())
-	}
-	threshold, err := phased.ParseRestartThreshold(dep.Annotations)
-	if err != nil {
-		c.setPhaseMetric(dep.Name, "config_error")
-		c.blocked.WithLabelValues(dep.Name, "config").Set(1)
-		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, err.Error())
-	}
-
-	// Restart failures stay blocked until an explicit resume for this revision.
-	if phased.Phase(dep) == config.RolloutDependencyPhaseBlocked {
-		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseBlocked)
-		c.blocked.WithLabelValues(dep.Name, "restarts").Set(1)
-		c.blocked.DeleteLabelValues(dep.Name, "config")
-		c.soakRemaining.WithLabelValues(dep.Name).Set(0)
-		return c.ensurePaused(ctx, dep)
-	}
-
-	soakStartedAt, hasSoak := parseSoakStartedAt(dep)
-	if !hasSoak || phased.Phase(dep) != config.RolloutDependencyPhaseSoaking {
-		return c.startSoak(ctx, dep, upstream)
-	}
-
-	remaining := soakDuration - time.Since(soakStartedAt)
-	if remaining > 0 {
-		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseSoaking)
-		c.soakRemaining.WithLabelValues(dep.Name).Set(remaining.Seconds())
-		return c.ensurePaused(ctx, dep)
-	}
-	c.soakRemaining.WithLabelValues(dep.Name).Set(0)
-
-	// Soak finished: evaluate restart ratio once.
-	pods, err := c.listDeploymentPods(upstream)
-	if err != nil {
-		return err
-	}
-	baseline, err := phased.DecodeRestartBaseline(annotationOrEmpty(dep, config.RolloutRestartBaselineAnnotationKey))
-	if err != nil {
-		return fmt.Errorf("decode restart baseline for %s: %w", dep.Name, err)
-	}
-	ratio := phased.RestartRatio(pods, baseline)
-	c.restartRatio.WithLabelValues(dep.Name).Set(ratio)
-
-	if phased.ExceedsRestartThreshold(ratio, threshold) {
-		level.Warn(c.logger).Log(
-			"msg", "phased deployment blocked by restart threshold",
-			"deployment", dep.Name,
-			"upstream", dependsOn,
-			"restart_ratio", ratio,
-			"threshold", threshold,
-		)
-		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseBlocked)
-		c.blocked.WithLabelValues(dep.Name, "restarts").Set(1)
-		return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"annotations": map[string]interface{}{
-					config.RolloutDependencyPhaseAnnotationKey:  config.RolloutDependencyPhaseBlocked,
-					config.RolloutDependencyReasonAnnotationKey: fmt.Sprintf("restart ratio %.4f >= threshold %.4f", ratio, threshold),
-				},
-			},
-			"spec": map[string]interface{}{
-				"paused": true,
-			},
-		})
+		if !phased.IsFullyRolledOut(canary) {
+			c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
+			c.blocked.DeleteLabelValues(dep.Name, "config")
+			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for canary %q to become fully rolled out", canaryName))
+		}
 	}
 
 	level.Info(c.logger).Log(
-		"msg", "phased deployment soak passed",
+		"msg", "phased deployment canaries ready",
 		"deployment", dep.Name,
-		"upstream", dependsOn,
-		"restart_ratio", ratio,
-		"threshold", threshold,
+		"canaries", strings.Join(canaries, ","),
+		"revision", revision,
 	)
-	c.blocked.DeleteLabelValues(dep.Name, "restarts")
-	return c.completeGate(ctx, dep, fmt.Sprintf("soak passed (restart ratio %.4f)", ratio))
-}
-
-func (c *PhasedDeploymentController) startSoak(ctx context.Context, dep, upstream *appsv1.Deployment) error {
-	pods, err := c.listDeploymentPods(upstream)
-	if err != nil {
-		return err
-	}
-	baseline, err := phased.EncodeRestartBaseline(phased.BuildRestartBaseline(pods))
-	if err != nil {
-		return err
-	}
-	now := time.Now().UTC().Format(time.RFC3339)
-	level.Info(c.logger).Log("msg", "starting phased deployment soak", "deployment", dep.Name, "upstream", upstream.Name, "pods", len(pods))
-	c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseSoaking)
 	c.blocked.DeleteLabelValues(dep.Name, "config")
-	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"annotations": map[string]interface{}{
-				config.RolloutDependencyPhaseAnnotationKey:  config.RolloutDependencyPhaseSoaking,
-				config.RolloutDependencyReasonAnnotationKey: fmt.Sprintf("soaking upstream %q", upstream.Name),
-				config.RolloutSoakStartedAtAnnotationKey:    now,
-				config.RolloutRestartBaselineAnnotationKey:  baseline,
-			},
-		},
-		"spec": map[string]interface{}{
-			"paused": true,
-		},
-	})
+	return c.completeGate(ctx, dep, fmt.Sprintf("canaries ready: %s", strings.Join(canaries, ",")))
 }
 
-func (c *PhasedDeploymentController) resetSoak(ctx context.Context, dep *appsv1.Deployment, reason string) error {
-	c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
-	c.soakRemaining.WithLabelValues(dep.Name).Set(0)
-	annotations := map[string]interface{}{
-		config.RolloutDependencyPhaseAnnotationKey:  config.RolloutDependencyPhaseWaiting,
-		config.RolloutDependencyReasonAnnotationKey: reason,
-		config.RolloutSoakStartedAtAnnotationKey:    nil,
-		config.RolloutRestartBaselineAnnotationKey:  nil,
+func (c *PhasedDeploymentController) getCanary(ctx context.Context, name string, byName map[string]*appsv1.Deployment) (*appsv1.Deployment, error) {
+	if d, ok := byName[name]; ok {
+		return d, nil
 	}
-	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"annotations": annotations,
-		},
-		"spec": map[string]interface{}{
-			"paused": true,
-		},
-	})
+	// Canary may lack the phased label; fetch directly.
+	d, err := c.kubeClient.AppsV1().Deployments(c.namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("canary deployment %q not found: %w", name, err)
+	}
+	return d, nil
 }
 
 func (c *PhasedDeploymentController) completeGate(ctx context.Context, dep *appsv1.Deployment, reason string) error {
 	hadPaused := annotationOrEmpty(dep, config.RolloutHadPausedAnnotationKey) == phased.HadPausedAnnotationTrue
 	paused := hadPaused
 	c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
-	c.blocked.DeleteLabelValues(dep.Name, "restarts")
 	c.blocked.DeleteLabelValues(dep.Name, "config")
-	c.soakRemaining.WithLabelValues(dep.Name).Set(0)
 
 	annotations := map[string]interface{}{
 		config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseComplete,
 		config.RolloutDependencyRevisionAnnotationKey: phased.Revision(dep),
 		config.RolloutDependencyReasonAnnotationKey:   reason,
-		config.RolloutSoakStartedAtAnnotationKey:      nil,
-		config.RolloutRestartBaselineAnnotationKey:    nil,
-		config.RolloutResumeAnnotationKey:             nil,
 	}
 	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
 		"metadata": map[string]interface{}{
@@ -460,17 +345,6 @@ func (c *PhasedDeploymentController) ensurePhase(ctx context.Context, dep *appsv
 	})
 }
 
-func (c *PhasedDeploymentController) ensurePaused(ctx context.Context, dep *appsv1.Deployment) error {
-	if dep.Spec.Paused {
-		return nil
-	}
-	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
-		"spec": map[string]interface{}{
-			"paused": true,
-		},
-	})
-}
-
 func (c *PhasedDeploymentController) patchDeployment(ctx context.Context, name string, patch map[string]interface{}) error {
 	b, err := json.Marshal(patch)
 	if err != nil {
@@ -482,33 +356,42 @@ func (c *PhasedDeploymentController) patchDeployment(ctx context.Context, name s
 	return err
 }
 
-func (c *PhasedDeploymentController) listDeploymentPods(dep *appsv1.Deployment) ([]*corev1.Pod, error) {
-	if dep.Spec.Selector == nil {
-		return nil, nil
+func (c *PhasedDeploymentController) emitBypassEvent(ctx context.Context, dep *appsv1.Deployment, revision string) {
+	until := annotationOrEmpty(dep, config.RolloutBypassUntilAnnotationKey)
+	msg := fmt.Sprintf("phased rollout bypassed for revision %s until %s", revision, until)
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s.bypass.%d", dep.Name, c.now().UnixNano()),
+			Namespace: c.namespace,
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:            "Deployment",
+			Namespace:       dep.Namespace,
+			Name:            dep.Name,
+			UID:             dep.UID,
+			APIVersion:      "apps/v1",
+			ResourceVersion: dep.ResourceVersion,
+		},
+		Reason:  bypassEventReason,
+		Message: msg,
+		Source:  corev1.EventSource{Component: bypassEventSource},
+		Type:    corev1.EventTypeWarning,
+		Count:   1,
+		FirstTimestamp: metav1.Time{
+			Time: c.now(),
+		},
+		LastTimestamp: metav1.Time{
+			Time: c.now(),
+		},
 	}
-	selector, err := metav1.LabelSelectorAsSelector(dep.Spec.Selector)
-	if err != nil {
-		return nil, err
+	if _, err := c.kubeClient.CoreV1().Events(c.namespace).Create(ctx, event, metav1.CreateOptions{}); err != nil {
+		level.Warn(c.logger).Log("msg", "failed to emit phased rollout bypass event", "deployment", dep.Name, "err", err)
 	}
-	pods, err := c.podLister.Pods(c.namespace).List(selector)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]*corev1.Pod, 0, len(pods))
-	for _, p := range pods {
-		if p.DeletionTimestamp != nil {
-			continue
-		}
-		out = append(out, p)
-	}
-	return out, nil
 }
 
 func (c *PhasedDeploymentController) setPhaseMetric(name, phase string) {
 	for _, p := range []string{
 		config.RolloutDependencyPhaseWaiting,
-		config.RolloutDependencyPhaseSoaking,
-		config.RolloutDependencyPhaseBlocked,
 		config.RolloutDependencyPhaseComplete,
 		"config_error",
 		"missing_revision",
@@ -524,8 +407,7 @@ func (c *PhasedDeploymentController) setPhaseMetric(name, phase string) {
 func (c *PhasedDeploymentController) clearMetrics(name string) {
 	c.phase.DeletePartialMatch(prometheus.Labels{"deployment": name})
 	c.blocked.DeletePartialMatch(prometheus.Labels{"deployment": name})
-	c.restartRatio.DeleteLabelValues(name)
-	c.soakRemaining.DeleteLabelValues(name)
+	c.bypassActive.DeleteLabelValues(name)
 }
 
 func annotationOrEmpty(dep *appsv1.Deployment, key string) string {
@@ -533,16 +415,4 @@ func annotationOrEmpty(dep *appsv1.Deployment, key string) string {
 		return ""
 	}
 	return dep.Annotations[key]
-}
-
-func parseSoakStartedAt(dep *appsv1.Deployment) (time.Time, bool) {
-	raw := annotationOrEmpty(dep, config.RolloutSoakStartedAtAnnotationKey)
-	if raw == "" {
-		return time.Time{}, false
-	}
-	t, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		return time.Time{}, false
-	}
-	return t, true
 }

--- a/pkg/controller/phased_deployment.go
+++ b/pkg/controller/phased_deployment.go
@@ -192,15 +192,26 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 	}
 
 	revision := phased.Revision(dep)
+	level.Debug(c.logger).Log(
+		"msg", "reconciling phased deployment",
+		"deployment", dep.Name,
+		"revision", revision,
+		"gated_revision", phased.DependencyRevision(dep),
+		"phase", phased.Phase(dep),
+		"paused", dep.Spec.Paused,
+		"canaries", strings.Join(canaries, ","),
+	)
 	if revision == "" {
 		c.setPhaseMetric(dep.Name, "missing_revision")
 		c.bypassActive.WithLabelValues(dep.Name).Set(0)
+		level.Debug(c.logger).Log("msg", "phased deployment cannot be gated without rollout revision", "deployment", dep.Name)
 		return nil
 	}
 
 	now := c.now()
-	if _, _, err := phased.BypassUntil(dep); err != nil {
-		level.Warn(c.logger).Log("msg", "invalid rollout-bypass-until, ignoring", "deployment", dep.Name, "err", err)
+	bypassUntil, bypassSet, bypassErr := phased.BypassUntil(dep)
+	if bypassErr != nil {
+		level.Warn(c.logger).Log("msg", "invalid rollout-bypass-until, ignoring", "deployment", dep.Name, "err", bypassErr)
 	}
 	if phased.BypassActive(dep, now) {
 		c.bypassActive.WithLabelValues(dep.Name).Set(1)
@@ -208,7 +219,14 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 			phased.DependencyRevision(dep) != revision ||
 			(dep.Spec.Paused && annotationOrEmpty(dep, config.RolloutHadPausedAnnotationKey) != phased.HadPausedAnnotationTrue)
 		if needsBypassApply {
-			level.Info(c.logger).Log("msg", "applying phased deployment bypass", "deployment", dep.Name, "revision", revision)
+			level.Warn(c.logger).Log(
+				"msg", "applying phased deployment bypass",
+				"deployment", dep.Name,
+				"revision", revision,
+				"bypass_until", bypassUntil.Format(time.RFC3339),
+				"phase", phased.Phase(dep),
+				"paused", dep.Spec.Paused,
+			)
 			if err := c.completeGate(ctx, dep, fmt.Sprintf("bypassed until %s", annotationOrEmpty(dep, config.RolloutBypassUntilAnnotationKey))); err != nil {
 				return err
 			}
@@ -218,13 +236,28 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 		}
 		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
 		c.blocked.DeleteLabelValues(dep.Name, "config")
+		level.Debug(c.logger).Log(
+			"msg", "phased deployment bypass remains active",
+			"deployment", dep.Name,
+			"revision", revision,
+			"bypass_until", bypassUntil.Format(time.RFC3339),
+		)
 		return nil
 	}
 	c.bypassActive.WithLabelValues(dep.Name).Set(0)
+	if bypassSet && bypassErr == nil {
+		level.Debug(c.logger).Log(
+			"msg", "phased deployment bypass is expired",
+			"deployment", dep.Name,
+			"revision", revision,
+			"bypass_until", bypassUntil.Format(time.RFC3339),
+		)
+	}
 
 	if phased.Phase(dep) == config.RolloutDependencyPhaseComplete && phased.DependencyRevision(dep) == revision {
 		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
 		c.blocked.DeleteLabelValues(dep.Name, "config")
+		level.Debug(c.logger).Log("msg", "phased deployment may proceed", "deployment", dep.Name, "revision", revision, "paused", dep.Spec.Paused)
 		return nil
 	}
 
@@ -241,6 +274,15 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 		} else if dep.Spec.Paused {
 			hadPaused = phased.HadPausedAnnotationTrue
 		}
+		level.Info(c.logger).Log(
+			"msg", "starting phased deployment gate",
+			"deployment", dep.Name,
+			"previous_revision", phased.DependencyRevision(dep),
+			"target_revision", revision,
+			"previous_phase", prevPhase,
+			"canaries", strings.Join(canaries, ","),
+			"had_paused", hadPaused,
+		)
 		if err := c.patchDeployment(ctx, dep.Name, map[string]interface{}{
 			"metadata": map[string]interface{}{
 				"annotations": map[string]interface{}{
@@ -273,12 +315,29 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 			c.blocked.WithLabelValues(dep.Name, "config").Set(1)
 			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, err.Error())
 		}
-		if phased.Revision(canary) != revision {
+		canaryRevision := phased.Revision(canary)
+		canaryReady := phased.IsFullyRolledOut(canary)
+		level.Debug(c.logger).Log(
+			"msg", "checking phased deployment canary",
+			"deployment", dep.Name,
+			"canary", canaryName,
+			"current_revision", canaryRevision,
+			"target_revision", revision,
+			"ready", canaryReady,
+			"paused", canary.Spec.Paused,
+			"generation", canary.Generation,
+			"observed_generation", canary.Status.ObservedGeneration,
+			"replicas", valueOrDefault(canary.Spec.Replicas, 1),
+			"updated_replicas", canary.Status.UpdatedReplicas,
+			"ready_replicas", canary.Status.ReadyReplicas,
+			"available_replicas", canary.Status.AvailableReplicas,
+		)
+		if canaryRevision != revision {
 			c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
 			c.blocked.DeleteLabelValues(dep.Name, "config")
 			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for canary %q to reach revision %s", canaryName, revision))
 		}
-		if !phased.IsFullyRolledOut(canary) {
+		if !canaryReady {
 			c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
 			c.blocked.DeleteLabelValues(dep.Name, "config")
 			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for canary %q to become fully rolled out", canaryName))
@@ -318,6 +377,17 @@ func (c *PhasedDeploymentController) completeGate(ctx context.Context, dep *apps
 		config.RolloutDependencyRevisionAnnotationKey: phased.Revision(dep),
 		config.RolloutDependencyReasonAnnotationKey:   reason,
 	}
+	action := "unpause-and-proceed"
+	if hadPaused {
+		action = "preserve-pause"
+	}
+	level.Info(c.logger).Log(
+		"msg", "completing phased deployment gate",
+		"deployment", dep.Name,
+		"revision", phased.Revision(dep),
+		"reason", reason,
+		"action", action,
+	)
 	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"annotations": annotations,
@@ -330,8 +400,22 @@ func (c *PhasedDeploymentController) completeGate(ctx context.Context, dep *apps
 
 func (c *PhasedDeploymentController) ensurePhase(ctx context.Context, dep *appsv1.Deployment, phase, reason string) error {
 	if phased.Phase(dep) == phase && annotationOrEmpty(dep, config.RolloutDependencyReasonAnnotationKey) == reason && dep.Spec.Paused {
+		level.Debug(c.logger).Log(
+			"msg", "phased deployment remains on hold",
+			"deployment", dep.Name,
+			"revision", phased.Revision(dep),
+			"phase", phase,
+			"reason", reason,
+		)
 		return nil
 	}
+	level.Info(c.logger).Log(
+		"msg", "holding phased deployment",
+		"deployment", dep.Name,
+		"revision", phased.Revision(dep),
+		"phase", phase,
+		"reason", reason,
+	)
 	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"annotations": map[string]interface{}{
@@ -415,4 +499,11 @@ func annotationOrEmpty(dep *appsv1.Deployment, key string) string {
 		return ""
 	}
 	return dep.Annotations[key]
+}
+
+func valueOrDefault(value *int32, fallback int32) int32 {
+	if value == nil {
+		return fallback
+	}
+	return *value
 }

--- a/pkg/controller/phased_deployment.go
+++ b/pkg/controller/phased_deployment.go
@@ -308,6 +308,7 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, "dependency cycle detected")
 	}
 
+	canariesReady := phased.CanariesReadyRevision(dep) == revision
 	for _, canaryName := range canaries {
 		canary, err := c.getCanary(ctx, canaryName, byName)
 		if err != nil {
@@ -324,6 +325,7 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 			"current_revision", canaryRevision,
 			"target_revision", revision,
 			"ready", canaryReady,
+			"ready_latched", canariesReady,
 			"paused", canary.Spec.Paused,
 			"generation", canary.Generation,
 			"observed_generation", canary.Status.ObservedGeneration,
@@ -337,10 +339,28 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 			c.blocked.DeleteLabelValues(dep.Name, "config")
 			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for canary %q to reach revision %s", canaryName, revision))
 		}
-		if !canaryReady {
+		if !canariesReady && !canaryReady {
 			c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
 			c.blocked.DeleteLabelValues(dep.Name, "config")
 			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for canary %q to become fully rolled out", canaryName))
+		}
+	}
+
+	if !canariesReady {
+		level.Info(c.logger).Log(
+			"msg", "latching phased deployment canaries ready",
+			"deployment", dep.Name,
+			"canaries", strings.Join(canaries, ","),
+			"revision", revision,
+		)
+		if err := c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					config.RolloutCanariesReadyRevisionAnnotationKey: revision,
+				},
+			},
+		}); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/controller/phased_deployment_test.go
+++ b/pkg/controller/phased_deployment_test.go
@@ -1,0 +1,208 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/phased"
+)
+
+func TestPhasedDeploymentController_WaitsForUpstreamThenSoaks(t *testing.T) {
+	replicas := int32(2)
+	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
+	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+
+	pods := []runtime.Object{
+		mockDeploymentPod("zone-a", "zone-a-0", "uid-a0", 0),
+		mockDeploymentPod("zone-a", "zone-a-1", "uid-a1", 0),
+	}
+
+	api := fake.NewSimpleClientset(append([]runtime.Object{upstream, follower}, pods...)...)
+	c := newTestPhasedController(t, api)
+	require.NoError(t, c.reconcile(context.Background()))
+
+	follower, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseSoaking, phased.Phase(follower))
+	require.True(t, follower.Spec.Paused)
+	require.NotEmpty(t, follower.Annotations[config.RolloutSoakStartedAtAnnotationKey])
+	require.NotEmpty(t, follower.Annotations[config.RolloutRestartBaselineAnnotationKey])
+}
+
+func TestPhasedDeploymentController_CompletesAfterSoakWithLowRestarts(t *testing.T) {
+	replicas := int32(2)
+	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
+	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseSoaking
+	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	follower.Annotations[config.RolloutSoakStartedAtAnnotationKey] = time.Now().UTC().Add(-6 * time.Minute).Format(time.RFC3339)
+	baseline, err := phased.EncodeRestartBaseline(phased.RestartBaseline{"uid-a0/app": 0, "uid-a1/app": 0})
+	require.NoError(t, err)
+	follower.Annotations[config.RolloutRestartBaselineAnnotationKey] = baseline
+	follower.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
+
+	pods := []runtime.Object{
+		mockDeploymentPod("zone-a", "zone-a-0", "uid-a0", 0),
+		mockDeploymentPod("zone-a", "zone-a-1", "uid-a1", 0),
+	}
+	api := fake.NewSimpleClientset(append([]runtime.Object{upstream, follower}, pods...)...)
+	c := newTestPhasedController(t, api)
+	require.NoError(t, c.reconcile(context.Background()))
+
+	follower, err = api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(follower))
+	require.False(t, follower.Spec.Paused)
+}
+
+func TestPhasedDeploymentController_BlocksOnHighRestartRatio(t *testing.T) {
+	replicas := int32(2)
+	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
+	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseSoaking
+	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	follower.Annotations[config.RolloutSoakStartedAtAnnotationKey] = time.Now().UTC().Add(-6 * time.Minute).Format(time.RFC3339)
+	baseline, err := phased.EncodeRestartBaseline(phased.RestartBaseline{"uid-a0/app": 0, "uid-a1/app": 0})
+	require.NoError(t, err)
+	follower.Annotations[config.RolloutRestartBaselineAnnotationKey] = baseline
+
+	// 1 restart across 2 pods => ratio 0.5 >= 0.1
+	pods := []runtime.Object{
+		mockDeploymentPod("zone-a", "zone-a-0", "uid-a0", 1),
+		mockDeploymentPod("zone-a", "zone-a-1", "uid-a1", 0),
+	}
+	api := fake.NewSimpleClientset(append([]runtime.Object{upstream, follower}, pods...)...)
+	c := newTestPhasedController(t, api)
+	require.NoError(t, c.reconcile(context.Background()))
+
+	follower, err = api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseBlocked, phased.Phase(follower))
+	require.True(t, follower.Spec.Paused)
+}
+
+func TestPhasedDeploymentController_ResumeUnpausesImmediately(t *testing.T) {
+	replicas := int32(1)
+	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
+	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseBlocked
+	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	follower.Annotations[config.RolloutResumeAnnotationKey] = "r1"
+	follower.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
+
+	api := fake.NewSimpleClientset(upstream, follower)
+	c := newTestPhasedController(t, api)
+	require.NoError(t, c.reconcile(context.Background()))
+
+	follower, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(follower))
+	require.False(t, follower.Spec.Paused)
+	require.Empty(t, follower.Annotations[config.RolloutResumeAnnotationKey])
+}
+
+func TestPhasedDeploymentController_ResetsSoakWhenUpstreamUnhealthy(t *testing.T) {
+	replicas := int32(2)
+	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, false) // not fully rolled out
+	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseSoaking
+	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	follower.Annotations[config.RolloutSoakStartedAtAnnotationKey] = time.Now().UTC().Add(-1 * time.Minute).Format(time.RFC3339)
+	follower.Annotations[config.RolloutRestartBaselineAnnotationKey] = `{}`
+
+	api := fake.NewSimpleClientset(upstream, follower)
+	c := newTestPhasedController(t, api)
+	require.NoError(t, c.reconcile(context.Background()))
+
+	follower, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseWaiting, phased.Phase(follower))
+	require.Empty(t, follower.Annotations[config.RolloutSoakStartedAtAnnotationKey])
+}
+
+func newTestPhasedController(t *testing.T, api *fake.Clientset) *PhasedDeploymentController {
+	t.Helper()
+	c := NewPhasedDeploymentController(api, testNamespace, time.Second, prometheus.NewRegistry(), log.NewNopLogger())
+	require.NoError(t, c.Init())
+	t.Cleanup(c.Stop)
+	return c
+}
+
+func mockPhasedDeployment(name, dependsOn, revision string, paused bool, replicas int32, fullyRolledOut bool) *appsv1.Deployment {
+	labels := map[string]string{
+		config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue,
+		"name":                       name,
+	}
+	ann := map[string]string{
+		config.RolloutRevisionAnnotationKey: revision,
+	}
+	if dependsOn != "" {
+		ann[config.RolloutDependsOnAnnotationKey] = dependsOn
+	}
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   testNamespace,
+			Labels:      labels,
+			Annotations: ann,
+			Generation:  1,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Paused:   paused,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": name}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"name": name}},
+			},
+		},
+	}
+	if fullyRolledOut {
+		d.Status = appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			Replicas:           replicas,
+			UpdatedReplicas:    replicas,
+			ReadyReplicas:      replicas,
+			AvailableReplicas:  replicas,
+		}
+	} else {
+		d.Status = appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			Replicas:           replicas,
+			UpdatedReplicas:    replicas - 1,
+			ReadyReplicas:      replicas - 1,
+			AvailableReplicas:  replicas - 1,
+		}
+	}
+	return d
+}
+
+func mockDeploymentPod(deployName, podName, uid string, restarts int32) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: testNamespace,
+			UID:       types.UID(uid),
+			Labels:    map[string]string{"name": deployName},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", Ready: true, RestartCount: restarts, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+			},
+		},
+	}
+}

--- a/pkg/controller/phased_deployment_test.go
+++ b/pkg/controller/phased_deployment_test.go
@@ -60,9 +60,33 @@ func TestPhasedDeploymentController_CompletesWhenCanaryReady(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(main))
 	require.False(t, main.Spec.Paused)
+	require.Equal(t, "r1", phased.CanariesReadyRevision(main))
 	require.Contains(t, logs.String(), `msg="phased deployment canaries ready"`)
 	require.Contains(t, logs.String(), `msg="completing phased deployment gate"`)
 	require.Contains(t, logs.String(), "action=unpause-and-proceed")
+}
+
+func TestPhasedDeploymentController_LatchedCanaryReadinessDoesNotRegress(t *testing.T) {
+	replicas := int32(2)
+	canary := mockPhasedDeployment("zone-a", "", "r1", false, replicas, false)
+	canary.Status.UpdatedReplicas = replicas
+	main := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	main.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	main.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
+	main.Annotations[config.RolloutCanariesReadyRevisionAnnotationKey] = "r1"
+
+	api := fake.NewSimpleClientset(canary, main)
+	var logs bytes.Buffer
+	c := newTestPhasedControllerWithLogger(t, api, log.NewLogfmtLogger(&logs))
+	require.NoError(t, c.reconcile(context.Background()))
+
+	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(main))
+	require.False(t, main.Spec.Paused)
+	require.Contains(t, logs.String(), "ready=false")
+	require.Contains(t, logs.String(), "ready_latched=true")
 }
 
 func TestPhasedDeploymentController_WaitsForAllCanaries(t *testing.T) {

--- a/pkg/controller/phased_deployment_test.go
+++ b/pkg/controller/phased_deployment_test.go
@@ -1,7 +1,9 @@
 package controller
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,7 +27,8 @@ func TestPhasedDeploymentController_WaitsForCanary(t *testing.T) {
 	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
 
 	api := fake.NewSimpleClientset(canary, main)
-	c := newTestPhasedController(t, api)
+	var logs bytes.Buffer
+	c := newTestPhasedControllerWithLogger(t, api, log.NewLogfmtLogger(&logs))
 	require.NoError(t, c.reconcile(context.Background()))
 
 	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
@@ -33,6 +36,11 @@ func TestPhasedDeploymentController_WaitsForCanary(t *testing.T) {
 	require.Equal(t, config.RolloutDependencyPhaseWaiting, phased.Phase(main))
 	require.True(t, main.Spec.Paused)
 	require.Contains(t, main.Annotations[config.RolloutDependencyReasonAnnotationKey], "fully rolled out")
+	require.Contains(t, logs.String(), `msg="checking phased deployment canary"`)
+	require.Contains(t, logs.String(), "current_revision=r1")
+	require.Contains(t, logs.String(), "target_revision=r1")
+	require.Contains(t, logs.String(), "ready=false")
+	require.True(t, strings.Contains(logs.String(), `msg="holding phased deployment"`))
 }
 
 func TestPhasedDeploymentController_CompletesWhenCanaryReady(t *testing.T) {
@@ -44,13 +52,17 @@ func TestPhasedDeploymentController_CompletesWhenCanaryReady(t *testing.T) {
 	main.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
 
 	api := fake.NewSimpleClientset(canary, main)
-	c := newTestPhasedController(t, api)
+	var logs bytes.Buffer
+	c := newTestPhasedControllerWithLogger(t, api, log.NewLogfmtLogger(&logs))
 	require.NoError(t, c.reconcile(context.Background()))
 
 	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(main))
 	require.False(t, main.Spec.Paused)
+	require.Contains(t, logs.String(), `msg="phased deployment canaries ready"`)
+	require.Contains(t, logs.String(), `msg="completing phased deployment gate"`)
+	require.Contains(t, logs.String(), "action=unpause-and-proceed")
 }
 
 func TestPhasedDeploymentController_WaitsForAllCanaries(t *testing.T) {
@@ -147,8 +159,12 @@ func TestPhasedDeploymentController_BypassHonorsPreExistingPause(t *testing.T) {
 }
 
 func newTestPhasedController(t *testing.T, api *fake.Clientset) *PhasedDeploymentController {
+	return newTestPhasedControllerWithLogger(t, api, log.NewNopLogger())
+}
+
+func newTestPhasedControllerWithLogger(t *testing.T, api *fake.Clientset, logger log.Logger) *PhasedDeploymentController {
 	t.Helper()
-	c := NewPhasedDeploymentController(api, testNamespace, time.Second, prometheus.NewRegistry(), log.NewNopLogger())
+	c := NewPhasedDeploymentController(api, testNamespace, time.Second, prometheus.NewRegistry(), logger)
 	require.NoError(t, c.Init())
 	t.Cleanup(c.Stop)
 	return c

--- a/pkg/controller/phased_deployment_test.go
+++ b/pkg/controller/phased_deployment_test.go
@@ -11,127 +11,137 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/grafana/rollout-operator/pkg/config"
 	"github.com/grafana/rollout-operator/pkg/phased"
 )
 
-func TestPhasedDeploymentController_WaitsForUpstreamThenSoaks(t *testing.T) {
+func TestPhasedDeploymentController_WaitsForCanary(t *testing.T) {
 	replicas := int32(2)
-	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
-	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
-	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
-	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	canary := mockPhasedDeployment("zone-a", "", "r1", false, replicas, false)
+	main := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	main.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
 
-	pods := []runtime.Object{
-		mockDeploymentPod("zone-a", "zone-a-0", "uid-a0", 0),
-		mockDeploymentPod("zone-a", "zone-a-1", "uid-a1", 0),
-	}
-
-	api := fake.NewSimpleClientset(append([]runtime.Object{upstream, follower}, pods...)...)
+	api := fake.NewSimpleClientset(canary, main)
 	c := newTestPhasedController(t, api)
 	require.NoError(t, c.reconcile(context.Background()))
 
-	follower, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, config.RolloutDependencyPhaseSoaking, phased.Phase(follower))
-	require.True(t, follower.Spec.Paused)
-	require.NotEmpty(t, follower.Annotations[config.RolloutSoakStartedAtAnnotationKey])
-	require.NotEmpty(t, follower.Annotations[config.RolloutRestartBaselineAnnotationKey])
+	require.Equal(t, config.RolloutDependencyPhaseWaiting, phased.Phase(main))
+	require.True(t, main.Spec.Paused)
+	require.Contains(t, main.Annotations[config.RolloutDependencyReasonAnnotationKey], "fully rolled out")
 }
 
-func TestPhasedDeploymentController_CompletesAfterSoakWithLowRestarts(t *testing.T) {
+func TestPhasedDeploymentController_CompletesWhenCanaryReady(t *testing.T) {
 	replicas := int32(2)
-	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
-	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
-	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseSoaking
-	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
-	follower.Annotations[config.RolloutSoakStartedAtAnnotationKey] = time.Now().UTC().Add(-6 * time.Minute).Format(time.RFC3339)
-	baseline, err := phased.EncodeRestartBaseline(phased.RestartBaseline{"uid-a0/app": 0, "uid-a1/app": 0})
-	require.NoError(t, err)
-	follower.Annotations[config.RolloutRestartBaselineAnnotationKey] = baseline
-	follower.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
+	canary := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
+	main := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	main.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	main.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
 
-	pods := []runtime.Object{
-		mockDeploymentPod("zone-a", "zone-a-0", "uid-a0", 0),
-		mockDeploymentPod("zone-a", "zone-a-1", "uid-a1", 0),
-	}
-	api := fake.NewSimpleClientset(append([]runtime.Object{upstream, follower}, pods...)...)
+	api := fake.NewSimpleClientset(canary, main)
 	c := newTestPhasedController(t, api)
 	require.NoError(t, c.reconcile(context.Background()))
 
-	follower, err = api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(follower))
-	require.False(t, follower.Spec.Paused)
+	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(main))
+	require.False(t, main.Spec.Paused)
 }
 
-func TestPhasedDeploymentController_BlocksOnHighRestartRatio(t *testing.T) {
-	replicas := int32(2)
-	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
-	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
-	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseSoaking
-	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
-	follower.Annotations[config.RolloutSoakStartedAtAnnotationKey] = time.Now().UTC().Add(-6 * time.Minute).Format(time.RFC3339)
-	baseline, err := phased.EncodeRestartBaseline(phased.RestartBaseline{"uid-a0/app": 0, "uid-a1/app": 0})
-	require.NoError(t, err)
-	follower.Annotations[config.RolloutRestartBaselineAnnotationKey] = baseline
-
-	// 1 restart across 2 pods => ratio 0.5 >= 0.1
-	pods := []runtime.Object{
-		mockDeploymentPod("zone-a", "zone-a-0", "uid-a0", 1),
-		mockDeploymentPod("zone-a", "zone-a-1", "uid-a1", 0),
-	}
-	api := fake.NewSimpleClientset(append([]runtime.Object{upstream, follower}, pods...)...)
-	c := newTestPhasedController(t, api)
-	require.NoError(t, c.reconcile(context.Background()))
-
-	follower, err = api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
-	require.NoError(t, err)
-	require.Equal(t, config.RolloutDependencyPhaseBlocked, phased.Phase(follower))
-	require.True(t, follower.Spec.Paused)
-}
-
-func TestPhasedDeploymentController_ResumeUnpausesImmediately(t *testing.T) {
+func TestPhasedDeploymentController_WaitsForAllCanaries(t *testing.T) {
 	replicas := int32(1)
-	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
-	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
-	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseBlocked
-	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
-	follower.Annotations[config.RolloutResumeAnnotationKey] = "r1"
-	follower.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
+	qf := mockPhasedDeployment("query-frontend-zone-a", "", "r1", false, replicas, true)
+	querier := mockPhasedDeployment("querier-zone-a", "", "r1", false, replicas, false)
+	main := mockPhasedDeployment("querier-zone-b", "querier-zone-a,query-frontend-zone-a", "r1", true, replicas, false)
+	main.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
 
-	api := fake.NewSimpleClientset(upstream, follower)
+	api := fake.NewSimpleClientset(qf, querier, main)
 	c := newTestPhasedController(t, api)
 	require.NoError(t, c.reconcile(context.Background()))
 
-	follower, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "querier-zone-b", metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(follower))
-	require.False(t, follower.Spec.Paused)
-	require.Empty(t, follower.Annotations[config.RolloutResumeAnnotationKey])
+	require.Equal(t, config.RolloutDependencyPhaseWaiting, phased.Phase(main))
+	require.Contains(t, main.Annotations[config.RolloutDependencyReasonAnnotationKey], "querier-zone-a")
+
+	querier.Status.UpdatedReplicas = replicas
+	querier.Status.ReadyReplicas = replicas
+	querier.Status.AvailableReplicas = replicas
+	_, err = api.AppsV1().Deployments(testNamespace).Update(context.Background(), querier, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	// Refresh informer by waiting briefly and re-init is heavy; reconcile uses lister which may be stale.
+	// Force a fresh controller against updated API.
+	c = newTestPhasedController(t, api)
+	require.NoError(t, c.reconcile(context.Background()))
+
+	main, err = api.AppsV1().Deployments(testNamespace).Get(context.Background(), "querier-zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(main))
+	require.False(t, main.Spec.Paused)
 }
 
-func TestPhasedDeploymentController_ResetsSoakWhenUpstreamUnhealthy(t *testing.T) {
-	replicas := int32(2)
-	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, false) // not fully rolled out
-	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
-	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseSoaking
-	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
-	follower.Annotations[config.RolloutSoakStartedAtAnnotationKey] = time.Now().UTC().Add(-1 * time.Minute).Format(time.RFC3339)
-	follower.Annotations[config.RolloutRestartBaselineAnnotationKey] = `{}`
+func TestPhasedDeploymentController_BypassUnpauses(t *testing.T) {
+	replicas := int32(1)
+	canary := mockPhasedDeployment("zone-a", "", "r1", false, replicas, false)
+	main := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	main.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	main.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
+	main.Annotations[config.RolloutBypassUntilAnnotationKey] = time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
 
-	api := fake.NewSimpleClientset(upstream, follower)
+	api := fake.NewSimpleClientset(canary, main)
 	c := newTestPhasedController(t, api)
 	require.NoError(t, c.reconcile(context.Background()))
 
-	follower, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, config.RolloutDependencyPhaseWaiting, phased.Phase(follower))
-	require.Empty(t, follower.Annotations[config.RolloutSoakStartedAtAnnotationKey])
+	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(main))
+	require.False(t, main.Spec.Paused)
+
+	events, err := api.CoreV1().Events(testNamespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, events.Items, 1)
+	require.Equal(t, bypassEventReason, events.Items[0].Reason)
+
+	// Second reconcile must not re-emit bypass telemetry.
+	require.NoError(t, c.reconcile(context.Background()))
+	events, err = api.CoreV1().Events(testNamespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, events.Items, 1)
+}
+
+func TestPhasedDeploymentController_BypassHonorsPreExistingPause(t *testing.T) {
+	replicas := int32(1)
+	canary := mockPhasedDeployment("zone-a", "", "r1", false, replicas, false)
+	main := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	main.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	main.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationTrue
+	main.Annotations[config.RolloutBypassUntilAnnotationKey] = time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+
+	api := fake.NewSimpleClientset(canary, main)
+	c := newTestPhasedController(t, api)
+	require.NoError(t, c.reconcile(context.Background()))
+
+	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(main))
+	require.True(t, main.Spec.Paused)
+
+	events, err := api.CoreV1().Events(testNamespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, events.Items, 1)
+
+	require.NoError(t, c.reconcile(context.Background()))
+	events, err = api.CoreV1().Events(testNamespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, events.Items, 1)
 }
 
 func newTestPhasedController(t *testing.T, api *fake.Clientset) *PhasedDeploymentController {
@@ -142,7 +152,7 @@ func newTestPhasedController(t *testing.T, api *fake.Clientset) *PhasedDeploymen
 	return c
 }
 
-func mockPhasedDeployment(name, dependsOn, revision string, paused bool, replicas int32, fullyRolledOut bool) *appsv1.Deployment {
+func mockPhasedDeployment(name, canaries, revision string, paused bool, replicas int32, fullyRolledOut bool) *appsv1.Deployment {
 	labels := map[string]string{
 		config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue,
 		"name":                       name,
@@ -150,8 +160,8 @@ func mockPhasedDeployment(name, dependsOn, revision string, paused bool, replica
 	ann := map[string]string{
 		config.RolloutRevisionAnnotationKey: revision,
 	}
-	if dependsOn != "" {
-		ann[config.RolloutDependsOnAnnotationKey] = dependsOn
+	if canaries != "" {
+		ann[config.RolloutCanaryAnnotationKey] = canaries
 	}
 	d := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -188,21 +198,4 @@ func mockPhasedDeployment(name, dependsOn, revision string, paused bool, replica
 		}
 	}
 	return d
-}
-
-func mockDeploymentPod(deployName, podName, uid string, restarts int32) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: testNamespace,
-			UID:       types.UID(uid),
-			Labels:    map[string]string{"name": deployName},
-		},
-		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
-			ContainerStatuses: []corev1.ContainerStatus{
-				{Name: "app", Ready: true, RestartCount: restarts, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
-			},
-		},
-	}
 }

--- a/pkg/controller/phased_deployment_test.go
+++ b/pkg/controller/phased_deployment_test.go
@@ -110,6 +110,7 @@ func TestPhasedDeploymentController_BypassUnpauses(t *testing.T) {
 	require.Equal(t, bypassEventReason, events.Items[0].Reason)
 
 	// Second reconcile must not re-emit bypass telemetry.
+	c = newTestPhasedController(t, api)
 	require.NoError(t, c.reconcile(context.Background()))
 	events, err = api.CoreV1().Events(testNamespace).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
@@ -138,6 +139,7 @@ func TestPhasedDeploymentController_BypassHonorsPreExistingPause(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, events.Items, 1)
 
+	c = newTestPhasedController(t, api)
 	require.NoError(t, c.reconcile(context.Background()))
 	events, err = api.CoreV1().Events(testNamespace).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)

--- a/pkg/phased/phased.go
+++ b/pkg/phased/phased.go
@@ -1,0 +1,278 @@
+package phased
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/common/model"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+const (
+	DefaultSoakDuration      = 5 * time.Minute
+	DefaultRestartThreshold  = 0.10
+	HadPausedAnnotationTrue  = "true"
+	HadPausedAnnotationFalse = "false"
+)
+
+// IsOptedIn reports whether the Deployment participates in phased rollouts.
+func IsOptedIn(d *appsv1.Deployment) bool {
+	if d == nil || d.Labels == nil {
+		return false
+	}
+	return d.Labels[config.RolloutPhasedLabelKey] == config.RolloutPhasedLabelValue
+}
+
+// DependsOn returns the upstream Deployment name, or empty if none.
+func DependsOn(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return strings.TrimSpace(d.Annotations[config.RolloutDependsOnAnnotationKey])
+}
+
+// Revision returns the shared rollout revision stamp.
+func Revision(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return strings.TrimSpace(d.Annotations[config.RolloutRevisionAnnotationKey])
+}
+
+// Phase returns the current dependency gate phase.
+func Phase(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return d.Annotations[config.RolloutDependencyPhaseAnnotationKey]
+}
+
+// DependencyRevision returns the revision currently being gated.
+func DependencyRevision(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return d.Annotations[config.RolloutDependencyRevisionAnnotationKey]
+}
+
+// ResumeRevision returns the revision requested for an explicit resume bypass.
+func ResumeRevision(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return strings.TrimSpace(d.Annotations[config.RolloutResumeAnnotationKey])
+}
+
+// GateActive reports whether the Deployment must stay paused for the current revision.
+func GateActive(d *appsv1.Deployment) bool {
+	if !IsOptedIn(d) || DependsOn(d) == "" {
+		return false
+	}
+	rev := Revision(d)
+	if rev == "" || DependencyRevision(d) != rev {
+		return false
+	}
+	phase := Phase(d)
+	return phase != "" && phase != config.RolloutDependencyPhaseComplete
+}
+
+// NeedsNewGate reports whether a revision change requires (re)starting the gate.
+func NeedsNewGate(d *appsv1.Deployment) bool {
+	if !IsOptedIn(d) || DependsOn(d) == "" {
+		return false
+	}
+	rev := Revision(d)
+	if rev == "" {
+		return false
+	}
+	return DependencyRevision(d) != rev
+}
+
+// ParseSoakDuration returns the soak duration from annotations, or the default.
+func ParseSoakDuration(annotations map[string]string) (time.Duration, error) {
+	if annotations == nil {
+		return DefaultSoakDuration, nil
+	}
+	raw := strings.TrimSpace(annotations[config.RolloutSoakDurationAnnotationKey])
+	if raw == "" {
+		return DefaultSoakDuration, nil
+	}
+	d, err := model.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", config.RolloutSoakDurationAnnotationKey, raw, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("%s must be positive, got %q", config.RolloutSoakDurationAnnotationKey, raw)
+	}
+	return time.Duration(d), nil
+}
+
+// ParseRestartThreshold returns the restart ratio threshold from annotations, or the default.
+func ParseRestartThreshold(annotations map[string]string) (float64, error) {
+	if annotations == nil {
+		return DefaultRestartThreshold, nil
+	}
+	raw := strings.TrimSpace(annotations[config.RolloutRestartThresholdAnnotationKey])
+	if raw == "" {
+		return DefaultRestartThreshold, nil
+	}
+	percent := false
+	if strings.HasSuffix(raw, "%") {
+		percent = true
+		raw = strings.TrimSuffix(raw, "%")
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", config.RolloutRestartThresholdAnnotationKey, annotations[config.RolloutRestartThresholdAnnotationKey], err)
+	}
+	if percent {
+		v = v / 100
+	}
+	if v < 0 {
+		return 0, fmt.Errorf("%s must be non-negative, got %q", config.RolloutRestartThresholdAnnotationKey, annotations[config.RolloutRestartThresholdAnnotationKey])
+	}
+	return v, nil
+}
+
+// ExceedsRestartThreshold reports whether the measured ratio should block progression.
+// A threshold of 0 means any positive restart ratio blocks; otherwise ratio >= threshold blocks.
+func ExceedsRestartThreshold(ratio, threshold float64) bool {
+	if threshold == 0 {
+		return ratio > 0
+	}
+	return ratio >= threshold
+}
+
+// IsFullyRolledOut reports whether every replica is updated, ready, and available.
+func IsFullyRolledOut(d *appsv1.Deployment) bool {
+	if d == nil {
+		return false
+	}
+	if d.Spec.Paused {
+		return false
+	}
+	desired := int32(1)
+	if d.Spec.Replicas != nil {
+		desired = *d.Spec.Replicas
+	}
+	if desired == 0 {
+		return d.Status.Replicas == 0 && d.Status.ObservedGeneration >= d.Generation
+	}
+	if d.Status.ObservedGeneration < d.Generation {
+		return false
+	}
+	return d.Status.UpdatedReplicas == desired &&
+		d.Status.ReadyReplicas == desired &&
+		d.Status.AvailableReplicas == desired &&
+		d.Status.Replicas == desired
+}
+
+// RestartBaseline maps "podUID/containerName" to restart count at soak start.
+type RestartBaseline map[string]int32
+
+func baselineKey(podUID types.UID, containerName string) string {
+	return string(podUID) + "/" + containerName
+}
+
+// BuildRestartBaseline captures current restart counts for the given pods.
+func BuildRestartBaseline(pods []*corev1.Pod) RestartBaseline {
+	baseline := make(RestartBaseline)
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			baseline[baselineKey(pod.UID, cs.Name)] = cs.RestartCount
+		}
+	}
+	return baseline
+}
+
+// EncodeRestartBaseline serializes a baseline for annotation storage.
+func EncodeRestartBaseline(baseline RestartBaseline) (string, error) {
+	if baseline == nil {
+		baseline = RestartBaseline{}
+	}
+	b, err := json.Marshal(baseline)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// DecodeRestartBaseline parses a baseline annotation value.
+func DecodeRestartBaseline(raw string) (RestartBaseline, error) {
+	if raw == "" {
+		return RestartBaseline{}, nil
+	}
+	var baseline RestartBaseline
+	if err := json.Unmarshal([]byte(raw), &baseline); err != nil {
+		return nil, err
+	}
+	if baseline == nil {
+		baseline = RestartBaseline{}
+	}
+	return baseline, nil
+}
+
+// RestartRatio is sum(container restart deltas since baseline) / len(pods).
+// Missing baseline entries (new pods/containers) are treated as zero.
+func RestartRatio(pods []*corev1.Pod, baseline RestartBaseline) float64 {
+	if len(pods) == 0 {
+		return 0
+	}
+	if baseline == nil {
+		baseline = RestartBaseline{}
+	}
+	var totalDelta int64
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			prev := baseline[baselineKey(pod.UID, cs.Name)]
+			delta := cs.RestartCount - prev
+			if delta > 0 {
+				totalDelta += int64(delta)
+			}
+		}
+	}
+	return float64(totalDelta) / float64(len(pods))
+}
+
+// DetectDependencyCycle walks depends-on links starting from start.
+// deployments is keyed by name. Returns true if a cycle involving start is found.
+func DetectDependencyCycle(start string, deployments map[string]*appsv1.Deployment) bool {
+	seen := map[string]struct{}{}
+	cur := start
+	for {
+		if _, ok := seen[cur]; ok {
+			return true
+		}
+		seen[cur] = struct{}{}
+		d, ok := deployments[cur]
+		if !ok {
+			return false
+		}
+		next := DependsOn(d)
+		if next == "" {
+			return false
+		}
+		cur = next
+	}
+}
+
+// AnnotationJSONPointer escapes an annotation key for use in a JSON Patch path.
+func AnnotationJSONPointer(key string) string {
+	// JSON Pointer: ~ -> ~0, / -> ~1
+	escaped := strings.ReplaceAll(key, "~", "~0")
+	escaped = strings.ReplaceAll(escaped, "/", "~1")
+	return "/metadata/annotations/" + escaped
+}

--- a/pkg/phased/phased.go
+++ b/pkg/phased/phased.go
@@ -1,23 +1,16 @@
 package phased
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
-	"github.com/prometheus/common/model"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/grafana/rollout-operator/pkg/config"
 )
 
 const (
-	DefaultSoakDuration      = 5 * time.Minute
-	DefaultRestartThreshold  = 0.10
 	HadPausedAnnotationTrue  = "true"
 	HadPausedAnnotationFalse = "false"
 )
@@ -30,12 +23,31 @@ func IsOptedIn(d *appsv1.Deployment) bool {
 	return d.Labels[config.RolloutPhasedLabelKey] == config.RolloutPhasedLabelValue
 }
 
-// DependsOn returns the upstream Deployment name, or empty if none.
-func DependsOn(d *appsv1.Deployment) string {
+// Canaries returns the canary Deployment names this Deployment depends on.
+// Values are comma-separated in grafana.com/rollout-canary.
+func Canaries(d *appsv1.Deployment) []string {
 	if d == nil || d.Annotations == nil {
-		return ""
+		return nil
 	}
-	return strings.TrimSpace(d.Annotations[config.RolloutDependsOnAnnotationKey])
+	raw := strings.TrimSpace(d.Annotations[config.RolloutCanaryAnnotationKey])
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+	for _, p := range parts {
+		name := strings.TrimSpace(p)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
 }
 
 // Revision returns the shared rollout revision stamp.
@@ -62,17 +74,34 @@ func DependencyRevision(d *appsv1.Deployment) string {
 	return d.Annotations[config.RolloutDependencyRevisionAnnotationKey]
 }
 
-// ResumeRevision returns the revision requested for an explicit resume bypass.
-func ResumeRevision(d *appsv1.Deployment) string {
+// BypassUntil parses grafana.com/rollout-bypass-until. ok is false when unset.
+func BypassUntil(d *appsv1.Deployment) (until time.Time, ok bool, err error) {
 	if d == nil || d.Annotations == nil {
-		return ""
+		return time.Time{}, false, nil
 	}
-	return strings.TrimSpace(d.Annotations[config.RolloutResumeAnnotationKey])
+	raw := strings.TrimSpace(d.Annotations[config.RolloutBypassUntilAnnotationKey])
+	if raw == "" {
+		return time.Time{}, false, nil
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("invalid %s %q: %w", config.RolloutBypassUntilAnnotationKey, raw, err)
+	}
+	return t, true, nil
+}
+
+// BypassActive reports whether a valid bypass-until annotation is still in the future.
+func BypassActive(d *appsv1.Deployment, now time.Time) bool {
+	until, ok, err := BypassUntil(d)
+	if err != nil || !ok {
+		return false
+	}
+	return now.Before(until)
 }
 
 // GateActive reports whether the Deployment must stay paused for the current revision.
 func GateActive(d *appsv1.Deployment) bool {
-	if !IsOptedIn(d) || DependsOn(d) == "" {
+	if !IsOptedIn(d) || len(Canaries(d)) == 0 {
 		return false
 	}
 	rev := Revision(d)
@@ -85,7 +114,7 @@ func GateActive(d *appsv1.Deployment) bool {
 
 // NeedsNewGate reports whether a revision change requires (re)starting the gate.
 func NeedsNewGate(d *appsv1.Deployment) bool {
-	if !IsOptedIn(d) || DependsOn(d) == "" {
+	if !IsOptedIn(d) || len(Canaries(d)) == 0 {
 		return false
 	}
 	rev := Revision(d)
@@ -93,61 +122,6 @@ func NeedsNewGate(d *appsv1.Deployment) bool {
 		return false
 	}
 	return DependencyRevision(d) != rev
-}
-
-// ParseSoakDuration returns the soak duration from annotations, or the default.
-func ParseSoakDuration(annotations map[string]string) (time.Duration, error) {
-	if annotations == nil {
-		return DefaultSoakDuration, nil
-	}
-	raw := strings.TrimSpace(annotations[config.RolloutSoakDurationAnnotationKey])
-	if raw == "" {
-		return DefaultSoakDuration, nil
-	}
-	d, err := model.ParseDuration(raw)
-	if err != nil {
-		return 0, fmt.Errorf("invalid %s %q: %w", config.RolloutSoakDurationAnnotationKey, raw, err)
-	}
-	if d <= 0 {
-		return 0, fmt.Errorf("%s must be positive, got %q", config.RolloutSoakDurationAnnotationKey, raw)
-	}
-	return time.Duration(d), nil
-}
-
-// ParseRestartThreshold returns the restart ratio threshold from annotations, or the default.
-func ParseRestartThreshold(annotations map[string]string) (float64, error) {
-	if annotations == nil {
-		return DefaultRestartThreshold, nil
-	}
-	raw := strings.TrimSpace(annotations[config.RolloutRestartThresholdAnnotationKey])
-	if raw == "" {
-		return DefaultRestartThreshold, nil
-	}
-	percent := false
-	if strings.HasSuffix(raw, "%") {
-		percent = true
-		raw = strings.TrimSuffix(raw, "%")
-	}
-	v, err := strconv.ParseFloat(raw, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid %s %q: %w", config.RolloutRestartThresholdAnnotationKey, annotations[config.RolloutRestartThresholdAnnotationKey], err)
-	}
-	if percent {
-		v = v / 100
-	}
-	if v < 0 {
-		return 0, fmt.Errorf("%s must be non-negative, got %q", config.RolloutRestartThresholdAnnotationKey, annotations[config.RolloutRestartThresholdAnnotationKey])
-	}
-	return v, nil
-}
-
-// ExceedsRestartThreshold reports whether the measured ratio should block progression.
-// A threshold of 0 means any positive restart ratio blocks; otherwise ratio >= threshold blocks.
-func ExceedsRestartThreshold(ratio, threshold float64) bool {
-	if threshold == 0 {
-		return ratio > 0
-	}
-	return ratio >= threshold
 }
 
 // IsFullyRolledOut reports whether every replica is updated, ready, and available.
@@ -174,99 +148,32 @@ func IsFullyRolledOut(d *appsv1.Deployment) bool {
 		d.Status.Replicas == desired
 }
 
-// RestartBaseline maps "podUID/containerName" to restart count at soak start.
-type RestartBaseline map[string]int32
-
-func baselineKey(podUID types.UID, containerName string) string {
-	return string(podUID) + "/" + containerName
-}
-
-// BuildRestartBaseline captures current restart counts for the given pods.
-func BuildRestartBaseline(pods []*corev1.Pod) RestartBaseline {
-	baseline := make(RestartBaseline)
-	for _, pod := range pods {
-		if pod == nil {
-			continue
-		}
-		for _, cs := range pod.Status.ContainerStatuses {
-			baseline[baselineKey(pod.UID, cs.Name)] = cs.RestartCount
-		}
-	}
-	return baseline
-}
-
-// EncodeRestartBaseline serializes a baseline for annotation storage.
-func EncodeRestartBaseline(baseline RestartBaseline) (string, error) {
-	if baseline == nil {
-		baseline = RestartBaseline{}
-	}
-	b, err := json.Marshal(baseline)
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
-}
-
-// DecodeRestartBaseline parses a baseline annotation value.
-func DecodeRestartBaseline(raw string) (RestartBaseline, error) {
-	if raw == "" {
-		return RestartBaseline{}, nil
-	}
-	var baseline RestartBaseline
-	if err := json.Unmarshal([]byte(raw), &baseline); err != nil {
-		return nil, err
-	}
-	if baseline == nil {
-		baseline = RestartBaseline{}
-	}
-	return baseline, nil
-}
-
-// RestartRatio is sum(container restart deltas since baseline) / len(pods).
-// Missing baseline entries (new pods/containers) are treated as zero.
-func RestartRatio(pods []*corev1.Pod, baseline RestartBaseline) float64 {
-	if len(pods) == 0 {
-		return 0
-	}
-	if baseline == nil {
-		baseline = RestartBaseline{}
-	}
-	var totalDelta int64
-	for _, pod := range pods {
-		if pod == nil {
-			continue
-		}
-		for _, cs := range pod.Status.ContainerStatuses {
-			prev := baseline[baselineKey(pod.UID, cs.Name)]
-			delta := cs.RestartCount - prev
-			if delta > 0 {
-				totalDelta += int64(delta)
-			}
-		}
-	}
-	return float64(totalDelta) / float64(len(pods))
-}
-
-// DetectDependencyCycle walks depends-on links starting from start.
+// DetectDependencyCycle walks canary links starting from start.
 // deployments is keyed by name. Returns true if a cycle involving start is found.
 func DetectDependencyCycle(start string, deployments map[string]*appsv1.Deployment) bool {
+	onPath := map[string]struct{}{}
 	seen := map[string]struct{}{}
-	cur := start
-	for {
-		if _, ok := seen[cur]; ok {
+	var walk func(string) bool
+	walk = func(cur string) bool {
+		if _, ok := onPath[cur]; ok {
 			return true
 		}
+		if _, ok := seen[cur]; ok {
+			return false
+		}
+		onPath[cur] = struct{}{}
 		seen[cur] = struct{}{}
-		d, ok := deployments[cur]
-		if !ok {
-			return false
+		if d, ok := deployments[cur]; ok {
+			for _, next := range Canaries(d) {
+				if walk(next) {
+					return true
+				}
+			}
 		}
-		next := DependsOn(d)
-		if next == "" {
-			return false
-		}
-		cur = next
+		delete(onPath, cur)
+		return false
 	}
+	return walk(start)
 }
 
 // AnnotationJSONPointer escapes an annotation key for use in a JSON Patch path.

--- a/pkg/phased/phased.go
+++ b/pkg/phased/phased.go
@@ -74,6 +74,14 @@ func DependencyRevision(d *appsv1.Deployment) string {
 	return d.Annotations[config.RolloutDependencyRevisionAnnotationKey]
 }
 
+// CanariesReadyRevision returns the revision for which every canary reached full readiness.
+func CanariesReadyRevision(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return strings.TrimSpace(d.Annotations[config.RolloutCanariesReadyRevisionAnnotationKey])
+}
+
 // BypassUntil parses grafana.com/rollout-bypass-until. ok is false when unset.
 func BypassUntil(d *appsv1.Deployment) (until time.Time, ok bool, err error) {
 	if d == nil || d.Annotations == nil {

--- a/pkg/phased/phased_test.go
+++ b/pkg/phased/phased_test.go
@@ -1,0 +1,139 @@
+package phased
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+func TestParseSoakDuration(t *testing.T) {
+	d, err := ParseSoakDuration(nil)
+	require.NoError(t, err)
+	require.Equal(t, DefaultSoakDuration, d)
+
+	d, err = ParseSoakDuration(map[string]string{config.RolloutSoakDurationAnnotationKey: "2m"})
+	require.NoError(t, err)
+	require.Equal(t, 2*time.Minute, d)
+
+	_, err = ParseSoakDuration(map[string]string{config.RolloutSoakDurationAnnotationKey: "nope"})
+	require.Error(t, err)
+}
+
+func TestParseRestartThreshold(t *testing.T) {
+	v, err := ParseRestartThreshold(nil)
+	require.NoError(t, err)
+	require.InDelta(t, 0.10, v, 0.0001)
+
+	v, err = ParseRestartThreshold(map[string]string{config.RolloutRestartThresholdAnnotationKey: "10%"})
+	require.NoError(t, err)
+	require.InDelta(t, 0.10, v, 0.0001)
+
+	v, err = ParseRestartThreshold(map[string]string{config.RolloutRestartThresholdAnnotationKey: "0.25"})
+	require.NoError(t, err)
+	require.InDelta(t, 0.25, v, 0.0001)
+}
+
+func TestIsFullyRolledOut(t *testing.T) {
+	replicas := int32(3)
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Generation: 2},
+		Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 2,
+			Replicas:           3,
+			UpdatedReplicas:    3,
+			ReadyReplicas:      3,
+			AvailableReplicas:  3,
+		},
+	}
+	require.True(t, IsFullyRolledOut(d))
+
+	d.Spec.Paused = true
+	require.False(t, IsFullyRolledOut(d))
+	d.Spec.Paused = false
+
+	d.Status.ReadyReplicas = 2
+	require.False(t, IsFullyRolledOut(d))
+}
+
+func TestRestartRatio(t *testing.T) {
+	pods := []*corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{UID: types.UID("a")},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", RestartCount: 2},
+			}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{UID: types.UID("b")},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", RestartCount: 0},
+			}},
+		},
+	}
+	baseline := RestartBaseline{"a/app": 1, "b/app": 0}
+	// deltas: 1 + 0 = 1; pods = 2; ratio = 0.5
+	require.InDelta(t, 0.5, RestartRatio(pods, baseline), 0.0001)
+
+	// New pod with no baseline counts full restarts.
+	pods = append(pods, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID("c")},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "app", RestartCount: 1},
+		}},
+	})
+	require.InDelta(t, 2.0/3.0, RestartRatio(pods, baseline), 0.0001)
+}
+
+func TestDetectDependencyCycle(t *testing.T) {
+	a := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "a", Annotations: map[string]string{config.RolloutDependsOnAnnotationKey: "c"}}}
+	b := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "b", Annotations: map[string]string{config.RolloutDependsOnAnnotationKey: "a"}}}
+	c := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "c", Annotations: map[string]string{config.RolloutDependsOnAnnotationKey: "b"}}}
+	byName := map[string]*appsv1.Deployment{"a": a, "b": b, "c": c}
+	require.True(t, DetectDependencyCycle("a", byName))
+
+	c.Annotations = nil
+	require.False(t, DetectDependencyCycle("a", byName))
+}
+
+func TestGateActive(t *testing.T) {
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue},
+			Annotations: map[string]string{
+				config.RolloutDependsOnAnnotationKey:          "upstream",
+				config.RolloutRevisionAnnotationKey:           "r1",
+				config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseWaiting,
+				config.RolloutDependencyRevisionAnnotationKey: "r1",
+			},
+		},
+	}
+	require.True(t, GateActive(d))
+
+	d.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseComplete
+	require.False(t, GateActive(d))
+}
+
+func TestExceedsRestartThreshold(t *testing.T) {
+	require.False(t, ExceedsRestartThreshold(0, 0))
+	require.True(t, ExceedsRestartThreshold(0.01, 0))
+	require.False(t, ExceedsRestartThreshold(0.09, 0.1))
+	require.True(t, ExceedsRestartThreshold(0.1, 0.1))
+	require.True(t, ExceedsRestartThreshold(0.2, 0.1))
+}
+
+func TestEncodeDecodeRestartBaseline(t *testing.T) {
+	in := RestartBaseline{"uid/app": 3}
+	raw, err := EncodeRestartBaseline(in)
+	require.NoError(t, err)
+	out, err := DecodeRestartBaseline(raw)
+	require.NoError(t, err)
+	require.Equal(t, in, out)
+}

--- a/pkg/phased/phased_test.go
+++ b/pkg/phased/phased_test.go
@@ -6,38 +6,17 @@ import (
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/grafana/rollout-operator/pkg/config"
 )
 
-func TestParseSoakDuration(t *testing.T) {
-	d, err := ParseSoakDuration(nil)
-	require.NoError(t, err)
-	require.Equal(t, DefaultSoakDuration, d)
-
-	d, err = ParseSoakDuration(map[string]string{config.RolloutSoakDurationAnnotationKey: "2m"})
-	require.NoError(t, err)
-	require.Equal(t, 2*time.Minute, d)
-
-	_, err = ParseSoakDuration(map[string]string{config.RolloutSoakDurationAnnotationKey: "nope"})
-	require.Error(t, err)
-}
-
-func TestParseRestartThreshold(t *testing.T) {
-	v, err := ParseRestartThreshold(nil)
-	require.NoError(t, err)
-	require.InDelta(t, 0.10, v, 0.0001)
-
-	v, err = ParseRestartThreshold(map[string]string{config.RolloutRestartThresholdAnnotationKey: "10%"})
-	require.NoError(t, err)
-	require.InDelta(t, 0.10, v, 0.0001)
-
-	v, err = ParseRestartThreshold(map[string]string{config.RolloutRestartThresholdAnnotationKey: "0.25"})
-	require.NoError(t, err)
-	require.InDelta(t, 0.25, v, 0.0001)
+func TestCanaries(t *testing.T) {
+	d := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		config.RolloutCanaryAnnotationKey: " zone-a , query-frontend-zone-a,zone-a ",
+	}}}
+	require.Equal(t, []string{"zone-a", "query-frontend-zone-a"}, Canaries(d))
+	require.Nil(t, Canaries(&appsv1.Deployment{}))
 }
 
 func TestIsFullyRolledOut(t *testing.T) {
@@ -63,44 +42,21 @@ func TestIsFullyRolledOut(t *testing.T) {
 	require.False(t, IsFullyRolledOut(d))
 }
 
-func TestRestartRatio(t *testing.T) {
-	pods := []*corev1.Pod{
-		{
-			ObjectMeta: metav1.ObjectMeta{UID: types.UID("a")},
-			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
-				{Name: "app", RestartCount: 2},
-			}},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{UID: types.UID("b")},
-			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
-				{Name: "app", RestartCount: 0},
-			}},
-		},
-	}
-	baseline := RestartBaseline{"a/app": 1, "b/app": 0}
-	// deltas: 1 + 0 = 1; pods = 2; ratio = 0.5
-	require.InDelta(t, 0.5, RestartRatio(pods, baseline), 0.0001)
-
-	// New pod with no baseline counts full restarts.
-	pods = append(pods, &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{UID: types.UID("c")},
-		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
-			{Name: "app", RestartCount: 1},
-		}},
-	})
-	require.InDelta(t, 2.0/3.0, RestartRatio(pods, baseline), 0.0001)
-}
-
 func TestDetectDependencyCycle(t *testing.T) {
-	a := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "a", Annotations: map[string]string{config.RolloutDependsOnAnnotationKey: "c"}}}
-	b := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "b", Annotations: map[string]string{config.RolloutDependsOnAnnotationKey: "a"}}}
-	c := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "c", Annotations: map[string]string{config.RolloutDependsOnAnnotationKey: "b"}}}
+	a := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "a", Annotations: map[string]string{config.RolloutCanaryAnnotationKey: "c"}}}
+	b := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "b", Annotations: map[string]string{config.RolloutCanaryAnnotationKey: "a"}}}
+	c := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "c", Annotations: map[string]string{config.RolloutCanaryAnnotationKey: "b"}}}
 	byName := map[string]*appsv1.Deployment{"a": a, "b": b, "c": c}
 	require.True(t, DetectDependencyCycle("a", byName))
 
 	c.Annotations = nil
 	require.False(t, DetectDependencyCycle("a", byName))
+
+	// Multi-canary diamond is not a cycle.
+	main := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "main", Annotations: map[string]string{config.RolloutCanaryAnnotationKey: "left,right"}}}
+	left := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "left"}}
+	right := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "right"}}
+	require.False(t, DetectDependencyCycle("main", map[string]*appsv1.Deployment{"main": main, "left": left, "right": right}))
 }
 
 func TestGateActive(t *testing.T) {
@@ -108,7 +64,7 @@ func TestGateActive(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue},
 			Annotations: map[string]string{
-				config.RolloutDependsOnAnnotationKey:          "upstream",
+				config.RolloutCanaryAnnotationKey:             "upstream",
 				config.RolloutRevisionAnnotationKey:           "r1",
 				config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseWaiting,
 				config.RolloutDependencyRevisionAnnotationKey: "r1",
@@ -121,19 +77,14 @@ func TestGateActive(t *testing.T) {
 	require.False(t, GateActive(d))
 }
 
-func TestExceedsRestartThreshold(t *testing.T) {
-	require.False(t, ExceedsRestartThreshold(0, 0))
-	require.True(t, ExceedsRestartThreshold(0.01, 0))
-	require.False(t, ExceedsRestartThreshold(0.09, 0.1))
-	require.True(t, ExceedsRestartThreshold(0.1, 0.1))
-	require.True(t, ExceedsRestartThreshold(0.2, 0.1))
-}
+func TestBypassActive(t *testing.T) {
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	d := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		config.RolloutBypassUntilAnnotationKey: now.Add(time.Hour).Format(time.RFC3339),
+	}}}
+	require.True(t, BypassActive(d, now))
+	require.False(t, BypassActive(d, now.Add(2*time.Hour)))
 
-func TestEncodeDecodeRestartBaseline(t *testing.T) {
-	in := RestartBaseline{"uid/app": 3}
-	raw, err := EncodeRestartBaseline(in)
-	require.NoError(t, err)
-	out, err := DecodeRestartBaseline(raw)
-	require.NoError(t, err)
-	require.Equal(t, in, out)
+	d.Annotations[config.RolloutBypassUntilAnnotationKey] = "not-a-time"
+	require.False(t, BypassActive(d, now))
 }

--- a/pkg/zpdb/eviction_controller.go
+++ b/pkg/zpdb/eviction_controller.go
@@ -182,8 +182,6 @@ func (c *EvictionController) HandlePodEvictionRequest(ctx context.Context, ar v1
 	// set up key=value pairs we include on all logs within this context
 	request.initLogger()
 
-	level.Debug(logger).Log("msg", "considering pod eviction")
-
 	// validate that this is a valid pod eviction create request
 	if err := request.validate(); err != nil {
 		level.Warn(request.log).Log("msg", logDenyMesg, "reason", "not a valid create pod eviction request", "err", err)
@@ -203,11 +201,15 @@ func (c *EvictionController) HandlePodEvictionRequest(ctx context.Context, ar v1
 	// path below exactly as before.
 	if cachedPod, cacheErr := c.podObserver.podLister.Pods(request.req.Request.Namespace).Get(request.req.Request.Name); cacheErr == nil {
 		if pdbConfig, findErr := c.cfgObserver.pdbCache.find(cachedPod); findErr == nil && pdbConfig == nil {
-			level.Debug(request.log).Log("msg", logAllowMesg, "reason", "pod is not within a zpdb scope")
+			if !isDeploymentManagedPod(cachedPod) {
+				level.Debug(request.log).Log("msg", logAllowMesg, "reason", "pod is not within a zpdb scope")
+			}
 			c.metrics.EvictionRequests.WithLabelValues("pod-not-in-scope", fmt.Sprintf("%d", http.StatusOK)).Inc()
 			return request.allow()
 		}
 	}
+
+	level.Debug(request.log).Log("msg", "considering pod eviction")
 
 	// get the pod which has been requested for eviction
 	var pod *corev1.Pod
@@ -242,7 +244,9 @@ func (c *EvictionController) HandlePodEvictionRequest(ctx context.Context, ar v1
 		c.metrics.EvictionRequests.WithLabelValues("cfg-not-found", fmt.Sprintf("%d", http.StatusBadRequest)).Inc()
 		return request.denyWithReason(err.Error(), http.StatusBadRequest)
 	} else if pdbConfig == nil {
-		level.Debug(request.log).Log("msg", logAllowMesg, "reason", "pod is not within a zpdb scope")
+		if !isDeploymentManagedPod(pod) {
+			level.Debug(request.log).Log("msg", logAllowMesg, "reason", "pod is not within a zpdb scope")
+		}
 		c.metrics.EvictionRequests.WithLabelValues("pod-not-in-scope", fmt.Sprintf("%d", http.StatusOK)).Inc()
 		return request.allow()
 	}

--- a/pkg/zpdb/eviction_controller_test.go
+++ b/pkg/zpdb/eviction_controller_test.go
@@ -103,6 +103,15 @@ func (d *dummyLogger) assertHasLog(t *testing.T, elements []string) {
 	require.Fail(t, "Expected log not found", strings.Join(elements, ", "))
 }
 
+func (d *dummyLogger) assertNoLogContains(t *testing.T, elements ...string) {
+	t.Helper()
+	for _, line := range d.logs {
+		for _, element := range elements {
+			require.NotContains(t, line, element)
+		}
+	}
+}
+
 func newTestContext(t *testing.T, request admissionv1.AdmissionReview, pdbRawConfig *unstructured.Unstructured, objects ...runtime.Object) *testContext {
 	testCtx := &testContext{
 		ctx:     context.Background(),
@@ -245,6 +254,22 @@ func TestPodEviction_PodNotInScope(t *testing.T) {
 	testCtx := newTestContext(t, createBasicEvictionAdmissionReview(testPodZoneA0, testNamespace), nil, pod, sts)
 	defer testCtx.controller.Stop()
 	testCtx.assertAllowResponse(t)
+	testCtx.logs.assertHasLog(t, []string{`msg="pod eviction allowed"`, `reason="pod is not within a zpdb scope"`})
+	require.Equal(t, float64(1), testutil.ToFloat64(testCtx.controller.metrics.EvictionRequests.WithLabelValues("pod-not-in-scope", "200")))
+}
+
+func TestPodEviction_DeploymentPodNotInScope_DoesNotLogZPDBDecision(t *testing.T) {
+	pod := newDeploymentPod("distributor-zone-b-abc")
+	testCtx := newTestContext(t, createBasicEvictionAdmissionReview(pod.Name, testNamespace), nil, pod)
+	defer testCtx.controller.Stop()
+
+	testCtx.assertAllowResponse(t)
+
+	testCtx.logs.assertNoLogContains(t,
+		"observer ignoring pod - not within zpdb scope",
+		"considering pod eviction",
+		"pod eviction allowed",
+	)
 	require.Equal(t, float64(1), testutil.ToFloat64(testCtx.controller.metrics.EvictionRequests.WithLabelValues("pod-not-in-scope", "200")))
 }
 
@@ -790,6 +815,24 @@ func newPod(name string, sts *appsv1.StatefulSet) *corev1.Pod {
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
 		},
+	}
+}
+
+func newDeploymentPod(name string) *corev1.Pod {
+	controller := true
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID(uuid.New().String()),
+			Name:      name,
+			Namespace: testNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "ReplicaSet",
+				Name:       "distributor-zone-b-abc",
+				Controller: &controller,
+			}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
 }
 

--- a/pkg/zpdb/pod_observer.go
+++ b/pkg/zpdb/pod_observer.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -124,11 +126,20 @@ func (c *podObserver) accept(obj interface{}) (*corev1.Pod, bool) {
 		return nil, false
 	}
 	if pdbConfig == nil {
-		level.Debug(c.logger).Log("msg", "observer ignoring pod - not within zpdb scope", "pod", pod.Name)
+		if !isDeploymentManagedPod(pod) {
+			level.Debug(c.logger).Log("msg", "observer ignoring pod - not within zpdb scope", "pod", pod.Name)
+		}
 		return nil, false
 	}
 
 	return pod, true
+}
+
+func isDeploymentManagedPod(pod *corev1.Pod) bool {
+	owner := metav1.GetControllerOf(pod)
+	// Deployment pods are directly controlled by ReplicaSets; checking the local owner reference avoids
+	// an API lookup on every pod informer event.
+	return owner != nil && owner.APIVersion == appsv1.SchemeGroupVersion.String() && owner.Kind == "ReplicaSet"
 }
 
 func (c *podObserver) onPodAdded(obj interface{}) {

--- a/pkg/zpdb/pod_observer_test.go
+++ b/pkg/zpdb/pod_observer_test.go
@@ -134,6 +134,40 @@ func TestPodObserver_InvalidObject(t *testing.T) {
 	observer.onPodDeleted(invalidObj)
 }
 
+func TestIsDeploymentManagedPod(t *testing.T) {
+	controller := true
+	notController := false
+	tests := map[string]struct {
+		owner *metav1.OwnerReference
+		want  bool
+	}{
+		"deployment ReplicaSet": {
+			owner: &metav1.OwnerReference{APIVersion: "apps/v1", Kind: "ReplicaSet", Controller: &controller},
+			want:  true,
+		},
+		"StatefulSet": {
+			owner: &metav1.OwnerReference{APIVersion: "apps/v1", Kind: "StatefulSet", Controller: &controller},
+		},
+		"non-controller ReplicaSet reference": {
+			owner: &metav1.OwnerReference{APIVersion: "apps/v1", Kind: "ReplicaSet", Controller: &notController},
+		},
+		"ReplicaSet from another API group": {
+			owner: &metav1.OwnerReference{APIVersion: "example.com/v1", Kind: "ReplicaSet", Controller: &controller},
+		},
+		"no owner": {},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			pod := &corev1.Pod{}
+			if tc.owner != nil {
+				pod.OwnerReferences = []metav1.OwnerReference{*tc.owner}
+			}
+			require.Equal(t, tc.want, isDeploymentManagedPod(pod))
+		})
+	}
+}
+
 // TestObserver_IgnorePodEvents validates the pod eviction cache is not invalidated until the pod phase changes
 func TestObserver_IgnorePodEvents(t *testing.T) {
 	_, observer := newPodObserverTestCase(t)


### PR DESCRIPTION
## Summary

Add opt-in phased rollouts for Deployments so a main workload (for example zone-b) stays paused until its canary Deployment(s) finish rolling and become ready—without introducing OpenKruise/Argo/Flagger or managing ReplicaSets.

- Mutating webhook `/admission/phased-deployment` pauses mains on revision change and re-applies `spec.paused` while the gate is active (Flux SSA-safe)
- Controller waits until every `grafana.com/rollout-canary` (comma-separated) reaches the shared `grafana.com/rollout-revision` and is fully rolled out, then unpauses
- Incident bypass via time-limited `grafana.com/rollout-bypass-until` (Warning event + metric); no soak/restart health checks here (proposal 4b)

### Context

Stateless components still use native Deployment rolling updates today, so a bad image can hit every replica in a cell before post-rollout checks fail. This is proposal 4c from the safer stateless rollouts design: explicit Git-defined Deployments plus operator gating. Prometheus health gating (4b) is intentionally out of scope for this PR.