### PR TITLE
Prefer annotation for min-time-between-zones-downscale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main / unreleased
 
+* [CHANGE] Prefer `grafana.com/min-time-between-zones-downscale` as a StatefulSet annotation instead of a label. The label remains supported as a fallback and logs a deprecation warning when used. #463
 * [ENHANCEMENT] Updated dependencies, including: #470
   * `github.com/prometheus/client_golang` from `v1.23.2` to `v1.24.1`
   * `github.com/prometheus/common` from `v0.70.0` to `v0.70.1`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For each **rollout group**, the operator **guarantees**:
 
 ## How scaling up and down works
 
-The operator can also optionally coordinate scaling up and down of `StatefulSets` that are part of the same `rollout-group` based on the `grafana.com/rollout-downscale-leader` annotation. When using this feature, the `grafana.com/min-time-between-zones-downscale` label must also be set on each `StatefulSet`.
+The operator can also optionally coordinate scaling up and down of `StatefulSets` that are part of the same `rollout-group` based on the `grafana.com/rollout-downscale-leader` annotation. When using this feature, the `grafana.com/min-time-between-zones-downscale` annotation must also be set on each `StatefulSet`. For migration, the same key is still accepted as a label (with a warning) and will be removed in a future release.
 
 This can be useful for automating the tedious scaling of stateful services like Mimir ingesters. Making use of this feature requires adding a few annotations and labels to configure how it works.
 
@@ -41,25 +41,25 @@ Example usage for a multi-AZ ingester group:
 
 - For `ingester-zone-a`, add the following:
   - Labels:
-    - `grafana.com/min-time-between-zones-downscale=12h` (change the value here to an appropriate duration)
     - `grafana.com/prepare-downscale=true` (to allow the service to be notified when it will be scaled down)
   - Annotations:
+    - `grafana.com/min-time-between-zones-downscale=12h` (change the value here to an appropriate duration)
     - `grafana.com/prepare-downscale-http-path=ingester/prepare-shutdown` (to call a specific endpoint on the service)
     - `grafana.com/prepare-downscale-http-port=80` (to call a specific endpoint on the service)
 - For `ingester-zone-b`, add the following:
   - Labels:
-    - `grafana.com/min-time-between-zones-downscale=12h` (change the value here to an appropriate duration)
     - `grafana.com/prepare-downscale=true` (to allow the service to be notified when it will be scaled down)
   - Annotations:
+    - `grafana.com/min-time-between-zones-downscale=12h` (change the value here to an appropriate duration)
     - `grafana.com/rollout-downscale-leader=ingester-zone-a` (zone `b` will follow zone `a`, after a delay)
     - `grafana.com/rollout-upscale-only-when-leader-ready=true` (zone `b` will only scale up once all replicas in zone `a` are ready)
     - `grafana.com/prepare-downscale-http-path=ingester/prepare-shutdown` (to call a specific endpoint on the service)
     - `grafana.com/prepare-downscale-http-port=80` (to call a specific endpoint on the service)
 - For `ingester-zone-c`, add the following:
   - Labels:
-    - `grafana.com/min-time-between-zones-downscale=12h` (change the value here to an appropriate duration)
     - `grafana.com/prepare-downscale=true` (to allow the service to be notified when it will be scaled down)
   - Annotations:
+    - `grafana.com/min-time-between-zones-downscale=12h` (change the value here to an appropriate duration)
     - `grafana.com/rollout-downscale-leader=ingester-zone-b` (zone `c` will follow zone `b`, after a delay)
     - `grafana.com/rollout-upscale-only-when-leader-ready=true` (zone `c` will only scale up once all replicas in zone `b` are ready)
     - `grafana.com/prepare-downscale-http-path=ingester/prepare-shutdown` (to call a specific endpoint on the service)
@@ -394,7 +394,7 @@ The following annotations also have to be present:
 - `grafana.com/prepare-downscale-http-path`
 - `grafana.com/prepare-downscale-http-port`
 
-If the `grafana.com/last-downscale` annotation is present on any of the stateful sets in the same rollout group it's value will be checked against the current time. If the difference is less than the `grafana.com/min-time-between-zones-downscale` label (if present) then the request is rejected. Otherwise the request is approved. This mechanism can be used to maintain a time between downscales of the stateful sets in a rollout group.
+If the `grafana.com/last-downscale` annotation is present on any of the stateful sets in the same rollout group it's value will be checked against the current time. If the difference is less than the `grafana.com/min-time-between-zones-downscale` annotation (if present; the same key is still accepted as a label for migration) then the request is rejected. Otherwise the request is approved. This mechanism can be used to maintain a time between downscales of the stateful sets in a rollout group.
 
 The endpoint created from `grafana.com/prepare-downscale-http-path` and `grafana.com/prepare-downscale-http-port` will be called for each of the pods that have to be downscaled. If any of these requests fail the downscaling request is rejected.
 

--- a/pkg/admission/prep_downscale.go
+++ b/pkg/admission/prep_downscale.go
@@ -130,7 +130,7 @@ func prepareDownscale(ctx context.Context, l log.Logger, ar admissionv1.Admissio
 				),
 			)
 		}
-		foundSts, err := findDownscalesDoneMinTimeAgo(stsList, ar.Request.Name)
+		foundSts, err := findDownscalesDoneMinTimeAgo(stsList, ar.Request.Name, logger)
 		if err != nil {
 			level.Warn(logger).Log("msg", "downscale not allowed due to error while parsing downscale annotations", "err", err)
 			return deny(
@@ -141,7 +141,7 @@ func prepareDownscale(ctx context.Context, l log.Logger, ar admissionv1.Admissio
 			)
 		}
 		if foundSts != nil {
-			msg := fmt.Sprintf("downscale of %s/%s in %s from %d to %d replicas is not allowed because statefulset %v was downscaled at %v and is labelled to wait %s between zone downscales",
+			msg := fmt.Sprintf("downscale of %s/%s in %s from %d to %d replicas is not allowed because statefulset %v was downscaled at %v and is configured to wait %s between zone downscales",
 				ar.Request.Resource.Resource, ar.Request.Name, ar.Request.Namespace, *oldInfo.replicas, *newInfo.replicas, foundSts.name, foundSts.lastDownscaleTime, foundSts.waitTime)
 			level.Warn(logger).Log("msg", msg, "err", err)
 			return deny(msg)
@@ -286,19 +286,19 @@ type statefulSetDownscale struct {
 }
 
 // findDownscalesDoneMinTimeAgo checks whether there's any StatefulSet in the stsList which has been downscaled
-// less than "min allowed time" ago. The timestamp of the last downscale and the minimum time required between
-// downscales are set as StatefulSet annotation and label respectively. If such annotations and labels can't be
-// parsed, then this function returns an error.
+// less than "min allowed time" ago. The timestamp of the last downscale is a StatefulSet annotation; the
+// minimum time between zone downscales is preferred as an annotation (label still accepted for migration).
+// If such values can't be parsed, then this function returns an error.
 //
 // The StatefulSet whose name matches the input excludeStsName is not checked.
-func findDownscalesDoneMinTimeAgo(stsList *appsv1.StatefulSetList, excludeStsName string) (*statefulSetDownscale, error) {
+func findDownscalesDoneMinTimeAgo(stsList *appsv1.StatefulSetList, excludeStsName string, logger log.Logger) (*statefulSetDownscale, error) {
 	for _, sts := range stsList.Items {
 		if sts.Name == excludeStsName {
 			continue
 		}
 		lastDownscaleAnnotation, ok := sts.Annotations[config.LastDownscaleAnnotationKey]
 		if !ok {
-			// No last downscale label set on the statefulset, we can continue
+			// No last downscale annotation set on the statefulset, we can continue
 			continue
 		}
 
@@ -307,15 +307,15 @@ func findDownscalesDoneMinTimeAgo(stsList *appsv1.StatefulSetList, excludeStsNam
 			return nil, fmt.Errorf("can't parse %v annotation of %s: %w", config.LastDownscaleAnnotationKey, sts.Name, err)
 		}
 
-		timeBetweenDownscaleLabel, ok := sts.Labels[config.MinTimeBetweenZonesDownscaleLabelKey]
+		timeBetweenDownscale, ok := config.GetMinTimeBetweenZonesDownscale(&sts, logger)
 		if !ok {
-			// No time between downscale label set on the statefulset, we can continue
+			// No time between downscale configured on the statefulset, we can continue
 			continue
 		}
 
-		minTimeBetweenDownscale, err := time.ParseDuration(timeBetweenDownscaleLabel)
+		minTimeBetweenDownscale, err := time.ParseDuration(timeBetweenDownscale)
 		if err != nil {
-			return nil, fmt.Errorf("can't parse %v label of %s: %w", config.MinTimeBetweenZonesDownscaleLabelKey, sts.Name, err)
+			return nil, fmt.Errorf("can't parse annotation or label %v of %s: %w", config.MinTimeBetweenZonesDownscaleAnnotationKey, sts.Name, err)
 		}
 
 		if time.Since(lastDownscale) < minTimeBetweenDownscale {

--- a/pkg/admission/prep_downscale_test.go
+++ b/pkg/admission/prep_downscale_test.go
@@ -337,11 +337,11 @@ func testPrepDownscaleWebhook(t *testing.T, oldReplicas, newReplicas int, option
 					Namespace: namespace,
 					UID:       types.UID(stsName),
 					Labels: map[string]string{
-						config.RolloutGroupLabelKey:                 "ingester",
-						config.MinTimeBetweenZonesDownscaleLabelKey: "12h",
+						config.RolloutGroupLabelKey: "ingester",
 					},
 					Annotations: map[string]string{
-						config.LastDownscaleAnnotationKey: time.Now().UTC().Format(time.RFC3339),
+						config.LastDownscaleAnnotationKey:                time.Now().UTC().Format(time.RFC3339),
+						config.MinTimeBetweenZonesDownscaleAnnotationKey: "12h",
 					},
 				},
 			},
@@ -814,8 +814,10 @@ func testPrepDownscaleWebhookWithZoneTracker(t *testing.T, oldReplicas, newRepli
 					Namespace: namespace,
 					UID:       types.UID(stsName),
 					Labels: map[string]string{
-						config.RolloutGroupLabelKey:                 "ingester",
-						config.MinTimeBetweenZonesDownscaleLabelKey: "12h",
+						config.RolloutGroupLabelKey: "ingester",
+					},
+					Annotations: map[string]string{
+						config.MinTimeBetweenZonesDownscaleAnnotationKey: "12h",
 					},
 				},
 			},

--- a/pkg/admission/zone_tracker.go
+++ b/pkg/admission/zone_tracker.go
@@ -131,7 +131,7 @@ func (zt *zoneTracker) prepareDownscale(ctx context.Context, l log.Logger, ar ad
 			)
 		}
 		// Check if the zone has been downscaled recently.
-		foundSts, err := zt.findDownscalesDoneMinTimeAgo(stsList, ar.Request.Name)
+		foundSts, err := zt.findDownscalesDoneMinTimeAgo(stsList, ar.Request.Name, logger)
 		if err != nil {
 			level.Warn(logger).Log("msg", "downscale not allowed due to error while parsing downscale timestamps from the zone ConfigMap", "err", err)
 			return deny(
@@ -142,7 +142,7 @@ func (zt *zoneTracker) prepareDownscale(ctx context.Context, l log.Logger, ar ad
 			)
 		}
 		if foundSts != nil {
-			msg := fmt.Sprintf("downscale of %s/%s in %s from %d to %d replicas is not allowed because statefulset %v was downscaled at %v and is labelled to wait %s between zone downscales",
+			msg := fmt.Sprintf("downscale of %s/%s in %s from %d to %d replicas is not allowed because statefulset %v was downscaled at %v and is configured to wait %s between zone downscales",
 				ar.Request.Resource.Resource, ar.Request.Name, ar.Request.Namespace, *oldInfo.replicas, *newInfo.replicas, foundSts.name, foundSts.lastDownscaleTime, foundSts.waitTime)
 			level.Warn(logger).Log("msg", msg, "err", err)
 			return deny(msg)
@@ -358,7 +358,7 @@ func (zt *zoneTracker) setDownscaled(ctx context.Context, zone string) error {
 }
 
 // findDownscalesDoneMinTimeAgo returns the statefulset that was downscaled the least amount of time ago
-func (zt *zoneTracker) findDownscalesDoneMinTimeAgo(stsList *appsv1.StatefulSetList, stsName string) (*statefulSetDownscale, error) {
+func (zt *zoneTracker) findDownscalesDoneMinTimeAgo(stsList *appsv1.StatefulSetList, stsName string, logger log.Logger) (*statefulSetDownscale, error) {
 	zt.mu.Lock()
 	defer zt.mu.Unlock()
 
@@ -378,15 +378,15 @@ func (zt *zoneTracker) findDownscalesDoneMinTimeAgo(stsList *appsv1.StatefulSetL
 			return nil, fmt.Errorf("can't parse last downscale time of %s: %w", sts.Name, err)
 		}
 
-		timeBetweenDownscaleLabel, ok := sts.Labels[config.MinTimeBetweenZonesDownscaleLabelKey]
+		timeBetweenDownscale, ok := config.GetMinTimeBetweenZonesDownscale(&sts, logger)
 		if !ok {
-			// No time between downscale label set on the statefulset, we can continue
+			// No time between downscale configured on the statefulset, we can continue
 			continue
 		}
 
-		minTimeBetweenDownscale, err := time.ParseDuration(timeBetweenDownscaleLabel)
+		minTimeBetweenDownscale, err := time.ParseDuration(timeBetweenDownscale)
 		if err != nil {
-			return nil, fmt.Errorf("can't parse %v label of %s: %w", config.MinTimeBetweenZonesDownscaleLabelKey, sts.Name, err)
+			return nil, fmt.Errorf("can't parse annotation or label %v of %s: %w", config.MinTimeBetweenZonesDownscaleAnnotationKey, sts.Name, err)
 		}
 
 		if time.Since(lastDownscale) < minTimeBetweenDownscale {

--- a/pkg/admission/zone_tracker_test.go
+++ b/pkg/admission/zone_tracker_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -104,6 +105,54 @@ func TestZoneTrackerFindDownscalesDoneMinTimeAgo(t *testing.T) {
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-zone",
+					Annotations: map[string]string{
+						config.MinTimeBetweenZonesDownscaleAnnotationKey: "2h",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "other-zone",
+					Annotations: map[string]string{
+						config.MinTimeBetweenZonesDownscaleAnnotationKey: "1h",
+					},
+				},
+			},
+		},
+	}
+
+	if err := zt.loadZones(ctx, stsList); err != nil {
+		t.Fatalf("loadZones failed: %v", err)
+	}
+
+	s, err := zt.findDownscalesDoneMinTimeAgo(stsList, "other-zone", log.NewNopLogger())
+	if err != nil {
+		t.Fatalf("findDownscalesDoneMinTimeAgo failed: %v", err)
+	}
+
+	if s == nil {
+		t.Fatalf("findDownscalesDoneMinTimeAgo returned nil, want statefulSetDownscale")
+	}
+
+	if s.name != "test-zone" {
+		t.Errorf("findDownscalesDoneMinTimeAgo returned statefulSetDownscale with name %s, want test-zone", s.name)
+	}
+
+	if s.waitTime != 2*time.Hour {
+		t.Errorf("findDownscalesDoneMinTimeAgo returned statefulSetDownscale with waitTime %v, want 2h", s.waitTime)
+	}
+}
+
+func TestZoneTrackerFindDownscalesDoneMinTimeAgoLabelFallback(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewClientset()
+	zt := newZoneTracker(client, "cluster.local", "testnamespace", "testconfigmap")
+
+	stsList := &appsv1.StatefulSetList{
+		Items: []appsv1.StatefulSet{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-zone",
 					Labels: map[string]string{
 						config.MinTimeBetweenZonesDownscaleLabelKey: "2h",
 					},
@@ -124,22 +173,11 @@ func TestZoneTrackerFindDownscalesDoneMinTimeAgo(t *testing.T) {
 		t.Fatalf("loadZones failed: %v", err)
 	}
 
-	s, err := zt.findDownscalesDoneMinTimeAgo(stsList, "other-zone")
-	if err != nil {
-		t.Fatalf("findDownscalesDoneMinTimeAgo failed: %v", err)
-	}
-
-	if s == nil {
-		t.Fatalf("findDownscalesDoneMinTimeAgo returned nil, want statefulSetDownscale")
-	}
-
-	if s.name != "test-zone" {
-		t.Errorf("findDownscalesDoneMinTimeAgo returned statefulSetDownscale with name %s, want test-zone", s.name)
-	}
-
-	if s.waitTime != 2*time.Hour {
-		t.Errorf("findDownscalesDoneMinTimeAgo returned statefulSetDownscale with waitTime %v, want 2h", s.waitTime)
-	}
+	s, err := zt.findDownscalesDoneMinTimeAgo(stsList, "other-zone", log.NewNopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	require.Equal(t, "test-zone", s.name)
+	require.Equal(t, 2*time.Hour, s.waitTime)
 }
 
 func TestLoadZonesCreatesInitialZones(t *testing.T) {
@@ -155,16 +193,16 @@ func TestLoadZonesCreatesInitialZones(t *testing.T) {
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-zone",
-					Labels: map[string]string{
-						config.MinTimeBetweenZonesDownscaleLabelKey: "2h",
+					Annotations: map[string]string{
+						config.MinTimeBetweenZonesDownscaleAnnotationKey: "2h",
 					},
 				},
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "other-zone",
-					Labels: map[string]string{
-						config.MinTimeBetweenZonesDownscaleLabelKey: "1h",
+					Annotations: map[string]string{
+						config.MinTimeBetweenZonesDownscaleAnnotationKey: "1h",
 					},
 				},
 			},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,9 +7,12 @@ const (
 
 	// LastDownscaleAnnotationKey is the last time the statefulset was scaled down in UTC in time.RFC3339 format.
 	LastDownscaleAnnotationKey = "grafana.com/last-downscale"
-	// MinTimeBetweenZonesDownscaleLabelKey is the minimum duration allowed between downscales of zones that are
-	// part of the same rollout group in Go time.Duration format.
-	MinTimeBetweenZonesDownscaleLabelKey = "grafana.com/min-time-between-zones-downscale"
+	// MinTimeBetweenZonesDownscaleAnnotationKey is the minimum duration allowed between downscales of zones that are
+	// part of the same rollout group in Go time.Duration format. Prefer this over the label with the same key.
+	MinTimeBetweenZonesDownscaleAnnotationKey = "grafana.com/min-time-between-zones-downscale"
+	// MinTimeBetweenZonesDownscaleLabelKey is the deprecated label form of MinTimeBetweenZonesDownscaleAnnotationKey.
+	// Still accepted for migration; prefer the annotation.
+	MinTimeBetweenZonesDownscaleLabelKey = MinTimeBetweenZonesDownscaleAnnotationKey
 	// PrepareDownscalePathAnnotationKey is the path to the endpoint on each pod that should be called when the
 	// statefulset is being prepared to be scaled down.
 	PrepareDownscalePathAnnotationKey = "grafana.com/prepare-downscale-http-path"

--- a/pkg/config/min_time_between_zones.go
+++ b/pkg/config/min_time_between_zones.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// warnedMinTimeLabelObjects tracks objects for which we've already logged the
+// deprecated-label warning, to avoid spamming on every reconcile/admission check.
+var warnedMinTimeLabelObjects sync.Map
+
+// GetMinTimeBetweenZonesDownscale returns the configured minimum time between zone
+// downscales from the object's metadata. The annotation is preferred. The label is
+// still accepted for migration and emits a warning when used.
+func GetMinTimeBetweenZonesDownscale(obj metav1.Object, logger log.Logger) (string, bool) {
+	if annotations := obj.GetAnnotations(); annotations != nil {
+		if value, ok := annotations[MinTimeBetweenZonesDownscaleAnnotationKey]; ok && value != "" {
+			return value, true
+		}
+	}
+
+	if labels := obj.GetLabels(); labels != nil {
+		if value, ok := labels[MinTimeBetweenZonesDownscaleLabelKey]; ok && value != "" {
+			warnKey := obj.GetNamespace() + "/" + obj.GetName()
+			if _, alreadyWarned := warnedMinTimeLabelObjects.LoadOrStore(warnKey, struct{}{}); !alreadyWarned {
+				level.Warn(logger).Log(
+					"msg", fmt.Sprintf("%s is set as a label; prefer the annotation with the same key. Label support will be removed in a future release", MinTimeBetweenZonesDownscaleLabelKey),
+					"name", obj.GetName(),
+					"namespace", obj.GetNamespace(),
+				)
+			}
+			return value, true
+		}
+	}
+
+	return "", false
+}

--- a/pkg/config/min_time_between_zones.go
+++ b/pkg/config/min_time_between_zones.go
@@ -9,9 +9,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// warnedMinTimeLabelObjects tracks objects for which we've already logged the
-// deprecated-label warning, to avoid spamming on every reconcile/admission check.
-var warnedMinTimeLabelObjects sync.Map
+// warnMinTimeLabelOnce ensures we only log the deprecated-label warning once
+// for the process lifetime, to avoid spamming on every reconcile/admission check.
+var warnMinTimeLabelOnce sync.Once
 
 // GetMinTimeBetweenZonesDownscale returns the configured minimum time between zone
 // downscales from the object's metadata. The annotation is preferred. The label is
@@ -25,14 +25,13 @@ func GetMinTimeBetweenZonesDownscale(obj metav1.Object, logger log.Logger) (stri
 
 	if labels := obj.GetLabels(); labels != nil {
 		if value, ok := labels[MinTimeBetweenZonesDownscaleLabelKey]; ok && value != "" {
-			warnKey := obj.GetNamespace() + "/" + obj.GetName()
-			if _, alreadyWarned := warnedMinTimeLabelObjects.LoadOrStore(warnKey, struct{}{}); !alreadyWarned {
+			warnMinTimeLabelOnce.Do(func() {
 				level.Warn(logger).Log(
 					"msg", fmt.Sprintf("%s is set as a label; prefer the annotation with the same key. Label support will be removed in a future release", MinTimeBetweenZonesDownscaleLabelKey),
 					"name", obj.GetName(),
 					"namespace", obj.GetNamespace(),
 				)
-			}
+			})
 			return value, true
 		}
 	}

--- a/pkg/config/min_time_between_zones_test.go
+++ b/pkg/config/min_time_between_zones_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetMinTimeBetweenZonesDownscale(t *testing.T) {
+	t.Run("prefers annotation over label", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := log.NewLogfmtLogger(&buf)
+
+		obj := &metav1.ObjectMeta{
+			Name:      "sts-annotation-preferred",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				MinTimeBetweenZonesDownscaleAnnotationKey: "12h",
+			},
+			Labels: map[string]string{
+				MinTimeBetweenZonesDownscaleLabelKey: "1h",
+			},
+		}
+
+		value, ok := GetMinTimeBetweenZonesDownscale(obj, logger)
+		require.True(t, ok)
+		require.Equal(t, "12h", value)
+		require.Empty(t, buf.String())
+	})
+
+	t.Run("falls back to label with warning", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := log.NewLogfmtLogger(&buf)
+
+		obj := &metav1.ObjectMeta{
+			Name:      "sts-label-fallback",
+			Namespace: "ns",
+			Labels: map[string]string{
+				MinTimeBetweenZonesDownscaleLabelKey: "6h",
+			},
+		}
+
+		value, ok := GetMinTimeBetweenZonesDownscale(obj, logger)
+		require.True(t, ok)
+		require.Equal(t, "6h", value)
+		require.Contains(t, buf.String(), "is set as a label")
+		require.Contains(t, buf.String(), "prefer the annotation")
+
+		// Second read should not warn again for the same object.
+		buf.Reset()
+		value, ok = GetMinTimeBetweenZonesDownscale(obj, logger)
+		require.True(t, ok)
+		require.Equal(t, "6h", value)
+		require.Empty(t, buf.String())
+	})
+
+	t.Run("empty annotation falls back to label", func(t *testing.T) {
+		obj := &metav1.ObjectMeta{
+			Name:      "sts-empty-annotation",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				MinTimeBetweenZonesDownscaleAnnotationKey: "",
+			},
+			Labels: map[string]string{
+				MinTimeBetweenZonesDownscaleLabelKey: "3h",
+			},
+		}
+
+		value, ok := GetMinTimeBetweenZonesDownscale(obj, log.NewNopLogger())
+		require.True(t, ok)
+		require.Equal(t, "3h", value)
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		value, ok := GetMinTimeBetweenZonesDownscale(&metav1.ObjectMeta{Name: "sts"}, log.NewNopLogger())
+		require.False(t, ok)
+		require.Empty(t, value)
+	})
+}
+
+func TestMinTimeBetweenZonesDownscaleKeys(t *testing.T) {
+	require.Equal(t, MinTimeBetweenZonesDownscaleAnnotationKey, MinTimeBetweenZonesDownscaleLabelKey)
+	require.True(t, strings.HasPrefix(MinTimeBetweenZonesDownscaleAnnotationKey, "grafana.com/"))
+}

--- a/pkg/config/min_time_between_zones_test.go
+++ b/pkg/config/min_time_between_zones_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -11,6 +12,9 @@ import (
 )
 
 func TestGetMinTimeBetweenZonesDownscale(t *testing.T) {
+	// Reset the process-wide Once so this test package can assert warning behavior.
+	warnMinTimeLabelOnce = sync.Once{}
+
 	t.Run("prefers annotation over label", func(t *testing.T) {
 		var buf bytes.Buffer
 		logger := log.NewLogfmtLogger(&buf)
@@ -33,6 +37,7 @@ func TestGetMinTimeBetweenZonesDownscale(t *testing.T) {
 	})
 
 	t.Run("falls back to label with warning", func(t *testing.T) {
+		warnMinTimeLabelOnce = sync.Once{}
 		var buf bytes.Buffer
 		logger := log.NewLogfmtLogger(&buf)
 
@@ -50,7 +55,7 @@ func TestGetMinTimeBetweenZonesDownscale(t *testing.T) {
 		require.Contains(t, buf.String(), "is set as a label")
 		require.Contains(t, buf.String(), "prefer the annotation")
 
-		// Second read should not warn again for the same object.
+		// Second read should not warn again.
 		buf.Reset()
 		value, ok = GetMinTimeBetweenZonesDownscale(obj, logger)
 		require.True(t, ok)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -406,19 +406,15 @@ func TestRolloutController_Reconcile(t *testing.T) {
 		"should not update replicas within minimum time between downscales": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-a", withReplicas(2, 2),
-					withLabels(map[string]string{
-						"grafana.com/min-time-between-zones-downscale": "12h",
-					}),
 					withAnnotations(map[string]string{
-						"grafana.com/last-downscale": time.Now().UTC().Add(-time.Hour).Format(time.RFC3339),
+						"grafana.com/min-time-between-zones-downscale": "12h",
+						"grafana.com/last-downscale":                   time.Now().UTC().Add(-time.Hour).Format(time.RFC3339),
 					}),
 				),
 				mockStatefulSet("ingester-zone-b", withReplicas(3, 3), withPrevRevision(),
-					withLabels(map[string]string{
-						"grafana.com/min-time-between-zones-downscale": "12h",
-					}),
 					withAnnotations(map[string]string{
-						"grafana.com/rollout-downscale-leader": "ingester-zone-a",
+						"grafana.com/min-time-between-zones-downscale": "12h",
+						"grafana.com/rollout-downscale-leader":         "ingester-zone-a",
 					}),
 				),
 			},
@@ -433,15 +429,13 @@ func TestRolloutController_Reconcile(t *testing.T) {
 		},
 		"should return early and not delete pods if StatefulSet replicas are adjusted": {
 			statefulSets: []runtime.Object{
-				mockStatefulSet("ingester-zone-a", withReplicas(2, 2), withLabels(map[string]string{
+				mockStatefulSet("ingester-zone-a", withReplicas(2, 2), withAnnotations(map[string]string{
 					"grafana.com/min-time-between-zones-downscale": "12h",
 				})),
 				mockStatefulSet("ingester-zone-b", withReplicas(3, 3), withPrevRevision(),
-					withLabels(map[string]string{
-						"grafana.com/min-time-between-zones-downscale": "12h",
-					}),
 					withAnnotations(map[string]string{
-						"grafana.com/rollout-downscale-leader": "ingester-zone-a",
+						"grafana.com/min-time-between-zones-downscale": "12h",
+						"grafana.com/rollout-downscale-leader":         "ingester-zone-a",
 					}),
 				),
 			},
@@ -456,15 +450,13 @@ func TestRolloutController_Reconcile(t *testing.T) {
 		},
 		"should not return early and should delete pods if StatefulSet replicas cannot be scaled down": {
 			statefulSets: []runtime.Object{
-				mockStatefulSet("ingester-zone-a", withReplicas(2, 2), withLabels(map[string]string{
+				mockStatefulSet("ingester-zone-a", withReplicas(2, 2), withAnnotations(map[string]string{
 					"grafana.com/min-time-between-zones-downscale": "12h",
 				})),
 				mockStatefulSet("ingester-zone-b", withReplicas(3, 3), withPrevRevision(),
-					withLabels(map[string]string{
-						"grafana.com/min-time-between-zones-downscale": "12h",
-					}),
 					withAnnotations(map[string]string{
-						"grafana.com/rollout-downscale-leader": "ingester-zone-a",
+						"grafana.com/min-time-between-zones-downscale": "12h",
+						"grafana.com/rollout-downscale-leader":         "ingester-zone-a",
 					}),
 				),
 			},
@@ -480,15 +472,13 @@ func TestRolloutController_Reconcile(t *testing.T) {
 		},
 		"should not return early and should delete pods if StatefulSet replicas cannot be scaled down - enforce downscale pdb": {
 			statefulSets: []runtime.Object{
-				mockStatefulSet("ingester-zone-a", withReplicas(1, 1), withLabels(map[string]string{
+				mockStatefulSet("ingester-zone-a", withReplicas(1, 1), withAnnotations(map[string]string{
 					"grafana.com/min-time-between-zones-downscale": "12h",
 				})),
 				mockStatefulSet("ingester-zone-b", withReplicas(3, 3), withPrevRevision(),
-					withLabels(map[string]string{
-						"grafana.com/min-time-between-zones-downscale": "12h",
-					}),
 					withAnnotations(map[string]string{
-						"grafana.com/rollout-downscale-leader": "ingester-zone-a",
+						"grafana.com/min-time-between-zones-downscale": "12h",
+						"grafana.com/rollout-downscale-leader":         "ingester-zone-a",
 					}),
 				),
 			},
@@ -505,15 +495,13 @@ func TestRolloutController_Reconcile(t *testing.T) {
 		},
 		"should not return early and should delete pods if StatefulSet replicas cannot be scaled up": {
 			statefulSets: []runtime.Object{
-				mockStatefulSet("ingester-zone-a", withReplicas(3, 3), withLabels(map[string]string{
+				mockStatefulSet("ingester-zone-a", withReplicas(3, 3), withAnnotations(map[string]string{
 					"grafana.com/min-time-between-zones-downscale": "12h",
 				})),
 				mockStatefulSet("ingester-zone-b", withReplicas(2, 2), withPrevRevision(),
-					withLabels(map[string]string{
-						"grafana.com/min-time-between-zones-downscale": "12h",
-					}),
 					withAnnotations(map[string]string{
-						"grafana.com/rollout-downscale-leader": "ingester-zone-a",
+						"grafana.com/min-time-between-zones-downscale": "12h",
+						"grafana.com/rollout-downscale-leader":         "ingester-zone-a",
 					}),
 				),
 			},
@@ -529,15 +517,13 @@ func TestRolloutController_Reconcile(t *testing.T) {
 		},
 		"zpdb is enforced during a scale-up with a version update": {
 			statefulSets: []runtime.Object{
-				mockStatefulSet("ingester-zone-a", withReplicas(3, 3), withPrevRevision(), withLabels(map[string]string{
+				mockStatefulSet("ingester-zone-a", withReplicas(3, 3), withPrevRevision(), withAnnotations(map[string]string{
 					"grafana.com/min-time-between-zones-downscale": "12h",
 				})),
 				mockStatefulSet("ingester-zone-b", withReplicas(1, 1), withPrevRevision(),
-					withLabels(map[string]string{
-						"grafana.com/min-time-between-zones-downscale": "12h",
-					}),
 					withAnnotations(map[string]string{
-						"grafana.com/rollout-downscale-leader": "ingester-zone-a",
+						"grafana.com/min-time-between-zones-downscale": "12h",
+						"grafana.com/rollout-downscale-leader":         "ingester-zone-a",
 					}),
 				),
 			},

--- a/pkg/controller/replicas.go
+++ b/pkg/controller/replicas.go
@@ -119,15 +119,14 @@ func minimumTimeHasElapsed(follower *v1.StatefulSet, all []*v1.StatefulSet, logg
 		return true, nil
 	}
 
-	followerLabels := follower.GetLabels()
-	rawValue, ok := followerLabels[config.MinTimeBetweenZonesDownscaleLabelKey]
+	rawValue, ok := config.GetMinTimeBetweenZonesDownscale(follower, logger)
 	if !ok {
-		return false, fmt.Errorf("missing label %s on follower", config.MinTimeBetweenZonesDownscaleLabelKey)
+		return false, fmt.Errorf("missing annotation or label %s on follower", config.MinTimeBetweenZonesDownscaleAnnotationKey)
 	}
 
 	minTimeSinceDownscale, err := time.ParseDuration(rawValue)
 	if err != nil {
-		return false, fmt.Errorf("unable to parse label %s value on follower: %w", config.MinTimeBetweenZonesDownscaleLabelKey, err)
+		return false, fmt.Errorf("unable to parse annotation or label %s value on follower: %w", config.MinTimeBetweenZonesDownscaleAnnotationKey, err)
 	}
 
 	timeSinceDownscale := time.Since(lastDownscale)

--- a/pkg/controller/replicas_test.go
+++ b/pkg/controller/replicas_test.go
@@ -156,8 +156,8 @@ func TestMinimumTimeHasElapsed(t *testing.T) {
 		downscale1 := time.Now().UTC().Round(time.Second).Add(-12 * time.Hour)
 		downscale2 := time.Now().UTC().Round(time.Second).Add(-24 * time.Hour)
 
-		sts1 := mockStatefulSet("test-zone-a", withLabels(map[string]string{
-			config.MinTimeBetweenZonesDownscaleLabelKey: "invalid",
+		sts1 := mockStatefulSet("test-zone-a", withAnnotations(map[string]string{
+			config.MinTimeBetweenZonesDownscaleAnnotationKey: "invalid",
 		}))
 		sts2 := mockStatefulSet("test-zone-b", withAnnotations(map[string]string{
 			config.LastDownscaleAnnotationKey: downscale1.Format(time.RFC3339),
@@ -174,8 +174,8 @@ func TestMinimumTimeHasElapsed(t *testing.T) {
 		downscale1 := time.Now().UTC().Round(time.Second).Add(-10 * time.Hour)
 		downscale2 := time.Now().UTC().Round(time.Second).Add(-24 * time.Hour)
 
-		sts1 := mockStatefulSet("test-zone-a", withLabels(map[string]string{
-			config.MinTimeBetweenZonesDownscaleLabelKey: "12h",
+		sts1 := mockStatefulSet("test-zone-a", withAnnotations(map[string]string{
+			config.MinTimeBetweenZonesDownscaleAnnotationKey: "12h",
 		}))
 		sts2 := mockStatefulSet("test-zone-b", withAnnotations(map[string]string{
 			config.LastDownscaleAnnotationKey: downscale1.Format(time.RFC3339),
@@ -193,6 +193,25 @@ func TestMinimumTimeHasElapsed(t *testing.T) {
 		downscale1 := time.Now().UTC().Round(time.Second).Add(-14 * time.Hour)
 		downscale2 := time.Now().UTC().Round(time.Second).Add(-26 * time.Hour)
 
+		sts1 := mockStatefulSet("test-zone-a", withAnnotations(map[string]string{
+			config.MinTimeBetweenZonesDownscaleAnnotationKey: "12h",
+		}))
+		sts2 := mockStatefulSet("test-zone-b", withAnnotations(map[string]string{
+			config.LastDownscaleAnnotationKey: downscale1.Format(time.RFC3339),
+		}))
+		sts3 := mockStatefulSet("test-zone-c", withAnnotations(map[string]string{
+			config.LastDownscaleAnnotationKey: downscale2.Format(time.RFC3339),
+		}))
+
+		elapsed, err := minimumTimeHasElapsed(sts1, []*v1.StatefulSet{sts1, sts2, sts3}, log.NewNopLogger())
+		require.NoError(t, err)
+		require.True(t, elapsed)
+	})
+
+	t.Run("enough time via deprecated label", func(t *testing.T) {
+		downscale1 := time.Now().UTC().Round(time.Second).Add(-14 * time.Hour)
+		downscale2 := time.Now().UTC().Round(time.Second).Add(-26 * time.Hour)
+
 		sts1 := mockStatefulSet("test-zone-a", withLabels(map[string]string{
 			config.MinTimeBetweenZonesDownscaleLabelKey: "12h",
 		}))
@@ -206,6 +225,26 @@ func TestMinimumTimeHasElapsed(t *testing.T) {
 		elapsed, err := minimumTimeHasElapsed(sts1, []*v1.StatefulSet{sts1, sts2, sts3}, log.NewNopLogger())
 		require.NoError(t, err)
 		require.True(t, elapsed)
+	})
+
+	t.Run("annotation preferred over label", func(t *testing.T) {
+		downscale1 := time.Now().UTC().Round(time.Second).Add(-10 * time.Hour)
+
+		sts1 := mockStatefulSet("test-zone-a",
+			withLabels(map[string]string{
+				config.MinTimeBetweenZonesDownscaleLabelKey: "1h",
+			}),
+			withAnnotations(map[string]string{
+				config.MinTimeBetweenZonesDownscaleAnnotationKey: "12h",
+			}),
+		)
+		sts2 := mockStatefulSet("test-zone-b", withAnnotations(map[string]string{
+			config.LastDownscaleAnnotationKey: downscale1.Format(time.RFC3339),
+		}))
+
+		elapsed, err := minimumTimeHasElapsed(sts1, []*v1.StatefulSet{sts1, sts2}, log.NewNopLogger())
+		require.NoError(t, err)
+		require.False(t, elapsed)
 	})
 }
 
@@ -331,21 +370,18 @@ func TestReconcileStsReplicas(t *testing.T) {
 		downscale3 := time.Now().UTC().Round(time.Second).Add(-48 * time.Hour)
 
 		sts1 := mockStatefulSet("test-zone-a", withReplicas(2, 2), withAnnotations(map[string]string{
-			config.LastDownscaleAnnotationKey: downscale1.Format(time.RFC3339),
-		}), withLabels(map[string]string{
-			config.MinTimeBetweenZonesDownscaleLabelKey: "12h",
+			config.LastDownscaleAnnotationKey:                downscale1.Format(time.RFC3339),
+			config.MinTimeBetweenZonesDownscaleAnnotationKey: "12h",
 		}))
 		sts2 := mockStatefulSet("test-zone-b", withReplicas(3, 3), withAnnotations(map[string]string{
-			config.RolloutDownscaleLeaderAnnotationKey: "test-zone-a",
-			config.LastDownscaleAnnotationKey:          downscale2.Format(time.RFC3339),
-		}), withLabels(map[string]string{
-			config.MinTimeBetweenZonesDownscaleLabelKey: "invalid",
+			config.RolloutDownscaleLeaderAnnotationKey:       "test-zone-a",
+			config.LastDownscaleAnnotationKey:                downscale2.Format(time.RFC3339),
+			config.MinTimeBetweenZonesDownscaleAnnotationKey: "invalid",
 		}))
 		sts3 := mockStatefulSet("test-zone-c", withReplicas(3, 3), withAnnotations(map[string]string{
-			config.RolloutDownscaleLeaderAnnotationKey: "test-zone-b",
-			config.LastDownscaleAnnotationKey:          downscale3.Format(time.RFC3339),
-		}), withLabels(map[string]string{
-			config.MinTimeBetweenZonesDownscaleLabelKey: "12h",
+			config.RolloutDownscaleLeaderAnnotationKey:       "test-zone-b",
+			config.LastDownscaleAnnotationKey:                downscale3.Format(time.RFC3339),
+			config.MinTimeBetweenZonesDownscaleAnnotationKey: "12h",
 		}))
 
 		replicas, err := desiredStsReplicas("test", sts2, []*v1.StatefulSet{sts1, sts2, sts3}, log.NewNopLogger())
@@ -359,21 +395,18 @@ func TestReconcileStsReplicas(t *testing.T) {
 		downscale3 := time.Now().UTC().Round(time.Second).Add(-10 * time.Hour)
 
 		sts1 := mockStatefulSet("test-zone-a", withReplicas(2, 2), withAnnotations(map[string]string{
-			config.LastDownscaleAnnotationKey: downscale1.Format(time.RFC3339),
-		}), withLabels(map[string]string{
-			config.MinTimeBetweenZonesDownscaleLabelKey: "12h",
+			config.LastDownscaleAnnotationKey:                downscale1.Format(time.RFC3339),
+			config.MinTimeBetweenZonesDownscaleAnnotationKey: "12h",
 		}))
 		sts2 := mockStatefulSet("test-zone-b", withReplicas(3, 3), withAnnotations(map[string]string{
-			config.RolloutDownscaleLeaderAnnotationKey: "test-zone-a",
-			config.LastDownscaleAnnotationKey:          downscale2.Format(time.RFC3339),
-		}), withLabels(map[string]string{
-			config.MinTimeBetweenZonesDownscaleLabelKey: "12h",
+			config.RolloutDownscaleLeaderAnnotationKey:       "test-zone-a",
+			config.LastDownscaleAnnotationKey:                downscale2.Format(time.RFC3339),
+			config.MinTimeBetweenZonesDownscaleAnnotationKey: "12h",
 		}))
 		sts3 := mockStatefulSet("test-zone-c", withReplicas(3, 3), withAnnotations(map[string]string{
-			config.RolloutDownscaleLeaderAnnotationKey: "test-zone-b",
-			config.LastDownscaleAnnotationKey:          downscale3.Format(time.RFC3339),
-		}), withLabels(map[string]string{
-			config.MinTimeBetweenZonesDownscaleLabelKey: "12h",
+			config.RolloutDownscaleLeaderAnnotationKey:       "test-zone-b",
+			config.LastDownscaleAnnotationKey:                downscale3.Format(time.RFC3339),
+			config.MinTimeBetweenZonesDownscaleAnnotationKey: "12h",
 		}))
 
 		replicas, err := desiredStsReplicas("test", sts2, []*v1.StatefulSet{sts1, sts2, sts3}, log.NewNopLogger())
@@ -387,21 +420,18 @@ func TestReconcileStsReplicas(t *testing.T) {
 		downscale3 := time.Now().UTC().Round(time.Second).Add(-48 * time.Hour)
 
 		sts1 := mockStatefulSet("test-zone-a", withReplicas(2, 2), withAnnotations(map[string]string{
-			config.LastDownscaleAnnotationKey: downscale1.Format(time.RFC3339),
-		}), withLabels(map[string]string{
-			config.MinTimeBetweenZonesDownscaleLabelKey: "12h",
+			config.LastDownscaleAnnotationKey:                downscale1.Format(time.RFC3339),
+			config.MinTimeBetweenZonesDownscaleAnnotationKey: "12h",
 		}))
 		sts2 := mockStatefulSet("test-zone-b", withReplicas(3, 3), withAnnotations(map[string]string{
-			config.RolloutDownscaleLeaderAnnotationKey: "test-zone-a",
-			config.LastDownscaleAnnotationKey:          downscale2.Format(time.RFC3339),
-		}), withLabels(map[string]string{
-			config.MinTimeBetweenZonesDownscaleLabelKey: "12h",
+			config.RolloutDownscaleLeaderAnnotationKey:       "test-zone-a",
+			config.LastDownscaleAnnotationKey:                downscale2.Format(time.RFC3339),
+			config.MinTimeBetweenZonesDownscaleAnnotationKey: "12h",
 		}))
 		sts3 := mockStatefulSet("test-zone-c", withReplicas(3, 3), withAnnotations(map[string]string{
-			config.RolloutDownscaleLeaderAnnotationKey: "test-zone-b",
-			config.LastDownscaleAnnotationKey:          downscale3.Format(time.RFC3339),
-		}), withLabels(map[string]string{
-			config.MinTimeBetweenZonesDownscaleLabelKey: "12h",
+			config.RolloutDownscaleLeaderAnnotationKey:       "test-zone-b",
+			config.LastDownscaleAnnotationKey:                downscale3.Format(time.RFC3339),
+			config.MinTimeBetweenZonesDownscaleAnnotationKey: "12h",
 		}))
 
 		replicas, err := desiredStsReplicas("test", sts2, []*v1.StatefulSet{sts1, sts2, sts3}, log.NewNopLogger())


### PR DESCRIPTION
## Summary

Move `grafana.com/min-time-between-zones-downscale` to an annotation, since it's StatefulSet configuration and never used for selection.

- Prefer the annotation when both are set
- Keep label support as a migration path and warn once per object when the label is used
- Update README examples to show the annotation

Ref: https://github.com/grafana/rollout-operator/issues/61

Made with [Cursor](https://cursor.com)