### PR TITLE
Split integration tests across CI runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,8 +38,16 @@ jobs:
       - run: make test
       - run: make test-boringcrypto
 
+  # Number of matrix.shard entries controls runner count (values must be 0..N-1).
   integration:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1]
+    env:
+      SHARD_INDEX: ${{ matrix.shard }}
+      SHARD_COUNT: ${{ strategy.job-total }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -88,8 +96,16 @@ jobs:
       - run: make build-image
       - run: make integration
 
+  # Number of matrix.shard entries controls runner count (values must be 0..N-1).
   integration-boringcrypto:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1]
+    env:
+      SHARD_INDEX: ${{ matrix.shard }}
+      SHARD_COUNT: ${{ strategy.job-total }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,8 @@ SHARD_COUNT ?= 1
 .PHONY: integration
 integration: ## Run integration tests (set SHARD_INDEX/SHARD_COUNT to split across runners)
 integration: check-kind integration/mock-service/.uptodate
-	@set -euo pipefail; \
+	@# bash: make uses /bin/sh (dash on Ubuntu), which has no pipefail
+	@bash -euo pipefail -c '\
 	if [ "$(SHARD_COUNT)" -le 1 ]; then \
 		go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...; \
 	else \
@@ -102,18 +103,18 @@ integration: check-kind integration/mock-service/.uptodate
 			echo "SHARD_INDEX ($(SHARD_INDEX)) must be in [0, $(SHARD_COUNT))" >&2; \
 			exit 1; \
 		fi; \
-		listed=$$(go test -tags requires_docker -list 'Test.*' ./integration/...); \
-		tests=$$(printf '%s\n' "$$listed" | awk -v n="$(SHARD_COUNT)" -v i="$(SHARD_INDEX)" \
-			'/^Test/ { if ((c++ % n) == i) print }'); \
+		listed=$$(go test -tags requires_docker -list "Test.*" ./integration/...); \
+		tests=$$(printf "%s\n" "$$listed" | awk -v n="$(SHARD_COUNT)" -v i="$(SHARD_INDEX)" \
+			"/^Test/ { if ((c++ % n) == i) print }"); \
 		if [ -z "$$tests" ]; then \
 			echo "No integration tests for shard $(SHARD_INDEX)/$(SHARD_COUNT)"; \
 			exit 0; \
 		fi; \
-		pattern=$$(printf '%s\n' "$$tests" | paste -sd '|' -); \
+		pattern=$$(printf "%s\n" "$$tests" | paste -sd "|" -); \
 		echo "Running shard $(SHARD_INDEX)/$(SHARD_COUNT):"; \
-		printf '%s\n' "$$tests"; \
+		printf "%s\n" "$$tests"; \
 		go test -v -tags requires_docker -count 1 -timeout 1h -run "^($$pattern)$$" ./integration/...; \
-	fi
+	fi'
 
 integration/mock-service/.uptodate:
 	GOOS=linux GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' -o ./integration/mock-service/mock-service ./integration/mock-service

--- a/Makefile
+++ b/Makefile
@@ -87,10 +87,33 @@ test-boringcrypto: ## Run tests with GOEXPERIMENT=boringcrypto
 check-kind: ## Check if kind is installed
 	@which kind >/dev/null 2>&1 || (echo "Error: kind binary not found. Please install kind: https://kind.sigs.k8s.io/docs/user/quick-start/#installation" && exit 1)
 
+# Optional CI sharding: SHARD_INDEX=0 SHARD_COUNT=2 make integration
+SHARD_INDEX ?= 0
+SHARD_COUNT ?= 1
+
 .PHONY: integration
-integration: ## Run integration tests
+integration: ## Run integration tests (set SHARD_INDEX/SHARD_COUNT to split across runners)
 integration: check-kind integration/mock-service/.uptodate
-	go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
+	@set -euo pipefail; \
+	if [ "$(SHARD_COUNT)" -le 1 ]; then \
+		go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...; \
+	else \
+		if [ "$(SHARD_INDEX)" -lt 0 ] || [ "$(SHARD_INDEX)" -ge "$(SHARD_COUNT)" ]; then \
+			echo "SHARD_INDEX ($(SHARD_INDEX)) must be in [0, $(SHARD_COUNT))" >&2; \
+			exit 1; \
+		fi; \
+		listed=$$(go test -tags requires_docker -list 'Test.*' ./integration/...); \
+		tests=$$(printf '%s\n' "$$listed" | awk -v n="$(SHARD_COUNT)" -v i="$(SHARD_INDEX)" \
+			'/^Test/ { if ((c++ % n) == i) print }'); \
+		if [ -z "$$tests" ]; then \
+			echo "No integration tests for shard $(SHARD_INDEX)/$(SHARD_COUNT)"; \
+			exit 0; \
+		fi; \
+		pattern=$$(printf '%s\n' "$$tests" | paste -sd '|' -); \
+		echo "Running shard $(SHARD_INDEX)/$(SHARD_COUNT):"; \
+		printf '%s\n' "$$tests"; \
+		go test -v -tags requires_docker -count 1 -timeout 1h -run "^($$pattern)$$" ./integration/...; \
+	fi
 
 integration/mock-service/.uptodate:
 	GOOS=linux GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' -o ./integration/mock-service/mock-service ./integration/mock-service

--- a/Makefile
+++ b/Makefile
@@ -94,27 +94,7 @@ SHARD_COUNT ?= 1
 .PHONY: integration
 integration: ## Run integration tests (set SHARD_INDEX/SHARD_COUNT to split across runners)
 integration: check-kind integration/mock-service/.uptodate
-	@# bash: make uses /bin/sh (dash on Ubuntu), which has no pipefail
-	@bash -euo pipefail -c '\
-	if [ "$(SHARD_COUNT)" -le 1 ]; then \
-		go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...; \
-	else \
-		if [ "$(SHARD_INDEX)" -lt 0 ] || [ "$(SHARD_INDEX)" -ge "$(SHARD_COUNT)" ]; then \
-			echo "SHARD_INDEX ($(SHARD_INDEX)) must be in [0, $(SHARD_COUNT))" >&2; \
-			exit 1; \
-		fi; \
-		listed=$$(go test -tags requires_docker -list "Test.*" ./integration/...); \
-		tests=$$(printf "%s\n" "$$listed" | awk -v n="$(SHARD_COUNT)" -v i="$(SHARD_INDEX)" \
-			"/^Test/ { if ((c++ % n) == i) print }"); \
-		if [ -z "$$tests" ]; then \
-			echo "No integration tests for shard $(SHARD_INDEX)/$(SHARD_COUNT)"; \
-			exit 0; \
-		fi; \
-		pattern=$$(printf "%s\n" "$$tests" | paste -sd "|" -); \
-		echo "Running shard $(SHARD_INDEX)/$(SHARD_COUNT):"; \
-		printf "%s\n" "$$tests"; \
-		go test -v -tags requires_docker -count 1 -timeout 1h -run "^($$pattern)$$" ./integration/...; \
-	fi'
+	SHARD_INDEX=$(SHARD_INDEX) SHARD_COUNT=$(SHARD_COUNT) ./tools/run-integration-tests.sh
 
 integration/mock-service/.uptodate:
 	GOOS=linux GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' -o ./integration/mock-service/mock-service ./integration/mock-service

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run integration tests, optionally sharded across CI runners.
+# Usage: SHARD_INDEX=0 SHARD_COUNT=2 ./tools/run-integration-tests.sh
+# When SHARD_COUNT is unset or <= 1, runs the full suite.
+
+set -euo pipefail
+
+SHARD_INDEX="${SHARD_INDEX:-0}"
+SHARD_COUNT="${SHARD_COUNT:-1}"
+
+if [ "${SHARD_COUNT}" -le 1 ]; then
+	go test -v -tags requires_docker -count 1 -timeout 1h ./integration/...
+	exit 0
+fi
+
+if [ "${SHARD_INDEX}" -lt 0 ] || [ "${SHARD_INDEX}" -ge "${SHARD_COUNT}" ]; then
+	echo "SHARD_INDEX (${SHARD_INDEX}) must be in [0, ${SHARD_COUNT})" >&2
+	exit 1
+fi
+
+listed=$(go test -tags requires_docker -list "Test.*" ./integration/...)
+tests=$(printf '%s\n' "${listed}" | awk -v n="${SHARD_COUNT}" -v i="${SHARD_INDEX}" \
+	'/^Test/ { if ((c++ % n) == i) print }')
+
+if [ -z "${tests}" ]; then
+	echo "No integration tests for shard ${SHARD_INDEX}/${SHARD_COUNT}"
+	exit 0
+fi
+
+pattern=$(printf '%s\n' "${tests}" | paste -sd '|' -)
+echo "Running shard ${SHARD_INDEX}/${SHARD_COUNT}:"
+printf '%s\n' "${tests}"
+go test -v -tags requires_docker -count 1 -timeout 1h -run "^(${pattern})$" ./integration/...


### PR DESCRIPTION
## Summary

Integration jobs currently run the full suite on one runner (~16m). Shard them across multiple runners so CI wall time stays manageable as the suite grows.

- Matrix `integration` and `integration-boringcrypto` over two shards by default
- `make integration` honors `SHARD_INDEX` / `SHARD_COUNT` (local runs unchanged when unset)
- Runner count is the length of `matrix.shard` (`SHARD_COUNT` comes from `strategy.job-total`)

Made with [Cursor](https://cursor.com)