### PR TITLE
Fix recovery from failed StatefulSet rollouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main / unreleased
 
 * [CHANGE] Prefer `grafana.com/min-time-between-zones-downscale` as a StatefulSet annotation instead of a label. The label remains supported as a fallback and logs a deprecation warning when used. #463
+* [BUGFIX] Allow a StatefulSet rollout to recover when pods from a previous failed update are not Ready (e.g. CrashLoopBackOff): only pods already on the current update revision consume the `rollout-max-unavailable` budget, so a subsequent Spec update can replace the stuck pods. #339
 * [ENHANCEMENT] Updated dependencies, including: #470
   * `github.com/prometheus/client_golang` from `v1.23.2` to `v1.24.1`
   * `github.com/prometheus/common` from `v0.70.0` to `v0.70.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## main / unreleased
 
 * [CHANGE] Prefer `grafana.com/min-time-between-zones-downscale` as a StatefulSet annotation instead of a label. The label remains supported as a fallback and logs a deprecation warning when used. #463
-* [BUGFIX] Allow a StatefulSet rollout to recover when pods from a previous failed update are not Ready (e.g. CrashLoopBackOff): only pods already on the current update revision consume the `rollout-max-unavailable` budget, so a subsequent Spec update can replace the stuck pods. #466
+* [BUGFIX] Allow a StatefulSet rollout to recover when pods from a previous failed update are stuck in an unrecoverable state (e.g. `CrashLoopBackOff` or `ImagePullBackOff`): outdated stuck pods are deleted even when the `rollout-max-unavailable` budget is exhausted, since deleting an already-unavailable pod doesn't reduce availability. A subsequent Spec update can then replace them without a manual delete. #466
 * [ENHANCEMENT] Updated dependencies, including: #470
   * `github.com/prometheus/client_golang` from `v1.23.2` to `v1.24.1`
   * `github.com/prometheus/common` from `v0.70.0` to `v0.70.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## main / unreleased
 
 * [CHANGE] Prefer `grafana.com/min-time-between-zones-downscale` as a StatefulSet annotation instead of a label. The label remains supported as a fallback and logs a deprecation warning when used. #463
-* [BUGFIX] Allow a StatefulSet rollout to recover when pods from a previous failed update are not Ready (e.g. CrashLoopBackOff): only pods already on the current update revision consume the `rollout-max-unavailable` budget, so a subsequent Spec update can replace the stuck pods. #339
+* [BUGFIX] Allow a StatefulSet rollout to recover when pods from a previous failed update are not Ready (e.g. CrashLoopBackOff): only pods already on the current update revision consume the `rollout-max-unavailable` budget, so a subsequent Spec update can replace the stuck pods. #466
 * [ENHANCEMENT] Updated dependencies, including: #470
   * `github.com/prometheus/client_golang` from `v1.23.2` to `v1.24.1`
   * `github.com/prometheus/common` from `v0.70.0` to `v0.70.1`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For each **rollout group**, the operator **guarantees**:
 1. Pods in 2 different StatefulSets are not rolled out at the same time
 1. Pods in a StatefulSet are rolled out if and only if all pods in all other StatefulSets of the same group are `Ready` (otherwise it will start or continue the rollout once this check is satisfied)
 1. Pods are rolled out if and only if all StatefulSets in the same group have `OnDelete` update strategy (otherwise the operator will skip the group and log an error)
-1. The maximum number of not-Ready pods in a StatefulSet doesn't exceed the value configured in the `rollout-max-unavailable` annotation (if not set, it defaults to `1`). Values:
+1. The maximum number of unavailable pods **already on the current update revision** in a StatefulSet doesn't exceed the value configured in the `rollout-max-unavailable` annotation (if not set, it defaults to `1`). Outdated not-Ready pods (for example CrashLoopBackOff from a previous failed update) do not consume this budget, so a subsequent StatefulSet update can still replace them. Values:
    - `<= 0`: invalid (will default to `1` and log a warning)
    - `1`: pods are rolled out sequentially
    - `> 1`: pods are rolled out in parallel (honoring the configured number of max unavailable pods)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For each **rollout group**, the operator **guarantees**:
 1. Pods in 2 different StatefulSets are not rolled out at the same time
 1. Pods in a StatefulSet are rolled out if and only if all pods in all other StatefulSets of the same group are `Ready` (otherwise it will start or continue the rollout once this check is satisfied)
 1. Pods are rolled out if and only if all StatefulSets in the same group have `OnDelete` update strategy (otherwise the operator will skip the group and log an error)
-1. The maximum number of unavailable pods **already on the current update revision** in a StatefulSet doesn't exceed the value configured in the `rollout-max-unavailable` annotation (if not set, it defaults to `1`). Outdated not-Ready pods (for example CrashLoopBackOff from a previous failed update) do not consume this budget, so a subsequent StatefulSet update can still replace them. Values:
+1. The maximum number of not-Ready pods in a StatefulSet doesn't exceed the value configured in the `rollout-max-unavailable` annotation (if not set, it defaults to `1`). One exception applies: outdated pods stuck in an unrecoverable state (for example `CrashLoopBackOff` or `ImagePullBackOff` left behind by a previous failed update) are deleted even when this limit is reached, because deleting an already-unavailable pod doesn't reduce availability any further. This allows a subsequent StatefulSet update to replace them without a manual pod delete. Values:
    - `<= 0`: invalid (will default to `1` and log a warning)
    - `1`: pods are rolled out sequentially
    - `> 1`: pods are rolled out in parallel (honoring the configured number of max unavailable pods)

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -72,6 +72,53 @@ func TestRolloutHappyCase(t *testing.T) {
 	requireEventuallyPod(t, api, ctx, "mock-zone-c-0", expectReady(), expectVersion("2"))
 }
 
+// TestRolloutRecoversFromFailedUpdate reproduces https://github.com/grafana/rollout-operator/issues/339:
+// after a bad rollout leaves pods not Ready, a subsequent StatefulSet update must still roll those pods
+// to the fixed revision without requiring a manual pod delete.
+func TestRolloutRecoversFromFailedUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	cluster := createKindCluster(t, "rollout-operator:latest", "mock-service:latest")
+	api := cluster.API()
+
+	path := initManifestFiles(t, "webhooks-not-enabled")
+
+	createRolloutOperator(t, ctx, api, cluster.ExtAPI(), path, false)
+	rolloutOperatorPod := eventuallyGetFirstPod(ctx, t, api, "name=rollout-operator")
+	requireEventuallyPod(t, api, ctx, rolloutOperatorPod, expectPodPhase(corev1.PodRunning), expectReady())
+
+	createMockServiceZone(t, ctx, api, corev1.NamespaceDefault, "mock-zone-a", 1)
+	createMockServiceZone(t, ctx, api, corev1.NamespaceDefault, "mock-zone-b", 1)
+	createMockServiceZone(t, ctx, api, corev1.NamespaceDefault, "mock-zone-c", 1)
+	requireEventuallyPod(t, api, ctx, "mock-zone-a-0", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
+	requireEventuallyPod(t, api, ctx, "mock-zone-b-0", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
+	requireEventuallyPod(t, api, ctx, "mock-zone-c-0", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
+
+	// Bad rollout: version 2 never becomes ready.
+	_, err := api.AppsV1().StatefulSets(corev1.NamespaceDefault).Update(ctx, mockServiceStatefulSet("mock-zone-a", "2", false, 1), metav1.UpdateOptions{})
+	require.NoError(t, err, "Can't update StatefulSet")
+	_, err = api.AppsV1().StatefulSets(corev1.NamespaceDefault).Update(ctx, mockServiceStatefulSet("mock-zone-b", "2", false, 1), metav1.UpdateOptions{})
+	require.NoError(t, err, "Can't update StatefulSet")
+	_, err = api.AppsV1().StatefulSets(corev1.NamespaceDefault).Update(ctx, mockServiceStatefulSet("mock-zone-c", "2", false, 1), metav1.UpdateOptions{})
+	require.NoError(t, err, "Can't update StatefulSet")
+
+	requireEventuallyPod(t, api, ctx, "mock-zone-a-0", expectNotReady(), expectVersion("2"))
+	requireEventuallyPod(t, api, ctx, "mock-zone-b-0", expectReady(), expectVersion("1"))
+	requireEventuallyPod(t, api, ctx, "mock-zone-c-0", expectReady(), expectVersion("1"))
+
+	// Fix: update to version 3 with readiness enabled. Operator must replace the stuck zone-a pod.
+	_, err = api.AppsV1().StatefulSets(corev1.NamespaceDefault).Update(ctx, mockServiceStatefulSet("mock-zone-a", "3", true, 1), metav1.UpdateOptions{})
+	require.NoError(t, err, "Can't update StatefulSet")
+	_, err = api.AppsV1().StatefulSets(corev1.NamespaceDefault).Update(ctx, mockServiceStatefulSet("mock-zone-b", "3", true, 1), metav1.UpdateOptions{})
+	require.NoError(t, err, "Can't update StatefulSet")
+	_, err = api.AppsV1().StatefulSets(corev1.NamespaceDefault).Update(ctx, mockServiceStatefulSet("mock-zone-c", "3", true, 1), metav1.UpdateOptions{})
+	require.NoError(t, err, "Can't update StatefulSet")
+
+	requireEventuallyPod(t, api, ctx, "mock-zone-a-0", expectReady(), expectVersion("3"))
+	requireEventuallyPod(t, api, ctx, "mock-zone-b-0", expectReady(), expectVersion("3"))
+	requireEventuallyPod(t, api, ctx, "mock-zone-c-0", expectReady(), expectVersion("3"))
+}
+
 // TestRolloutHappyCaseWithZpdb performs pod updates via the rolling update controller and uses the zpdb to determine if the pod delete is safe or not
 func TestRolloutHappyCaseWithZpdb(t *testing.T) {
 	ctx := context.Background()

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -73,8 +73,8 @@ func TestRolloutHappyCase(t *testing.T) {
 }
 
 // TestRolloutRecoversFromFailedUpdate reproduces https://github.com/grafana/rollout-operator/issues/339:
-// after a bad rollout leaves pods not Ready, a subsequent StatefulSet update must still roll those pods
-// to the fixed revision without requiring a manual pod delete.
+// after a bad rollout leaves pods in CrashLoopBackOff, a subsequent StatefulSet update must still
+// roll those pods to the fixed revision without requiring a manual pod delete.
 func TestRolloutRecoversFromFailedUpdate(t *testing.T) {
 	ctx := context.Background()
 
@@ -94,15 +94,17 @@ func TestRolloutRecoversFromFailedUpdate(t *testing.T) {
 	requireEventuallyPod(t, api, ctx, "mock-zone-b-0", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
 	requireEventuallyPod(t, api, ctx, "mock-zone-c-0", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
 
-	// Bad rollout: version 2 never becomes ready.
-	_, err := api.AppsV1().StatefulSets(corev1.NamespaceDefault).Update(ctx, mockServiceStatefulSet("mock-zone-a", "2", false, 1), metav1.UpdateOptions{})
+	// Bad rollout: version 2 crashes on startup.
+	_, err := api.AppsV1().StatefulSets(corev1.NamespaceDefault).Update(ctx, mockServiceStatefulSetCrashing("mock-zone-a", "2", 1), metav1.UpdateOptions{})
 	require.NoError(t, err, "Can't update StatefulSet")
-	_, err = api.AppsV1().StatefulSets(corev1.NamespaceDefault).Update(ctx, mockServiceStatefulSet("mock-zone-b", "2", false, 1), metav1.UpdateOptions{})
+	_, err = api.AppsV1().StatefulSets(corev1.NamespaceDefault).Update(ctx, mockServiceStatefulSetCrashing("mock-zone-b", "2", 1), metav1.UpdateOptions{})
 	require.NoError(t, err, "Can't update StatefulSet")
-	_, err = api.AppsV1().StatefulSets(corev1.NamespaceDefault).Update(ctx, mockServiceStatefulSet("mock-zone-c", "2", false, 1), metav1.UpdateOptions{})
+	_, err = api.AppsV1().StatefulSets(corev1.NamespaceDefault).Update(ctx, mockServiceStatefulSetCrashing("mock-zone-c", "2", 1), metav1.UpdateOptions{})
 	require.NoError(t, err, "Can't update StatefulSet")
 
-	requireEventuallyPod(t, api, ctx, "mock-zone-a-0", expectNotReady(), expectVersion("2"))
+	// The rollout starts with zone-a and gets stuck there: the new pod crashloops and the other
+	// zones are never rolled.
+	requireEventuallyPod(t, api, ctx, "mock-zone-a-0", expectVersion("2"), expectNotReady(), expectContainerWaitingReason("CrashLoopBackOff"))
 	requireEventuallyPod(t, api, ctx, "mock-zone-b-0", expectReady(), expectVersion("1"))
 	requireEventuallyPod(t, api, ctx, "mock-zone-c-0", expectReady(), expectVersion("1"))
 

--- a/integration/manifests_mock_service_test.go
+++ b/integration/manifests_mock_service_test.go
@@ -65,6 +65,15 @@ func mockServiceService(name string) (*corev1.Service, error) {
 	}, nil
 }
 
+// mockServiceStatefulSetCrashing returns a StatefulSet whose pods exit immediately on startup,
+// so they end up in CrashLoopBackOff.
+func mockServiceStatefulSetCrashing(name, version string, replicas int) *appsv1.StatefulSet {
+	sts := mockServiceStatefulSet(name, version, false, replicas)
+	container := &sts.Spec.Template.Spec.Containers[0]
+	container.Env = append(container.Env, corev1.EnvVar{Name: "CRASH", Value: "true"})
+	return sts
+}
+
 func mockServiceStatefulSet(name, version string, ready bool, replicas int) *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/integration/mock-service/main.go
+++ b/integration/mock-service/main.go
@@ -11,6 +11,11 @@ import (
 )
 
 func main() {
+	// Simulate a service which crashes on startup (e.g. a bad rollout ending up in CrashLoopBackOff).
+	if os.Getenv("CRASH") == "true" {
+		log.Fatal("CRASH=true: exiting immediately to simulate a crashing service")
+	}
+
 	alive := &atomic.Int64{}
 	alive.Store(1)
 	ready := &atomic.Int64{}

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -131,6 +131,19 @@ func expectVersion(expectedVersion string) func(t *testing.T, pod *corev1.Pod) b
 	}
 }
 
+func expectContainerWaitingReason(expectedReason string) func(t *testing.T, pod *corev1.Pod) bool {
+	return func(t *testing.T, pod *corev1.Pod) bool {
+		for _, s := range pod.Status.ContainerStatuses {
+			if s.State.Waiting != nil && s.State.Waiting.Reason == expectedReason {
+				t.Logf("Pod %s container %s is waiting with reason %q as expected.", pod.Name, s.Name, expectedReason)
+				return true
+			}
+		}
+		t.Logf("No container of pod %s is waiting with reason %q", pod.Name, expectedReason)
+		return false
+	}
+}
+
 func expectedPodReadyState(expectedReady bool) func(t *testing.T, pod *corev1.Pod) bool {
 	return func(t *testing.T, pod *corev1.Pod) bool {
 		if len(pod.Status.ContainerStatuses) == 0 {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -569,7 +569,7 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 		// maxUnavailable above, but must not consume a slot in the delete batch.
 		candidates := make([]*corev1.Pod, 0, len(podsToUpdate))
 		for _, pod := range podsToUpdate {
-			if pod.Status.Phase == corev1.PodRunning && pod.DeletionTimestamp != nil {
+			if pod.DeletionTimestamp != nil {
 				level.Debug(c.logger).Log("msg", fmt.Sprintf("waiting for pod %s to be terminated", pod.Name))
 				continue
 			}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -557,12 +557,29 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 
 	if len(podsToUpdate) > 0 {
 		maxUnavailable := getMaxUnavailableForStatefulSet(sts, c.logger)
-		numNotReady := int(sts.Status.Replicas - sts.Status.ReadyReplicas)
+		// Only pods already on UpdateRevision (or deletes already in flight) consume the
+		// unavailability budget. Outdated not-Ready pods from a previous failed rollout
+		// still need deleting and must not block a subsequent StatefulSet update.
+		numUnavailable, err := c.unavailablePodCountForRollout(sts)
+		if err != nil {
+			return false, fmt.Errorf("failed to count unavailable pods for StatefulSet %s: %w", sts.Name, err)
+		}
+
+		// Exclude pods already terminating from delete candidates. They still count against
+		// maxUnavailable above, but must not consume a slot in the delete batch.
+		candidates := make([]*corev1.Pod, 0, len(podsToUpdate))
+		for _, pod := range podsToUpdate {
+			if pod.Status.Phase == corev1.PodRunning && pod.DeletionTimestamp != nil {
+				level.Debug(c.logger).Log("msg", fmt.Sprintf("waiting for pod %s to be terminated", pod.Name))
+				continue
+			}
+			candidates = append(candidates, pod)
+		}
 
 		// Compute the number of pods we should update, honoring the configured maxUnavailable.
 		numPods := max(0, min(
-			maxUnavailable-numNotReady, // No more than the configured maxUnavailable (including not-Ready pods).
-			len(podsToUpdate),          // No more than the total number of pods that need to be updated.
+			maxUnavailable-numUnavailable, // No more than the configured maxUnavailable.
+			len(candidates),               // No more than the candidates that can be deleted.
 		))
 
 		if numPods == 0 {
@@ -570,6 +587,7 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 				"msg", "StatefulSet has some pods to be updated but maxUnavailable pods has been reached",
 				"statefulset", sts.Name,
 				"pods_to_update", len(podsToUpdate),
+				"unavailable_pods", numUnavailable,
 				"replicas", sts.Status.Replicas,
 				"ready_replicas", sts.Status.ReadyReplicas,
 				"max_unavailable", maxUnavailable)
@@ -582,10 +600,10 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 		// Note that this will also have no effect if the pods are not within a ZPDB scope.
 		zpdbMaxUnavailableOverrideIfZero := zpdb.NewMaxUnavailableZeroOverride(maxUnavailable)
 
-		hasPartitionAwarePdb, err := c.zpdbController.HasPartitionAwarePdb(podsToUpdate[0])
+		hasPartitionAwarePdb, err := c.zpdbController.HasPartitionAwarePdb(candidates[0])
 		if err != nil {
 			// Note if we ignored this error and continued processing, the same error would be raised from the MarkPodAsDeleted() below.
-			return false, fmt.Errorf("failed to determine pod zpdb configuration %s: %w", podsToUpdate[0].Name, err)
+			return false, fmt.Errorf("failed to determine pod zpdb configuration %s: %w", candidates[0].Name, err)
 		}
 
 		// If the pods are covered by a partition aware ZPDB then the override is set to 1
@@ -595,15 +613,7 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 			zpdbMaxUnavailableOverrideIfZero = zpdb.NewMaxUnavailableZeroOverride(1)
 		}
 
-		for _, pod := range podsToUpdate[:numPods] {
-			// Skip if the pod is terminating. Since "Terminating" is not a pod Phase, we can infer it by checking
-			// if the pod is in the Running phase but the deletionTimestamp has been set (kubectl does something
-			// similar too).
-			if pod.Status.Phase == corev1.PodRunning && pod.DeletionTimestamp != nil {
-				level.Debug(c.logger).Log("msg", fmt.Sprintf("waiting for pod %s to be terminated", pod.Name))
-				continue
-			}
-
+		for _, pod := range candidates[:numPods] {
 			// Use the ZPDB to determine if this pod delete is allowed.
 			// The ZPDB serializes requests from this controller and from any incoming voluntary evictions.
 			// For each request, a full set of tests is performed to confirm the state of all pods in the ZPDB scope.
@@ -664,6 +674,37 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 	}
 
 	return false, nil
+}
+
+// unavailablePodCountForRollout returns how many pods already consume the rollout
+// maxUnavailable budget. Outdated not-Ready pods are excluded so a follow-up StatefulSet
+// update can recover from a failed rollout (e.g. CrashLoopBackOff on the previous revision).
+func (c *RolloutController) unavailablePodCountForRollout(sts *v1.StatefulSet) (int, error) {
+	pods, err := c.listPodsByStatefulSet(sts)
+	if err != nil {
+		return 0, err
+	}
+
+	updateRev := sts.Status.UpdateRevision
+	count := 0
+	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			// A delete is already in flight; keep it charged against the budget until the
+			// pod is gone and replaced, otherwise we can exceed maxUnavailable.
+			count++
+			continue
+		}
+		if pod.Labels[v1.ControllerRevisionHashLabelKey] == updateRev && !util.IsPodRunningAndReady(pod) {
+			count++
+		}
+	}
+
+	// Pods not yet recreated after a delete are also unavailable for the purposes of the budget.
+	if missing := int(sts.Status.Replicas) - len(pods); missing > 0 {
+		count += missing
+	}
+
+	return count, nil
 }
 
 func (c *RolloutController) podsNotMatchingUpdateRevision(sts *v1.StatefulSet) ([]*corev1.Pod, error) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -700,7 +700,7 @@ func (c *RolloutController) unavailablePodCountForRollout(sts *v1.StatefulSet) (
 	}
 
 	// Pods not yet recreated after a delete are also unavailable for the purposes of the budget.
-	if missing := int(sts.Status.Replicas) - len(pods); missing > 0 {
+	if missing := int(*sts.Spec.Replicas) - len(pods); missing > 0 {
 		count += missing
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -557,40 +557,51 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 
 	if len(podsToUpdate) > 0 {
 		maxUnavailable := getMaxUnavailableForStatefulSet(sts, c.logger)
-		// Only pods already on UpdateRevision (or deletes already in flight) consume the
-		// unavailability budget. Outdated not-Ready pods from a previous failed rollout
-		// still need deleting and must not block a subsequent StatefulSet update.
-		numUnavailable, err := c.unavailablePodCountForRollout(sts)
-		if err != nil {
-			return false, fmt.Errorf("failed to count unavailable pods for StatefulSet %s: %w", sts.Name, err)
-		}
+		numNotReady := int(sts.Status.Replicas - sts.Status.ReadyReplicas)
 
-		// Exclude pods already terminating from delete candidates. They still count against
-		// maxUnavailable above, but must not consume a slot in the delete batch.
-		candidates := make([]*corev1.Pod, 0, len(podsToUpdate))
-		for _, pod := range podsToUpdate {
+		// Compute the number of pods we should update, honoring the configured maxUnavailable.
+		numPods := max(0, min(
+			maxUnavailable-numNotReady, // No more than the configured maxUnavailable (including not-Ready pods).
+			len(podsToUpdate),          // No more than the total number of pods that need to be updated.
+		))
+
+		// Select the pods to delete:
+		// - Pods within the maxUnavailable batch, unless they're already terminating.
+		// - Outdated pods stuck in a state they can't recover from on their own (e.g. CrashLoopBackOff
+		//   left behind by a previous failed rollout) are always deleted, even beyond the maxUnavailable
+		//   budget: they're already unavailable, so deleting them doesn't reduce availability any further.
+		//   This allows a follow-up StatefulSet update to replace them without a manual delete.
+		//   See https://github.com/grafana/rollout-operator/issues/339
+		var podsToDelete []*corev1.Pod
+		for i, pod := range podsToUpdate {
+			// Skip if the pod is terminating. Since "Terminating" is not a pod Phase, we can infer it by
+			// checking if the deletionTimestamp has been set (kubectl does something similar too).
 			if pod.DeletionTimestamp != nil {
 				level.Debug(c.logger).Log("msg", fmt.Sprintf("waiting for pod %s to be terminated", pod.Name))
 				continue
 			}
-			candidates = append(candidates, pod)
+
+			if i < numPods {
+				podsToDelete = append(podsToDelete, pod)
+			} else if isPodStuck(pod) {
+				level.Info(c.logger).Log(
+					"msg", "deleting stuck outdated pod regardless of max unavailable",
+					"statefulset", sts.Name,
+					"pod", pod.Name)
+				podsToDelete = append(podsToDelete, pod)
+			}
 		}
 
-		// Compute the number of pods we should update, honoring the configured maxUnavailable.
-		numPods := max(0, min(
-			maxUnavailable-numUnavailable, // No more than the configured maxUnavailable.
-			len(candidates),               // No more than the candidates that can be deleted.
-		))
-
-		if numPods == 0 {
-			level.Info(c.logger).Log(
-				"msg", "StatefulSet has some pods to be updated but maxUnavailable pods has been reached",
-				"statefulset", sts.Name,
-				"pods_to_update", len(podsToUpdate),
-				"unavailable_pods", numUnavailable,
-				"replicas", sts.Status.Replicas,
-				"ready_replicas", sts.Status.ReadyReplicas,
-				"max_unavailable", maxUnavailable)
+		if len(podsToDelete) == 0 {
+			if numPods == 0 {
+				level.Info(c.logger).Log(
+					"msg", "StatefulSet has some pods to be updated but maxUnavailable pods has been reached",
+					"statefulset", sts.Name,
+					"pods_to_update", len(podsToUpdate),
+					"replicas", sts.Status.Replicas,
+					"ready_replicas", sts.Status.ReadyReplicas,
+					"max_unavailable", maxUnavailable)
+			}
 
 			return true, nil
 		}
@@ -600,10 +611,10 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 		// Note that this will also have no effect if the pods are not within a ZPDB scope.
 		zpdbMaxUnavailableOverrideIfZero := zpdb.NewMaxUnavailableZeroOverride(maxUnavailable)
 
-		hasPartitionAwarePdb, err := c.zpdbController.HasPartitionAwarePdb(candidates[0])
+		hasPartitionAwarePdb, err := c.zpdbController.HasPartitionAwarePdb(podsToDelete[0])
 		if err != nil {
 			// Note if we ignored this error and continued processing, the same error would be raised from the MarkPodAsDeleted() below.
-			return false, fmt.Errorf("failed to determine pod zpdb configuration %s: %w", candidates[0].Name, err)
+			return false, fmt.Errorf("failed to determine pod zpdb configuration %s: %w", podsToDelete[0].Name, err)
 		}
 
 		// If the pods are covered by a partition aware ZPDB then the override is set to 1
@@ -613,7 +624,7 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 			zpdbMaxUnavailableOverrideIfZero = zpdb.NewMaxUnavailableZeroOverride(1)
 		}
 
-		for _, pod := range candidates[:numPods] {
+		for _, pod := range podsToDelete {
 			// Use the ZPDB to determine if this pod delete is allowed.
 			// The ZPDB serializes requests from this controller and from any incoming voluntary evictions.
 			// For each request, a full set of tests is performed to confirm the state of all pods in the ZPDB scope.
@@ -676,35 +687,37 @@ func (c *RolloutController) updateStatefulSetPods(ctx context.Context, sts *v1.S
 	return false, nil
 }
 
-// unavailablePodCountForRollout returns how many pods already consume the rollout
-// maxUnavailable budget. Outdated not-Ready pods are excluded so a follow-up StatefulSet
-// update can recover from a failed rollout (e.g. CrashLoopBackOff on the previous revision).
-func (c *RolloutController) unavailablePodCountForRollout(sts *v1.StatefulSet) (int, error) {
-	pods, err := c.listPodsByStatefulSet(sts)
-	if err != nil {
-		return 0, err
+// stuckContainerWaitingReasons are container waiting reasons which indicate the container
+// cannot start or keep running without intervention: the pod will never become Ready on its own.
+var stuckContainerWaitingReasons = map[string]struct{}{
+	"CrashLoopBackOff":           {},
+	"ImagePullBackOff":           {},
+	"ErrImagePull":               {},
+	"InvalidImageName":           {},
+	"CreateContainerConfigError": {},
+	"CreateContainerError":       {},
+}
+
+// isPodStuck returns true if the pod is not Ready and at least one of its containers is stuck
+// in a state it can't recover from without the pod being replaced (e.g. CrashLoopBackOff).
+// Such a pod is already unavailable, so deleting it doesn't reduce availability any further.
+func isPodStuck(pod *corev1.Pod) bool {
+	if util.IsPodRunningAndReady(pod) {
+		return false
 	}
 
-	updateRev := sts.Status.UpdateRevision
-	count := 0
-	for _, pod := range pods {
-		if pod.DeletionTimestamp != nil {
-			// A delete is already in flight; keep it charged against the budget until the
-			// pod is gone and replaced, otherwise we can exceed maxUnavailable.
-			count++
-			continue
+	for _, statuses := range [][]corev1.ContainerStatus{pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses} {
+		for _, status := range statuses {
+			if status.State.Waiting == nil {
+				continue
+			}
+			if _, ok := stuckContainerWaitingReasons[status.State.Waiting.Reason]; ok {
+				return true
+			}
 		}
-		if pod.Labels[v1.ControllerRevisionHashLabelKey] == updateRev && !util.IsPodRunningAndReady(pod) {
-			count++
-		}
 	}
 
-	// Pods not yet recreated after a delete are also unavailable for the purposes of the budget.
-	if missing := int(*sts.Spec.Replicas) - len(pods); missing > 0 {
-		count += missing
-	}
-
-	return count, nil
+	return false
 }
 
 func (c *RolloutController) podsNotMatchingUpdateRevision(sts *v1.StatefulSet) ([]*corev1.Pod, error) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -698,14 +698,10 @@ var stuckContainerWaitingReasons = map[string]struct{}{
 	"CreateContainerError":       {},
 }
 
-// isPodStuck returns true if the pod is not Ready and at least one of its containers is stuck
-// in a state it can't recover from without the pod being replaced (e.g. CrashLoopBackOff).
-// Such a pod is already unavailable, so deleting it doesn't reduce availability any further.
+// isPodStuck returns true if at least one of the pod's containers is stuck in a state it can't
+// recover from without the pod being replaced (e.g. CrashLoopBackOff). Such a pod is already
+// unavailable, so deleting it doesn't reduce availability any further.
 func isPodStuck(pod *corev1.Pod) bool {
-	if util.IsPodRunningAndReady(pod) {
-		return false
-	}
-
 	for _, statuses := range [][]corev1.ContainerStatus{pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses} {
 		for _, status := range statuses {
 			if status.State.Waiting == nil {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -312,6 +312,19 @@ func TestRolloutController_Reconcile(t *testing.T) {
 			},
 			expectedDeletedPods: []string{"ingester-zone-a-0"},
 		},
+		"should count missing desired pods when StatefulSet status has caught up": {
+			statefulSets: []runtime.Object{
+				mockStatefulSet("ingester-zone-a", withPrevRevision(), withReplicas(3, 2), func(sts *v1.StatefulSet) {
+					sts.Status.Replicas = 2
+					sts.Annotations[config.RolloutMaxUnavailableAnnotationKey] = "1"
+				}),
+			},
+			pods: []runtime.Object{
+				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
+			},
+			expectedDeletedPods: nil,
+		},
 		"should not delete pods which are already terminating": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-a", withPrevRevision()),

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -325,13 +325,14 @@ func TestRolloutController_Reconcile(t *testing.T) {
 			},
 			expectedDeletedPods: nil,
 		},
-		"should not delete pods which are already terminating": {
+		"should not delete pods which are already terminating regardless of phase": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-a", withPrevRevision()),
 			},
 			pods: []runtime.Object{
 				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash, func(pod *corev1.Pod) {
 					pod.DeletionTimestamp = util.Now()
+					pod.Status.Phase = corev1.PodFailed
 				}),
 				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -264,41 +264,53 @@ func TestRolloutController_Reconcile(t *testing.T) {
 			},
 			expectedDeletedPods: []string{"ingester-zone-a-0"},
 		},
-		"should give priority to StatefulSet with not-Ready pods and take not-Ready pods in account when honoring max unavailable": {
+		"should give priority to StatefulSet with not-Ready pods and take not-Ready pods on update revision into account when honoring max unavailable": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-a", withPrevRevision()),
-				mockStatefulSet("ingester-zone-b", withPrevRevision(), func(sts *v1.StatefulSet) {
-					sts.Status.Replicas = 3
-					sts.Status.ReadyReplicas = 2
-				}),
+				mockStatefulSet("ingester-zone-b", withPrevRevision(), withReplicas(3, 2)),
 			},
 			pods: []runtime.Object{
 				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
-				mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+				// One pod already on the update revision and not Ready consumes 1 of maxUnavailable=2.
+				mockStatefulSetPod("ingester-zone-b-0", testLastRevisionHash, withNotReady()),
 				mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
 			},
-			expectedDeletedPods: []string{"ingester-zone-b-0"}, // Max unavailable = 2 but there's 1 not-Ready pod
+			expectedDeletedPods: []string{"ingester-zone-b-1"},
 		},
-		"should do nothing if the number of not-Ready pods >= max unavailable": {
+		"should do nothing if not-Ready pods already on update revision >= max unavailable": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-a", withPrevRevision()),
-				mockStatefulSet("ingester-zone-b", withPrevRevision(), func(sts *v1.StatefulSet) {
-					sts.Status.Replicas = 3
-					sts.Status.ReadyReplicas = 1
-				}),
+				mockStatefulSet("ingester-zone-b", withPrevRevision(), withReplicas(3, 1)),
 			},
 			pods: []runtime.Object{
 				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
-				mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
-				mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+				// Two pods already updated but not Ready consume the full maxUnavailable=2 budget.
+				mockStatefulSetPod("ingester-zone-b-0", testLastRevisionHash, withNotReady()),
+				mockStatefulSetPod("ingester-zone-b-1", testLastRevisionHash, withNotReady()),
 				mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
 			},
-			expectedDeletedPods: nil, // Max unavailable = 2 and there are 2 not-Ready pods
+			expectedDeletedPods: nil,
+		},
+		// Reproduces https://github.com/grafana/rollout-operator/issues/339:
+		// a failed rollout left pods not-Ready on an outdated revision; a subsequent
+		// StatefulSet update must still be allowed to delete those pods.
+		"should delete outdated not-Ready pods when StatefulSet is updated again": {
+			statefulSets: []runtime.Object{
+				mockStatefulSet("ingester-zone-a", withPrevRevision(), withReplicas(3, 2), func(sts *v1.StatefulSet) {
+					sts.Annotations[config.RolloutMaxUnavailableAnnotationKey] = "1"
+				}),
+			},
+			pods: []runtime.Object{
+				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash, withNotReady()),
+				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
+			},
+			expectedDeletedPods: []string{"ingester-zone-a-0"},
 		},
 		"should not delete pods which are already terminating": {
 			statefulSets: []runtime.Object{
@@ -1551,6 +1563,14 @@ func withReplicas(totalReplicas, readyReplicas int32) func(sts *v1.StatefulSet) 
 		sts.Spec.Replicas = &totalReplicas
 		sts.Status.Replicas = totalReplicas
 		sts.Status.ReadyReplicas = readyReplicas
+	}
+}
+
+func withNotReady() func(pod *corev1.Pod) {
+	return func(pod *corev1.Pod) {
+		for i := range pod.Status.ContainerStatuses {
+			pod.Status.ContainerStatuses[i].Ready = false
+		}
 	}
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -325,6 +325,19 @@ func TestRolloutController_Reconcile(t *testing.T) {
 			},
 			expectedDeletedPods: []string{"ingester-zone-a-0"},
 		},
+		"should delete outdated pods with a crashlooping restartable init sidecar even when application containers are ready": {
+			statefulSets: []runtime.Object{
+				mockStatefulSet("ingester-zone-a", withPrevRevision(), withReplicas(3, 2), func(sts *v1.StatefulSet) {
+					sts.Annotations[config.RolloutMaxUnavailableAnnotationKey] = "1"
+				}),
+			},
+			pods: []runtime.Object{
+				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash, withCrashLoopingInitSidecar()),
+				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
+			},
+			expectedDeletedPods: []string{"ingester-zone-a-0"},
+		},
 		"should not delete outdated not-Ready pods which are not stuck": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-a", withPrevRevision(), withReplicas(3, 2), func(sts *v1.StatefulSet) {
@@ -1631,6 +1644,23 @@ func withInitContainerImagePullBackOff() func(pod *corev1.Pod) {
 			Ready: false,
 			State: corev1.ContainerState{
 				Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"},
+			},
+		}}
+	}
+}
+
+func withCrashLoopingInitSidecar() func(pod *corev1.Pod) {
+	return func(pod *corev1.Pod) {
+		always := corev1.ContainerRestartPolicyAlways
+		pod.Spec.InitContainers = []corev1.Container{{
+			Name:          "sidecar",
+			RestartPolicy: &always,
+		}}
+		pod.Status.InitContainerStatuses = []corev1.ContainerStatus{{
+			Name:  "sidecar",
+			Ready: false,
+			State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
 			},
 		}}
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -264,7 +264,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 			},
 			expectedDeletedPods: []string{"ingester-zone-a-0"},
 		},
-		"should give priority to StatefulSet with not-Ready pods and take not-Ready pods on update revision into account when honoring max unavailable": {
+		"should give priority to StatefulSet with not-Ready pods and take not-Ready pods in account when honoring max unavailable": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-a", withPrevRevision()),
 				mockStatefulSet("ingester-zone-b", withPrevRevision(), withReplicas(3, 2)),
@@ -273,14 +273,13 @@ func TestRolloutController_Reconcile(t *testing.T) {
 				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
-				// One pod already on the update revision and not Ready consumes 1 of maxUnavailable=2.
-				mockStatefulSetPod("ingester-zone-b-0", testLastRevisionHash, withNotReady()),
+				mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
 			},
-			expectedDeletedPods: []string{"ingester-zone-b-1"},
+			expectedDeletedPods: []string{"ingester-zone-b-0"}, // Max unavailable = 2 but there's 1 not-Ready pod
 		},
-		"should do nothing if not-Ready pods already on update revision >= max unavailable": {
+		"should do nothing if the number of not-Ready pods >= max unavailable": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-a", withPrevRevision()),
 				mockStatefulSet("ingester-zone-b", withPrevRevision(), withReplicas(3, 1)),
@@ -289,37 +288,53 @@ func TestRolloutController_Reconcile(t *testing.T) {
 				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
-				// Two pods already updated but not Ready consume the full maxUnavailable=2 budget.
-				mockStatefulSetPod("ingester-zone-b-0", testLastRevisionHash, withNotReady()),
-				mockStatefulSetPod("ingester-zone-b-1", testLastRevisionHash, withNotReady()),
+				mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
 			},
-			expectedDeletedPods: nil,
+			expectedDeletedPods: nil, // Max unavailable = 2 and there are 2 not-Ready pods
 		},
 		// Reproduces https://github.com/grafana/rollout-operator/issues/339:
-		// a failed rollout left pods not-Ready on an outdated revision; a subsequent
-		// StatefulSet update must still be allowed to delete those pods.
-		"should delete outdated not-Ready pods when StatefulSet is updated again": {
+		// a failed rollout left a pod in CrashLoopBackOff on an outdated revision. It consumes the
+		// whole maxUnavailable=1 budget, but it must still be deleted so a subsequent StatefulSet
+		// update can replace it without a manual delete.
+		"should delete outdated pods stuck in CrashLoopBackOff even when max unavailable is reached": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-a", withPrevRevision(), withReplicas(3, 2), func(sts *v1.StatefulSet) {
 					sts.Annotations[config.RolloutMaxUnavailableAnnotationKey] = "1"
 				}),
 			},
 			pods: []runtime.Object{
-				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash, withNotReady()),
+				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash, withCrashLoopBackOff()),
+				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
+				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
+			},
+			// Only the stuck pod is deleted: healthy outdated pods keep honoring maxUnavailable.
+			expectedDeletedPods: []string{"ingester-zone-a-0"},
+		},
+		"should delete outdated pods stuck in ImagePullBackOff on an init container even when max unavailable is reached": {
+			statefulSets: []runtime.Object{
+				mockStatefulSet("ingester-zone-a", withPrevRevision(), withReplicas(3, 2), func(sts *v1.StatefulSet) {
+					sts.Annotations[config.RolloutMaxUnavailableAnnotationKey] = "1"
+				}),
+			},
+			pods: []runtime.Object{
+				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash, withInitContainerImagePullBackOff()),
 				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
 			},
 			expectedDeletedPods: []string{"ingester-zone-a-0"},
 		},
-		"should count missing desired pods when StatefulSet status has caught up": {
+		"should not delete outdated not-Ready pods which are not stuck": {
 			statefulSets: []runtime.Object{
 				mockStatefulSet("ingester-zone-a", withPrevRevision(), withReplicas(3, 2), func(sts *v1.StatefulSet) {
-					sts.Status.Replicas = 2
 					sts.Annotations[config.RolloutMaxUnavailableAnnotationKey] = "1"
 				}),
 			},
 			pods: []runtime.Object{
+				// Not Ready (e.g. failing readiness probe) but not in an unrecoverable state:
+				// it consumes the budget and is not fair game for an out-of-budget delete.
+				mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash, withNotReady()),
 				mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
 				mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
 			},
@@ -1585,6 +1600,39 @@ func withNotReady() func(pod *corev1.Pod) {
 		for i := range pod.Status.ContainerStatuses {
 			pod.Status.ContainerStatuses[i].Ready = false
 		}
+	}
+}
+
+func withCrashLoopBackOff() func(pod *corev1.Pod) {
+	return func(pod *corev1.Pod) {
+		// A crashlooping pod keeps the Running phase: the container is waiting in
+		// CrashLoopBackOff between restart attempts.
+		for i := range pod.Status.ContainerStatuses {
+			pod.Status.ContainerStatuses[i].Ready = false
+			pod.Status.ContainerStatuses[i].State = corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+			}
+		}
+	}
+}
+
+func withInitContainerImagePullBackOff() func(pod *corev1.Pod) {
+	return func(pod *corev1.Pod) {
+		// A pod whose init container can't pull its image never leaves the Pending phase.
+		pod.Status.Phase = corev1.PodPending
+		for i := range pod.Status.ContainerStatuses {
+			pod.Status.ContainerStatuses[i].Ready = false
+			pod.Status.ContainerStatuses[i].State = corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{Reason: "PodInitializing"},
+			}
+		}
+		pod.Status.InitContainerStatuses = []corev1.ContainerStatus{{
+			Name:  "init",
+			Ready: false,
+			State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"},
+			},
+		}}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix stuck rollouts when a failed update leaves pods in CrashLoopBackOff: a follow-up StatefulSet update can now replace those pods without a manual delete.

- Outdated pods stuck in an unrecoverable state (`CrashLoopBackOff`, `ImagePullBackOff`, `ErrImagePull`, `InvalidImageName`, `CreateContainerConfigError`, `CreateContainerError`) are deleted even when `rollout-max-unavailable` is reached — they're already unavailable, so deleting them doesn't reduce availability any further
- The maxUnavailable accounting is otherwise unchanged: not-Ready pods that aren't stuck (e.g. a failing readiness probe that could recover) still pause the rollout as before
- Terminating pods are skipped as delete candidates regardless of pod phase
- Unit coverage for the stuck-pod paths, plus an integration test reproducing a real CrashLoopBackOff (new `CRASH` mode in the mock service)

### Root cause

`updateStatefulSetPods` computes the delete batch as `maxUnavailable - (Replicas - ReadyReplicas)`. A crashlooping pod left behind by a failed rollout consumes the whole budget (usually 1), so a second Spec update never deletes it. An earlier revision of this PR only charged update-revision pods against the budget, but that would have allowed deleting healthy pods while unrelated outdated pods were down; keeping the original accounting and exempting only stuck pods preserves the conservative behavior everywhere else.

The ZPDB is still consulted for every delete. It already excludes the eviction target from its own zone's disruption tally, so evicting the stuck pod is allowed while any other disruption still blocks it.

Fixes: https://github.com/grafana/rollout-operator/issues/339