### PR TITLE
Add health-check driven between-zone rollout gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,73 @@ spec:
 
 To resume normal rollout behavior, remove the annotation or set it to any value other than `true`.
 
+## Health-check driven rollout gating
+
+After the first zone in a rollout group finishes updating, the operator can evaluate cell-level health before starting the next zone. Pod readiness remains the within-zone gate; health checks are an additional between-zone gate.
+
+Attach a check to StatefulSets in the group:
+
+```yaml
+metadata:
+  annotations:
+    grafana.com/rollout-health-check: ingester-cell-health
+```
+
+Define the reusable configuration as a namespaced `RolloutHealthCheck`:
+
+```yaml
+apiVersion: rollout-operator.grafana.com/v1
+kind: RolloutHealthCheck
+metadata:
+  name: ingester-cell-health
+spec:
+  selector:
+    matchLabels:
+      rollout-group: ingester
+  prometheusURL: http://critical-prometheus.critical-o11y.svc.cluster.local.:9090/critical-prometheus
+  checks:
+    - name: request-error-rate
+      currentRange: 5m
+      baselineRange: 10m
+      queryTimeout: 10s
+      queryRetries: 3
+      onFailure: Pause   # Pause | Warn | Disabled
+      onNoData: Pause
+      # ${targetMatchers} is replaced with namespace + pod matchers for candidate or stable pods.
+      # ${range} is replaced with currentRange or baselineRange.
+      query: |
+        scalar(
+          sum(
+            rate(
+              cortex_request_duration_seconds_count{
+                ${targetMatchers},
+                status_code=~"5..",
+                route!~"ready|debug_pprof"
+              }[${range}]
+            )
+          )
+          or vector(0)
+        )
+      # ${current} and ${baseline} are the scalar results of the query above.
+      # Must return scalar 1 (pass) or 0 (fail).
+      successQuery: |
+        (
+          (${current} < bool 1)
+          +
+          (${current} < bool (2 * ${baseline}))
+        ) > bool 0
+```
+
+Behavior:
+
+- The first zone always rolls without a health evaluation (minimum blast radius is one zone).
+- Before starting a subsequent zone, each enabled check runs against candidate pods (already updated) and stable pods (not yet updated). Failed, no-data, or unreachable checks with `onFailure`/`onNoData: Pause` block progression.
+- `Warn` emits a warning event/log and continues. `Disabled` (or `disabled: true` on a check) skips that check.
+- If the annotation references a missing `RolloutHealthCheck`, or the check's selector does not match the StatefulSet, the rollout proceeds as today and the operator emits an error log, a Kubernetes event, and increments `rollout_operator_health_check_misconfigured_total`.
+- Remove the annotation (or set individual checks to `Disabled`) to bypass the gate. The operator never reverts workload versions.
+
+The operator stores `grafana.com/rollout-health-check-started-at: <updateRevision>=<RFC3339>` on StatefulSets when it first observes pods needing that revision; the earliest timestamp in the group is used as the baseline evaluation time.
+
 ## Operations
 
 ### HTTP endpoints

--- a/README.md
+++ b/README.md
@@ -184,12 +184,21 @@ spec:
     - name: request-error-rate
       currentRange: 5m
       baselineRange: 10m
-      queryTimeout: 10s
-      queryRetries: 3
-      onFailure: Pause   # Pause | Warn | Disabled
-      onNoData: Pause
-      # ${targetMatchers} is replaced with namespace + pod matchers for candidate or stable pods.
-      # ${range} is replaced with currentRange or baselineRange.
+      errorPolicy:
+        retryInterval: 10s
+        maxAttempts: 3
+        exhaustedAction: Pause   # Pause | Warn | Disabled
+      failurePolicy:
+        reevaluationInterval: 2m30s
+        consecutiveFailures: 3
+        consecutiveSuccesses: 1
+        exceededAction: Pause   # Pause | Warn | Disabled
+      noDataPolicy:
+        retryInterval: 30s
+        maxAttempts: 3
+        exhaustedAction: Pause
+      # ${targetMatchers} is replaced with namespace, zone (pod "name" label), and pod matchers
+      # for candidate or stable pods. ${range} is replaced with currentRange or baselineRange.
       query: |
         scalar(
           sum(
@@ -216,12 +225,16 @@ spec:
 Behavior:
 
 - The first zone always rolls without a health evaluation (minimum blast radius is one zone).
-- Before starting a subsequent zone, each enabled check runs against candidate pods (already updated) and stable pods (not yet updated). Failed, no-data, or unreachable checks with `onFailure`/`onNoData: Pause` block progression.
+- Before starting a subsequent zone, each enabled check runs against candidate pods (already updated) and stable pods (not yet updated).
+- Query errors use `errorPolicy` (retries spaced by `retryInterval` across reconciles, then `exhaustedAction`). No-data uses `noDataPolicy` the same way. Defaults pause when attempts are exhausted.
+- Failed success queries accumulate under `failurePolicy`. Progression pauses until `consecutiveSuccesses` pass results are observed (default 1). After `consecutiveFailures`, `exceededAction` applies (`Pause` by default). Re-queries that update those counters are spaced by `reevaluationInterval`.
 - `Warn` emits a warning event/log and continues. `Disabled` (or `disabled: true` on a check) skips that check.
 - If the annotation references a missing `RolloutHealthCheck`, or the check's selector does not match the StatefulSet, the rollout proceeds as today and the operator emits an error log, a Kubernetes event, and increments `rollout_operator_health_check_misconfigured_total`.
 - Remove the annotation (or set individual checks to `Disabled`) to bypass the gate. The operator never reverts workload versions.
 
 The operator stores `grafana.com/rollout-health-check-started-at: <updateRevision>=<RFC3339>` on StatefulSets when it first observes pods needing that revision; the earliest timestamp in the group is used as the baseline evaluation time.
+
+Create/update of `RolloutHealthCheck` objects is validated by the `/admission/rollout-health-check-validation` webhook when webhooks are enabled.
 
 ## Operations
 
@@ -250,6 +263,10 @@ Offers a `ValidatingAdmissionWebhook` which can apply a `ZoneAwarePodDisruptionB
 #### `/admission/zpdb-validation`
 
 Offers a `ValidatingAdmissionWebhook` to validate `ZoneAwarePodDisruptionBudget` configuration files and will reject any misconfigured files.
+
+#### `/admission/rollout-health-check-validation`
+
+Offers a `ValidatingAdmissionWebhook` to validate `RolloutHealthCheck` configuration and will reject misconfigured objects.
 
 
 ### RBAC

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -420,6 +420,10 @@ func maybeStartTLSServer(cfg config, wireComponentConfig func(component string) 
 		return admission.ZoneAwarePdbValidatingWebhookHandler(ctx, l, ar)
 	}
 
+	rolloutHealthCheckValidationFunc := func(ctx context.Context, l log.Logger, ar v1.AdmissionReview, _ *kubernetes.Clientset) *v1.AdmissionResponse {
+		return admission.RolloutHealthCheckValidatingWebhookHandler(ctx, l, ar)
+	}
+
 	tlsSrv, err := newTLSServer(cfg, logger, cert, metrics)
 	if err != nil {
 		fatal(fmt.Errorf("failed to create tls server: %w", err))
@@ -428,7 +432,8 @@ func maybeStartTLSServer(cfg config, wireComponentConfig func(component string) 
 	// Each webhook that issues Kubernetes API calls gets its own dedicated client, so that an overloaded
 	// webhook is rate limited independently (its own per-API-group buckets) and cannot throttle the other
 	// webhooks or the core controller. The pod-eviction webhook uses the eviction controller's dedicated
-	// client; the zpdb-validation webhook makes no API calls, so it is served with a nil client.
+	// client; the zpdb-validation and rollout-health-check-validation webhooks make no API calls, so
+	// they are served with a nil client.
 	noDownscaleKubeClient, err := newDedicatedKubeClient(wireComponentConfig("no-downscale"))
 	if err != nil {
 		fatal(fmt.Errorf("failed to create no-downscale webhook Kubernetes client: %w", err))
@@ -449,6 +454,7 @@ func maybeStartTLSServer(cfg config, wireComponentConfig func(component string) 
 	tlsSrv.Handle(admission.PrepareDownscaleWebhookPath, admission.Serve(prepDownscaleAdmitFunc, logger, prepareDownscaleKubeClient, webhookHandlerTimeout))
 	tlsSrv.Handle(zpdb.PodEvictionWebhookPath, admission.Serve(podEvictionFunc, logger, nil, webhookHandlerTimeout))
 	tlsSrv.Handle(admission.ZpdbValidatorWebhookPath, admission.Serve(zpdbValidationFunc, logger, nil, webhookHandlerTimeout))
+	tlsSrv.Handle(admission.RolloutHealthCheckValidatorWebhookPath, admission.Serve(rolloutHealthCheckValidationFunc, logger, nil, webhookHandlerTimeout))
 	if err := tlsSrv.Start(); err != nil {
 		fatal(fmt.Errorf("failed to start tls server: %w", err))
 	}

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -25,16 +25,21 @@ import (
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Required to get the GCP auth provider working.
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/grafana/rollout-operator/pkg/admission"
 	"github.com/grafana/rollout-operator/pkg/controller"
+	"github.com/grafana/rollout-operator/pkg/healthcheck"
 	"github.com/grafana/rollout-operator/pkg/instrumentation"
 	"github.com/grafana/rollout-operator/pkg/tlscert"
 	"github.com/grafana/rollout-operator/pkg/webhooks"
@@ -167,6 +172,7 @@ func main() {
 	reg := prometheus.NewRegistry()
 	metrics := newMetrics(reg)
 	zpdbMetrics := zpdb.NewMetrics(reg)
+	healthMetrics := healthcheck.NewMetrics(reg)
 
 	ready := atomic.NewBool(false)
 	restart := make(chan string)
@@ -293,6 +299,14 @@ func main() {
 	evictionController := zpdb.NewEvictionController(evictionKubeClient, dynamicClient, cfg.kubeNamespace, podsFactory, cfg.zpdbPodReadyAnnotationPatchTimeout, logger, zpdbMetrics)
 	check(evictionController.Start())
 
+	healthObserver := healthcheck.NewObserver(dynamicClient, cfg.kubeNamespace, logger, healthMetrics)
+	check(healthObserver.Start())
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartStructuredLogging(0)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: coreKubeClient.CoreV1().Events(cfg.kubeNamespace)})
+	eventRecorder := eventBroadcaster.NewRecorder(clientgoscheme.Scheme, corev1.EventSource{Component: "rollout-operator"})
+
 	maybeStartTLSServer(cfg, wireComponentConfig, podHTTPClient, logger, coreKubeClient, restart, metrics, evictionController, webhookObserver)
 
 	// Monitors the validating and mutating webhook configurations and provides a metric
@@ -308,6 +322,8 @@ func main() {
 
 	// Init the controller
 	c := controller.NewRolloutController(coreKubeClient, restMapper, scaleClient, dynamicClient, cfg.kubeClusterDomain, cfg.kubeNamespace, podsFactory, podHTTPClient, cfg.reconcileInterval, reg, logger, evictionController)
+	healthEvaluator := healthcheck.NewEvaluator(nil, healthMetrics, logger)
+	c.SetHealthCheck(healthcheck.NewGate(healthObserver, healthEvaluator, healthMetrics, eventRecorder, logger), healthMetrics)
 	if err := c.Init(); err != nil {
 		fatal(fmt.Errorf("failed to init controller: %w", err))
 	}
@@ -317,6 +333,8 @@ func main() {
 		waitForSignalOrRestart(logger, restart)
 		c.Stop()
 		evictionController.Stop()
+		healthObserver.Stop()
+		eventBroadcaster.Shutdown()
 		webhookObserver.Stop()
 		if webhookCollector != nil {
 			reg.Unregister(webhookCollector)

--- a/development/apply.sh
+++ b/development/apply.sh
@@ -21,4 +21,10 @@ done
 kubectl apply --wait -f "$SCRIPT_DIR/namespace.yaml"
 kubectl apply --wait -f "$SCRIPT_DIR/zone-aware-pod-disruption-budget-custom-resource-definition.yaml"
 kubectl apply --wait -f "$SCRIPT_DIR/replica-templates-custom-resource-definition.yaml"
-find "$SCRIPT_DIR" -type f -name '*.yaml' -not -name 'namespace.yaml' -not -name 'zone-aware-pod-disruption-budget-custom-resource-definition.yaml' -not name 'replica-templates-custom-resource-definition.yaml' -exec kubectl apply --namespace=rollout-operator-development --wait -f {} \;
+kubectl apply --wait -f "$SCRIPT_DIR/rollout-health-check-custom-resource-definition.yaml"
+find "$SCRIPT_DIR" -type f -name '*.yaml' \
+  -not -name 'namespace.yaml' \
+  -not -name 'zone-aware-pod-disruption-budget-custom-resource-definition.yaml' \
+  -not -name 'replica-templates-custom-resource-definition.yaml' \
+  -not -name 'rollout-health-check-custom-resource-definition.yaml' \
+  -exec kubectl apply --namespace=rollout-operator-development --wait -f {} \;

--- a/development/rollout-health-check-custom-resource-definition.yaml
+++ b/development/rollout-health-check-custom-resource-definition.yaml
@@ -1,0 +1,1 @@
+../operations/rollout-operator/crds/rollout-health-check.yaml

--- a/development/rollout-health-check-example.yaml
+++ b/development/rollout-health-check-example.yaml
@@ -1,0 +1,37 @@
+apiVersion: rollout-operator.grafana.com/v1
+kind: RolloutHealthCheck
+metadata:
+  name: ingester-cell-health
+  namespace: rollout-operator-development
+spec:
+  selector:
+    matchLabels:
+      rollout-group: ingester
+  prometheusURL: http://critical-prometheus.critical-o11y.svc.cluster.local.:9090/critical-prometheus
+  checks:
+    - name: request-error-rate
+      currentRange: 5m
+      baselineRange: 10m
+      queryTimeout: 10s
+      queryRetries: 3
+      onFailure: Pause
+      onNoData: Pause
+      query: |
+        scalar(
+          sum(
+            rate(
+              cortex_request_duration_seconds_count{
+                ${targetMatchers},
+                status_code=~"5..",
+                route!~"ready|debug_pprof"
+              }[${range}]
+            )
+          )
+          or vector(0)
+        )
+      successQuery: |
+        (
+          (${current} < bool 1)
+          +
+          (${current} < bool (2 * ${baseline}))
+        ) > bool 0

--- a/development/rollout-health-check-example.yaml
+++ b/development/rollout-health-check-example.yaml
@@ -12,10 +12,19 @@ spec:
     - name: request-error-rate
       currentRange: 5m
       baselineRange: 10m
-      queryTimeout: 10s
-      queryRetries: 3
-      onFailure: Pause
-      onNoData: Pause
+      errorPolicy:
+        retryInterval: 10s
+        maxAttempts: 3
+        exhaustedAction: Pause
+      failurePolicy:
+        reevaluationInterval: 2m30s
+        consecutiveFailures: 3
+        consecutiveSuccesses: 1
+        exceededAction: Pause
+      noDataPolicy:
+        retryInterval: 30s
+        maxAttempts: 3
+        exhaustedAction: Pause
       query: |
         scalar(
           sum(

--- a/development/rollout-health-check-validating-webhook.yaml
+++ b/development/rollout-health-check-validating-webhook.yaml
@@ -1,0 +1,32 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: rollout-health-check-validation-rollout-operator-development
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: rollout-operator-development
+webhooks:
+- name: rollout-health-check-validation-rollout-operator-development.grafana.com
+  clientConfig:
+    service:
+      namespace: rollout-operator-development
+      name: rollout-operator
+      path: /admission/rollout-health-check-validation
+      port: 443
+  rules:
+  - operations:
+      - CREATE
+      - UPDATE
+    apiGroups:
+      - rollout-operator.grafana.com
+    apiVersions:
+      - v1
+    resources:
+      - rollouthealthchecks
+    scope: Namespaced
+  admissionReviewVersions: ["v1"]
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: rollout-operator-development
+  failurePolicy: Fail
+  sideEffects: None

--- a/development/rollout-operator-role.yaml
+++ b/development/rollout-operator-role.yaml
@@ -13,6 +13,7 @@ rules:
       - get
       - watch
       - delete
+      - patch
   - apiGroups:
       - apps
     resources:
@@ -29,11 +30,18 @@ rules:
     verbs:
       - update
   - apiGroups:
+      -
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
       - rollout-operator.grafana.com
     resources:
       - zoneawarepoddisruptionbudgets
+      - rollouthealthchecks
     verbs:
       - get
       - list
       - watch
-      

--- a/integration/manifests_rollout_operator_test.go
+++ b/integration/manifests_rollout_operator_test.go
@@ -86,6 +86,7 @@ func createRolloutOperatorDependencies(t *testing.T, ctx context.Context, api *k
 	require.NoError(t, err)
 
 	_ = createZoneAwarePodDistruptionBudgetCustomResourceDefinition(t, extApi)
+	_ = createRolloutHealthCheckCustomResourceDefinition(t, extApi)
 
 	if webhook {
 		_ = createReplicaTemplateCustomResourceDefinition(t, extApi)
@@ -162,6 +163,12 @@ func loadValidatingWebhookConfigurationFromFile(t *testing.T, path string) *admi
 
 func createZoneAwarePodDistruptionBudgetCustomResourceDefinition(t *testing.T, extApi *apiextensionsclient.Clientset) *apiextensionsv1.CustomResourceDefinition {
 	obj, err := extApi.ApiextensionsV1().CustomResourceDefinitions().Create(context.Background(), loadCustomResourceDefinitionFromDisk(t, "../development/zone-aware-pod-disruption-budget-custom-resource-definition.yaml"), metav1.CreateOptions{})
+	require.NoError(t, err)
+	return obj
+}
+
+func createRolloutHealthCheckCustomResourceDefinition(t *testing.T, extApi *apiextensionsclient.Clientset) *apiextensionsv1.CustomResourceDefinition {
+	obj, err := extApi.ApiextensionsV1().CustomResourceDefinitions().Create(context.Background(), loadCustomResourceDefinitionFromDisk(t, "../development/rollout-health-check-custom-resource-definition.yaml"), metav1.CreateOptions{})
 	require.NoError(t, err)
 	return obj
 }

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -58,6 +58,114 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: zoneawarepoddisruptionbudgets.rollout-operator.grafana.com
 spec:
   group: rollout-operator.grafana.com
@@ -199,9 +307,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -546,6 +595,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -4,6 +4,114 @@ metadata:
   name: rollout-operator
   namespace: default
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -44,9 +152,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -42,38 +42,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -58,6 +58,114 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: zoneawarepoddisruptionbudgets.rollout-operator.grafana.com
 spec:
   group: rollout-operator.grafana.com
@@ -199,9 +307,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -546,6 +595,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Ignore
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy.jsonnet
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy.jsonnet
@@ -7,5 +7,6 @@ rollout_operator {
     ignore_rollout_operator_prepare_downscale_webhook_failures: true,
     ignore_rollout_operator_zpdb_eviction_webhook_failures: true,
     ignore_rollout_operator_zpdb_validation_webhook_failures: true,
+    ignore_rollout_operator_rollout_health_check_validation_webhook_failures: true,
   },
 }

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -55,6 +55,114 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -123,6 +231,13 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - replicatemplates/scale
@@ -134,6 +249,14 @@ rules:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -486,6 +535,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -58,6 +58,114 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: zoneawarepoddisruptionbudgets.rollout-operator.grafana.com
 spec:
   group: rollout-operator.grafana.com
@@ -199,6 +307,13 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - replicatemplates/scale
@@ -210,6 +325,14 @@ rules:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -563,6 +612,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -55,6 +55,114 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -123,9 +231,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -470,6 +519,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -55,6 +55,114 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -123,9 +231,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -470,6 +519,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -55,6 +55,114 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -123,9 +231,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -470,6 +519,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -55,6 +55,114 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -123,9 +231,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -470,6 +519,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -55,6 +55,114 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -123,9 +231,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -470,6 +519,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -55,6 +55,114 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -123,9 +231,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -470,6 +519,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator/crds/rollout-health-check.yaml
+++ b/operations/rollout-operator/crds/rollout-health-check.yaml
@@ -1,0 +1,97 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - selector
+                - prometheusURL
+                - checks
+              properties:
+                selector:
+                  type: object
+                  description: Selector preventing this policy from being attached to an unrelated workload.
+                  required:
+                    - matchLabels
+                  properties:
+                    matchLabels:
+                      type: object
+                      additionalProperties:
+                        type: string
+                prometheusURL:
+                  type: string
+                  description: Base URL of the Prometheus HTTP API used to evaluate checks.
+                  minLength: 1
+                checks:
+                  type: array
+                  description: Ordered list of PromQL health checks evaluated before progressing to the next zone.
+                  minItems: 1
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - query
+                      - successQuery
+                    properties:
+                      name:
+                        type: string
+                        description: Unique name of this check within the RolloutHealthCheck.
+                        minLength: 1
+                      currentRange:
+                        type: string
+                        description: Range vector duration substituted for ${range} when evaluating candidate pods. Defaults to 5m.
+                      baselineRange:
+                        type: string
+                        description: Range vector duration substituted for ${range} when evaluating stable pods at the pre-rollout timestamp. Defaults to 10m.
+                      queryTimeout:
+                        type: string
+                        description: Per-query timeout. Defaults to 10s.
+                      queryRetries:
+                        type: integer
+                        description: Number of retries after the first attempt. Defaults to 3.
+                        minimum: 0
+                      onFailure:
+                        type: string
+                        description: Behavior when the success query returns failure. Defaults to Pause.
+                        enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                      onNoData:
+                        type: string
+                        description: Behavior when a query returns no data. Defaults to Pause.
+                        enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                      disabled:
+                        type: boolean
+                        description: When true, this check is skipped while other checks remain active.
+                      query:
+                        type: string
+                        description: |
+                          PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        minLength: 1
+                      successQuery:
+                        type: string
+                        description: |
+                          PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                        minLength: 1
+  scope: Namespaced
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    singular: rollouthealthcheck
+    shortNames:
+      - rhc

--- a/operations/rollout-operator/crds/rollout-health-check.yaml
+++ b/operations/rollout-operator/crds/rollout-health-check.yaml
@@ -54,34 +54,71 @@ spec:
                       baselineRange:
                         type: string
                         description: Range vector duration substituted for ${range} when evaluating stable pods at the pre-rollout timestamp. Defaults to 10m.
-                      queryTimeout:
-                        type: string
-                        description: Per-query timeout. Defaults to 10s.
-                      queryRetries:
-                        type: integer
-                        description: Number of retries after the first attempt. Defaults to 3.
-                        minimum: 0
-                      onFailure:
-                        type: string
-                        description: Behavior when the success query returns failure. Defaults to Pause.
-                        enum:
-                          - Pause
-                          - Warn
-                          - Disabled
-                      onNoData:
-                        type: string
-                        description: Behavior when a query returns no data. Defaults to Pause.
-                        enum:
-                          - Pause
-                          - Warn
-                          - Disabled
+                      errorPolicy:
+                        type: object
+                        description: Retry and action policy when a Prometheus query fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3, exhaustedAction=Pause.
+                        properties:
+                          retryInterval:
+                            type: string
+                            description: Delay between query attempts after an error. Defaults to 10s.
+                          maxAttempts:
+                            type: integer
+                            description: Maximum query attempts including the first. Defaults to 3.
+                            minimum: 1
+                          exhaustedAction:
+                            type: string
+                            description: Behavior when all attempts fail. Defaults to Pause.
+                            enum:
+                              - Pause
+                              - Warn
+                              - Disabled
+                      failurePolicy:
+                        type: object
+                        description: How failed successQuery results accumulate before gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3, consecutiveSuccesses=1, exceededAction=Pause.
+                        properties:
+                          reevaluationInterval:
+                            type: string
+                            description: Minimum time between evaluations that update consecutive counters. Defaults to 2m30s.
+                          consecutiveFailures:
+                            type: integer
+                            description: Number of consecutive failed evaluations required before exceededAction. Defaults to 3.
+                            minimum: 1
+                          consecutiveSuccesses:
+                            type: integer
+                            description: Number of consecutive successful evaluations required to pass. Defaults to 1.
+                            minimum: 1
+                          exceededAction:
+                            type: string
+                            description: Behavior when consecutiveFailures is reached. Defaults to Pause.
+                            enum:
+                              - Pause
+                              - Warn
+                              - Disabled
+                      noDataPolicy:
+                        type: object
+                        description: Retry and action policy when a query returns no data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                        properties:
+                          retryInterval:
+                            type: string
+                            description: Delay between query attempts after no-data. Defaults to 30s.
+                          maxAttempts:
+                            type: integer
+                            description: Maximum query attempts including the first. Defaults to 3.
+                            minimum: 1
+                          exhaustedAction:
+                            type: string
+                            description: Behavior when all attempts return no data. Defaults to Pause.
+                            enum:
+                              - Pause
+                              - Warn
+                              - Disabled
                       disabled:
                         type: boolean
                         description: When true, this check is skipped while other checks remain active.
                       query:
                         type: string
                         description: |
-                          PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                          PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                         minLength: 1
                       successQuery:
                         type: string

--- a/operations/rollout-operator/rollout-operator.libsonnet
+++ b/operations/rollout-operator/rollout-operator.libsonnet
@@ -38,6 +38,10 @@
     // Include the custom resource definiton for the zpdb.
     zpdb_custom_resource_definition_enabled: $._config.rollout_operator_webhooks_enabled,
 
+    // Include the custom resource definition for RolloutHealthCheck.
+    // Enabled whenever the operator is enabled; health checks are evaluated by the controller, not webhooks.
+    rollout_health_check_custom_resource_definition_enabled: $._config.rollout_operator_enabled,
+
     // Configure the rollout operator to enable support for ReplicaTemplates
     rollout_operator_replica_template_access_enabled: false,
 
@@ -67,6 +71,9 @@
 
   zpdb_template:: std.parseYaml(importstr 'crds/zone-aware-pod-disruption-budget.yaml'),
   zpdb_custom_resource: if !$._config.zpdb_custom_resource_definition_enabled then null else $.zpdb_template,
+
+  rollout_health_check_template:: std.parseYaml(importstr 'crds/rollout-health-check.yaml'),
+  rollout_health_check_custom_resource: if !$._config.rollout_health_check_custom_resource_definition_enabled then null else $.rollout_health_check_template,
 
   replica_template:: std.parseYaml(importstr 'crds/replica-templates.yaml'),
   replica_template_custom_resource: if !$._config.replica_template_custom_resource_definition_enabled then null else $.replica_template,
@@ -134,6 +141,9 @@
         policyRule.withApiGroups('') +
         policyRule.withResources(['configmaps']) +
         policyRule.withVerbs(['get', 'update', 'create']),
+        policyRule.withApiGroups('') +
+        policyRule.withResources(['events']) +
+        policyRule.withVerbs(['create', 'patch']),
       ] +
       (
         if $._config.rollout_operator_replica_template_access_enabled then [
@@ -145,6 +155,9 @@
       [
         policyRule.withApiGroups($.zpdb_template.spec.group) +
         policyRule.withResources([$.zpdb_template.spec.names.plural]) +
+        policyRule.withVerbs(['get', 'list', 'watch']),
+        policyRule.withApiGroups($.rollout_health_check_template.spec.group) +
+        policyRule.withResources([$.rollout_health_check_template.spec.names.plural]) +
         policyRule.withVerbs(['get', 'list', 'watch']),
       ]
 

--- a/operations/rollout-operator/rollout-operator.libsonnet
+++ b/operations/rollout-operator/rollout-operator.libsonnet
@@ -39,7 +39,8 @@
     zpdb_custom_resource_definition_enabled: $._config.rollout_operator_webhooks_enabled,
 
     // Include the custom resource definition for RolloutHealthCheck.
-    // Enabled whenever the operator is enabled; health checks are evaluated by the controller, not webhooks.
+    // Enabled whenever the operator is enabled; health checks are evaluated by the controller.
+    // When webhooks are enabled, CREATE/UPDATE are also validated by admission.
     rollout_health_check_custom_resource_definition_enabled: $._config.rollout_operator_enabled,
 
     // Configure the rollout operator to enable support for ReplicaTemplates
@@ -56,6 +57,7 @@
     ignore_rollout_operator_prepare_downscale_webhook_failures: false,
     ignore_rollout_operator_zpdb_eviction_webhook_failures: false,
     ignore_rollout_operator_zpdb_validation_webhook_failures: false,
+    ignore_rollout_operator_rollout_health_check_validation_webhook_failures: false,
   },
 
   assert !$._config.rollout_operator_replica_template_access_enabled || $._config.rollout_operator_webhooks_enabled : 'rollout_operator_replica_template_access_enabled requires rollout_operator_webhooks_enabled=true',
@@ -65,6 +67,7 @@
   assert !$._config.ignore_rollout_operator_prepare_downscale_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_prepare_downscale_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.ignore_rollout_operator_zpdb_eviction_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_zpdb_eviction_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.ignore_rollout_operator_zpdb_validation_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_zpdb_validation_webhook_failures requires rollout_operator_webhooks_enabled=true',
+  assert !$._config.ignore_rollout_operator_rollout_health_check_validation_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_rollout_health_check_validation_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.replica_template_custom_resource_definition_enabled || $._config.rollout_operator_webhooks_enabled : 'replica_template_custom_resource_definition_enabled requires rollout_operator_webhooks_enabled=true',
 
   local enableWebhooks = $._config.rollout_operator_replica_template_access_enabled || $._config.rollout_operator_webhooks_enabled,
@@ -250,6 +253,43 @@
             name: 'rollout-operator',
             namespace: $._config.namespace,
             path: '/admission/zpdb-validation',
+            port: 443,
+          },
+        },
+      },
+    ]),
+
+  rollout_health_check_validation_webhook: if !enableWebhooks then null else
+    validatingWebhookConfiguration.new('rollout-health-check-validation-%s' % $._config.namespace) +
+    validatingWebhookConfiguration.mixin.metadata.withLabels({
+      'grafana.com/namespace': $._config.namespace,
+      'grafana.com/inject-rollout-operator-ca': 'true',
+    }) +
+    validatingWebhookConfiguration.withWebhooksMixin([
+      validatingWebhook.withName('rollout-health-check-validation-%s.grafana.com' % $._config.namespace)
+      + validatingWebhook.withAdmissionReviewVersions(['v1'])
+      + validatingWebhook.withFailurePolicy(if $._config.ignore_rollout_operator_rollout_health_check_validation_webhook_failures then 'Ignore' else 'Fail')
+      + validatingWebhook.withSideEffects('None')
+      + validatingWebhook.withRulesMixin([
+        {
+          apiGroups: ['rollout-operator.grafana.com'],
+          apiVersions: ['v1'],
+          operations: ['CREATE', 'UPDATE'],
+          resources: ['rollouthealthchecks'],
+          scope: 'Namespaced',
+        },
+      ])
+      + {
+        namespaceSelector: {
+          matchLabels: {
+            'kubernetes.io/metadata.name': $._config.namespace,
+          },
+        },
+        clientConfig: {
+          service: {
+            name: 'rollout-operator',
+            namespace: $._config.namespace,
+            path: '/admission/rollout-health-check-validation',
             port: 443,
           },
         },

--- a/pkg/admission/rollout_health_check_validating_webhook.go
+++ b/pkg/admission/rollout_health_check_validating_webhook.go
@@ -1,0 +1,92 @@
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/spanlogger"
+	v1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/rollout-operator/pkg/healthcheck"
+)
+
+const (
+	RolloutHealthCheckValidatorWebhookPath = "/admission/rollout-health-check-validation"
+)
+
+type rolloutHealthCheckValidatingWebhook struct {
+	ctx     context.Context
+	logger  *spanlogger.SpanLogger
+	request v1.AdmissionReview
+}
+
+func (v *rolloutHealthCheckValidatingWebhook) initLogger() {
+	v.logger.SetSpanAndLogTag("object.name", v.request.Request.Name)
+	v.logger.SetSpanAndLogTag("object.resource", v.request.Request.Resource.Resource)
+	v.logger.SetSpanAndLogTag("object.namespace", v.request.Request.Namespace)
+	v.logger.SetSpanAndLogTag("request.uid", v.request.Request.UID)
+
+	if v.request.Request.DryRun != nil {
+		v.logger.SetSpanAndLogTag("request.dry_run", v.request.Request.DryRun)
+	}
+}
+
+func (v *rolloutHealthCheckValidatingWebhook) parse() (int32, error) {
+	var obj unstructured.Unstructured
+	if err := json.Unmarshal(v.request.Request.Object.Raw, &obj); err != nil {
+		level.Info(v.logger).Log("msg", errors.New("failed to unmarshal object"), "err", err)
+		return int32(http.StatusBadRequest), err
+	}
+
+	_, err := healthcheck.ParseAndValidate(&obj)
+	if err != nil {
+		level.Info(v.logger).Log("msg", errors.New("parsing failed"), "err", err)
+		return int32(http.StatusBadRequest), err
+	}
+
+	return 0, nil
+}
+
+func (v *rolloutHealthCheckValidatingWebhook) allow() *v1.AdmissionResponse {
+	return &v1.AdmissionResponse{
+		Allowed: true,
+		UID:     v.request.Request.UID,
+	}
+}
+
+func (v *rolloutHealthCheckValidatingWebhook) deny(reason string, httpStatusCode int32) *v1.AdmissionResponse {
+	return &v1.AdmissionResponse{
+		Allowed: false,
+		UID:     v.request.Request.UID,
+		Result: &metav1.Status{
+			Message: reason,
+			Code:    httpStatusCode,
+		},
+	}
+}
+
+// RolloutHealthCheckValidatingWebhookHandler validates RolloutHealthCheck custom resources.
+func RolloutHealthCheckValidatingWebhookHandler(ctx context.Context, l log.Logger, ar v1.AdmissionReview) *v1.AdmissionResponse {
+	logger, ctx := spanlogger.New(ctx, l, "admission.RolloutHealthCheckValidatingWebhookHandler()", tenantResolver)
+	defer logger.Finish()
+
+	validator := &rolloutHealthCheckValidatingWebhook{
+		ctx:     ctx,
+		logger:  logger,
+		request: ar,
+	}
+
+	validator.initLogger()
+
+	if httpStatusCode, err := validator.parse(); err != nil {
+		return validator.deny(err.Error(), httpStatusCode)
+	}
+
+	return validator.allow()
+}

--- a/pkg/admission/rollout_health_check_validating_webhook_test.go
+++ b/pkg/admission/rollout_health_check_validating_webhook_test.go
@@ -1,0 +1,105 @@
+package admission
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestRolloutHealthCheckValidatorHandlerSuccess(t *testing.T) {
+	request := createRolloutHealthCheckAdmissionReviewValid()
+	response := RolloutHealthCheckValidatingWebhookHandler(context.Background(), log.NewNopLogger(), request)
+	require.NotNil(t, response.UID)
+	require.True(t, response.Allowed)
+}
+
+func TestRolloutHealthCheckValidatorHandlerBadConfig(t *testing.T) {
+	request := createRolloutHealthCheckAdmissionReviewInvalid()
+	response := RolloutHealthCheckValidatingWebhookHandler(context.Background(), log.NewNopLogger(), request)
+	require.NotNil(t, response.UID)
+	require.False(t, response.Allowed)
+	require.Contains(t, response.Result.Message, "prometheusURL")
+	require.Equal(t, int32(http.StatusBadRequest), response.Result.Code)
+}
+
+func TestRolloutHealthCheckValidatorHandlerParseError(t *testing.T) {
+	request := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID:    "test-request-uid",
+			Object: runtime.RawExtension{Raw: []byte(``)},
+		},
+	}
+	response := RolloutHealthCheckValidatingWebhookHandler(context.Background(), log.NewNopLogger(), request)
+	require.False(t, response.Allowed)
+	require.Equal(t, int32(http.StatusBadRequest), response.Result.Code)
+}
+
+func createRolloutHealthCheckAdmissionReviewValid() admissionv1.AdmissionReview {
+	return admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID: "test-request-uid",
+			Object: runtime.RawExtension{
+				Raw: []byte(`{
+					"apiVersion": "rollout-operator.grafana.com/v1",
+					"kind": "RolloutHealthCheck",
+					"metadata": {
+						"name": "ingester-cell-health",
+						"namespace": "test"
+					},
+					"spec": {
+						"selector": {
+							"matchLabels": {
+								"rollout-group": "ingester"
+							}
+						},
+						"prometheusURL": "http://prometheus:9090",
+						"checks": [
+							{
+								"name": "errors",
+								"query": "scalar(sum(rate(errors{${targetMatchers}}[${range}])))",
+								"successQuery": "(${current} < bool (${baseline}))"
+							}
+						]
+					}
+				}`),
+			},
+		},
+	}
+}
+
+func createRolloutHealthCheckAdmissionReviewInvalid() admissionv1.AdmissionReview {
+	return admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID: "test-request-uid",
+			Object: runtime.RawExtension{
+				Raw: []byte(`{
+					"apiVersion": "rollout-operator.grafana.com/v1",
+					"kind": "RolloutHealthCheck",
+					"metadata": {
+						"name": "ingester-cell-health",
+						"namespace": "test"
+					},
+					"spec": {
+						"selector": {
+							"matchLabels": {
+								"rollout-group": "ingester"
+							}
+						},
+						"checks": [
+							{
+								"name": "errors",
+								"query": "scalar(sum(rate(errors{${targetMatchers}}[${range}])))",
+								"successQuery": "(${current} < bool (${baseline}))"
+							}
+						]
+					}
+				}`),
+			},
+		},
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,4 +61,13 @@ const (
 	// StatefulSets in the same rollout group to continue rolling out.
 	RolloutPausedAnnotationKey   = "grafana.com/rollout-paused"
 	RolloutPausedAnnotationValue = "true"
+
+	// RolloutHealthCheckAnnotationKey references a namespaced RolloutHealthCheck CR used to gate
+	// progression between zones after the first zone has rolled.
+	RolloutHealthCheckAnnotationKey = "grafana.com/rollout-health-check"
+
+	// RolloutHealthCheckStartedAtAnnotationKey stores "<updateRevision>=<RFC3339>" marking when
+	// the operator first observed pods needing an update for that revision. Used as the baseline
+	// evaluation timestamp (T0) for health checks.
+	RolloutHealthCheckStartedAtAnnotationKey = "grafana.com/rollout-health-check-started-at"
 )

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -70,6 +71,10 @@ type RolloutController struct {
 
 	healthGate    HealthGate
 	healthMetrics *healthcheck.Metrics
+	healthTimerMu sync.Mutex
+	healthTimer   *time.Timer
+	healthTimerAt time.Time
+	healthWakeCh  chan struct{}
 
 	// This bool is true if we should trigger a reconcile.
 	shouldReconcile atomic.Bool
@@ -128,6 +133,7 @@ func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTM
 		zpdbController:       zpdbController,
 		logger:               logger,
 		stopCh:               make(chan struct{}),
+		healthWakeCh:         make(chan struct{}, 1),
 		discoveredGroups:     map[string]struct{}{},
 		groupReconcileTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "rollout_operator_group_reconciles_total",
@@ -255,6 +261,8 @@ func (c *RolloutController) Run() {
 		select {
 		case <-c.stopCh:
 			return
+		case <-c.healthWakeCh:
+			// Health deadlines must not wait for unrelated informer events or the regular throttle.
 		case <-time.After(c.reconcileInterval):
 			// Throttle before checking again if we should reconcile.
 		}
@@ -263,6 +271,13 @@ func (c *RolloutController) Run() {
 
 // Stop the controller.
 func (c *RolloutController) Stop() {
+	c.healthTimerMu.Lock()
+	if c.healthTimer != nil {
+		c.healthTimer.Stop()
+		c.healthTimer = nil
+		c.healthTimerAt = time.Time{}
+	}
+	c.healthTimerMu.Unlock()
 	close(c.stopCh)
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/healthcheck"
 	"github.com/grafana/rollout-operator/pkg/instrumentation"
 	"github.com/grafana/rollout-operator/pkg/util"
 	"github.com/grafana/rollout-operator/pkg/zpdb"
@@ -66,6 +67,9 @@ type RolloutController struct {
 	logger               log.Logger
 
 	zpdbController ZPDBEvictionController
+
+	healthGate    HealthGate
+	healthMetrics *healthcheck.Metrics
 
 	// This bool is true if we should trigger a reconcile.
 	shouldReconcile atomic.Bool
@@ -366,7 +370,39 @@ func (c *RolloutController) reconcileStatefulSetsGroup(ctx context.Context, grou
 		sets = util.MoveStatefulSetToFront(sets, notReadySets[0])
 	}
 
+	// Stamp the pre-rollout baseline timestamp as soon as any StatefulSet in the group
+	// needs updates, so T0 is available before the first between-zone health evaluation.
+	if groupHasHealthCheckAnnotation(sets) {
+		needsStamp := false
+		for _, sts := range sets {
+			outdated, err := c.podsNotMatchingUpdateRevision(sts)
+			if err != nil {
+				return fmt.Errorf("unable to list outdated pods for StatefulSet %s: %w", sts.Name, err)
+			}
+			if len(outdated) > 0 {
+				needsStamp = true
+				break
+			}
+		}
+		if needsStamp {
+			if err := c.ensureHealthCheckStartedAt(ctx, sets); err != nil {
+				level.Warn(c.logger).Log("msg", "failed to ensure health-check started-at annotation", "group", groupName, "err", err)
+			}
+		}
+	}
+
 	for _, sts := range sets {
+		pause, err := c.maybeEvaluateHealthGate(ctx, groupName, sets, sts)
+		if err != nil {
+			return fmt.Errorf("failed to evaluate health check before StatefulSet %s: %w", sts.Name, err)
+		}
+		if pause {
+			// Skip this StatefulSet but continue the loop so a mid-roll zone that sorts
+			// later (all its pods Ready, so not reordered via notReadySets) can still progress.
+			level.Info(c.logger).Log("msg", "pausing rollout due to health check", "group", groupName, "statefulset", sts.Name)
+			continue
+		}
+
 		ongoing, err := c.updateStatefulSetPods(ctx, sts)
 		if err != nil {
 			// Do not continue with other StatefulSets because this StatefulSet
@@ -769,6 +805,9 @@ func (c *RolloutController) deleteMetricsForDecommissionedGroups(groups map[stri
 		c.groupReconcileFailed.DeleteLabelValues(name)
 		c.groupReconcileDuration.DeleteLabelValues(name)
 		c.groupReconcileLastSuccess.DeleteLabelValues(name)
+		if c.healthMetrics != nil {
+			c.healthMetrics.DeleteGroup(name)
+		}
 		delete(c.discoveredGroups, name)
 	}
 

--- a/pkg/controller/health.go
+++ b/pkg/controller/health.go
@@ -1,0 +1,214 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log/level"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/healthcheck"
+)
+
+// HealthGate evaluates cell-level health before progressing to the next zone.
+type HealthGate interface {
+	Evaluate(ctx context.Context, req healthcheck.Request) healthcheck.Decision
+}
+
+// SetHealthCheck wires optional health-check gating into the controller.
+func (c *RolloutController) SetHealthCheck(gate HealthGate, metrics *healthcheck.Metrics) {
+	c.healthGate = gate
+	c.healthMetrics = metrics
+}
+
+func (c *RolloutController) maybeEvaluateHealthGate(ctx context.Context, groupName string, sets []*v1.StatefulSet, next *v1.StatefulSet) (pause bool, err error) {
+	if c.healthGate == nil {
+		return false, nil
+	}
+	// Binding is per-StatefulSet: only gate when the zone about to roll references a check.
+	if strings.TrimSpace(next.Annotations[config.RolloutHealthCheckAnnotationKey]) == "" {
+		return false, nil
+	}
+
+	needsGate, err := c.shouldGateBeforeStatefulSet(sets, next)
+	if err != nil {
+		return false, err
+	}
+	if !needsGate {
+		return false, nil
+	}
+
+	// Skip PromQL evaluation when the next zone is paused; it will not roll anyway.
+	if next.Annotations[config.RolloutPausedAnnotationKey] == config.RolloutPausedAnnotationValue {
+		return false, nil
+	}
+
+	candidatePods, stablePods, err := c.listCandidateAndStablePods(sets)
+	if err != nil {
+		return false, err
+	}
+	baseline := earliestHealthCheckStartedAt(sets)
+	if baseline.IsZero() {
+		msg := fmt.Sprintf("health-check baseline timestamp missing for group %s; pausing before StatefulSet %s", groupName, next.Name)
+		level.Warn(c.logger).Log("msg", msg, "group", groupName, "statefulset", next.Name)
+		if c.healthMetrics != nil {
+			c.healthMetrics.Blocked.WithLabelValues(groupName).Set(1)
+		}
+		return true, nil
+	}
+
+	decision := c.healthGate.Evaluate(ctx, healthcheck.Request{
+		RolloutGroup:  groupName,
+		Namespace:     c.namespace,
+		Sets:          sets,
+		NextSTS:       next,
+		CandidatePods: candidatePods,
+		StablePods:    stablePods,
+		BaselineTime:  baseline,
+	})
+	return decision.ShouldPause, nil
+}
+
+func groupHasHealthCheckAnnotation(sets []*v1.StatefulSet) bool {
+	for _, sts := range sets {
+		if strings.TrimSpace(sts.Annotations[config.RolloutHealthCheckAnnotationKey]) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldGateBeforeStatefulSet is true when next still has pods to update, has not started
+// rolling yet, and at least one other StatefulSet in the group already has candidate pods.
+func (c *RolloutController) shouldGateBeforeStatefulSet(sets []*v1.StatefulSet, next *v1.StatefulSet) (bool, error) {
+	outdated, err := c.podsNotMatchingUpdateRevision(next)
+	if err != nil {
+		return false, err
+	}
+	if len(outdated) == 0 {
+		return false, nil
+	}
+
+	nextCandidates, err := c.podsMatchingUpdateRevision(next)
+	if err != nil {
+		return false, err
+	}
+	if len(nextCandidates) > 0 {
+		// Zone already mid-roll; do not re-gate.
+		return false, nil
+	}
+
+	for _, sts := range sets {
+		if sts.Name == next.Name {
+			continue
+		}
+		candidates, err := c.podsMatchingUpdateRevision(sts)
+		if err != nil {
+			return false, err
+		}
+		if len(candidates) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (c *RolloutController) podsMatchingUpdateRevision(sts *v1.StatefulSet) ([]*corev1.Pod, error) {
+	updateRev := sts.Status.UpdateRevision
+	if updateRev == "" {
+		return nil, fmt.Errorf("updateRevision is empty for StatefulSet %s", sts.Name)
+	}
+	pods, err := c.listPodsByStatefulSet(sts)
+	if err != nil {
+		return nil, err
+	}
+	var matching []*corev1.Pod
+	for _, pod := range pods {
+		if pod.Labels[v1.ControllerRevisionHashLabelKey] == updateRev {
+			matching = append(matching, pod)
+		}
+	}
+	return matching, nil
+}
+
+func (c *RolloutController) listCandidateAndStablePods(sets []*v1.StatefulSet) (candidates, stable []*corev1.Pod, err error) {
+	for _, sts := range sets {
+		pods, listErr := c.listPodsByStatefulSet(sts)
+		if listErr != nil {
+			return nil, nil, listErr
+		}
+		updateRev := sts.Status.UpdateRevision
+		for _, pod := range pods {
+			if pod.Labels[v1.ControllerRevisionHashLabelKey] == updateRev {
+				candidates = append(candidates, pod)
+			} else {
+				stable = append(stable, pod)
+			}
+		}
+	}
+	return candidates, stable, nil
+}
+
+func (c *RolloutController) ensureHealthCheckStartedAt(ctx context.Context, sets []*v1.StatefulSet) error {
+	now := time.Now().UTC()
+	for _, sts := range sets {
+		outdated, err := c.podsNotMatchingUpdateRevision(sts)
+		if err != nil {
+			return err
+		}
+		if len(outdated) == 0 {
+			continue
+		}
+		updateRev := sts.Status.UpdateRevision
+		existing := healthcheck.ParseStartedAtAnnotation(sts.Annotations[config.RolloutHealthCheckStartedAtAnnotationKey], updateRev)
+		if !existing.IsZero() {
+			continue
+		}
+		value := healthcheck.FormatStartedAtAnnotation(updateRev, now)
+		if err := c.patchStatefulSetAnnotation(ctx, sts, config.RolloutHealthCheckStartedAtAnnotationKey, value); err != nil {
+			return fmt.Errorf("failed to patch started-at on %s: %w", sts.Name, err)
+		}
+		if sts.Annotations == nil {
+			sts.Annotations = map[string]string{}
+		}
+		sts.Annotations[config.RolloutHealthCheckStartedAtAnnotationKey] = value
+	}
+	return nil
+}
+
+func earliestHealthCheckStartedAt(sets []*v1.StatefulSet) time.Time {
+	var earliest time.Time
+	for _, sts := range sets {
+		t := healthcheck.ParseStartedAtAnnotation(sts.Annotations[config.RolloutHealthCheckStartedAtAnnotationKey], sts.Status.UpdateRevision)
+		if t.IsZero() {
+			continue
+		}
+		if earliest.IsZero() || t.Before(earliest) {
+			earliest = t
+		}
+	}
+	return earliest
+}
+
+func (c *RolloutController) patchStatefulSetAnnotation(ctx context.Context, sts *v1.StatefulSet, key, value string) error {
+	patch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]string{
+				key: value,
+			},
+		},
+	}
+	data, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+	_, err = c.kubeClient.AppsV1().StatefulSets(c.namespace).Patch(ctx, sts.Name, types.MergePatchType, data, metav1.PatchOptions{})
+	return err
+}

--- a/pkg/controller/health.go
+++ b/pkg/controller/health.go
@@ -73,7 +73,57 @@ func (c *RolloutController) maybeEvaluateHealthGate(ctx context.Context, groupNa
 		StablePods:    stablePods,
 		BaselineTime:  baseline,
 	})
+	if decision.ShouldPause && decision.RequeueAfter > 0 {
+		c.scheduleHealthRequeue(decision.RequeueAfter, groupName, next.Name)
+	}
 	return decision.ShouldPause, nil
+}
+
+func (c *RolloutController) scheduleHealthRequeue(after time.Duration, groupName, statefulSet string) {
+	if after <= 0 {
+		return
+	}
+
+	due := time.Now().Add(after)
+	c.healthTimerMu.Lock()
+	defer c.healthTimerMu.Unlock()
+	if c.healthTimer != nil && !due.Before(c.healthTimerAt) {
+		return
+	}
+	if c.healthTimer != nil {
+		c.healthTimer.Stop()
+	}
+
+	var timer *time.Timer
+	timer = time.AfterFunc(after, func() {
+		c.healthTimerMu.Lock()
+		if c.healthTimer != timer {
+			c.healthTimerMu.Unlock()
+			return
+		}
+		c.healthTimer = nil
+		c.healthTimerAt = time.Time{}
+		c.healthTimerMu.Unlock()
+
+		select {
+		case <-c.stopCh:
+			return
+		default:
+			c.enqueueReconcile()
+			select {
+			case c.healthWakeCh <- struct{}{}:
+			default:
+			}
+		}
+	})
+	c.healthTimer = timer
+	c.healthTimerAt = due
+	level.Debug(c.logger).Log(
+		"msg", "scheduled health check reevaluation",
+		"group", groupName,
+		"statefulset", statefulSet,
+		"requeue_after", after,
+	)
 }
 
 func groupHasHealthCheckAnnotation(sets []*v1.StatefulSet) bool {

--- a/pkg/controller/health_test.go
+++ b/pkg/controller/health_test.go
@@ -1,0 +1,217 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/healthcheck"
+)
+
+type mockHealthGate struct {
+	mu          sync.Mutex
+	calls       int
+	shouldPause bool
+	lastReq     healthcheck.Request
+}
+
+func (m *mockHealthGate) Evaluate(_ context.Context, req healthcheck.Request) healthcheck.Decision {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	m.lastReq = req
+	return healthcheck.Decision{ShouldPause: m.shouldPause, Reason: "mock"}
+}
+
+func (m *mockHealthGate) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+func TestRolloutController_HealthCheckGating(t *testing.T) {
+	withHealthCheck := func(sts *v1.StatefulSet) {
+		if sts.Annotations == nil {
+			sts.Annotations = map[string]string{}
+		}
+		sts.Annotations[config.RolloutHealthCheckAnnotationKey] = "ingester-cell-health"
+		sts.Annotations[config.RolloutMaxUnavailableAnnotationKey] = "2"
+	}
+
+	t.Run("first zone rolls without gate", func(t *testing.T) {
+		gate := &mockHealthGate{shouldPause: true}
+		objects := []runtime.Object{
+			mockStatefulSet("ingester-zone-a", withPrevRevision(), withHealthCheck),
+			mockStatefulSet("ingester-zone-b", withPrevRevision(), withHealthCheck),
+			mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
+		}
+		c := newControllerWithHealthGate(t, objects, gate)
+		require.NoError(t, c.reconcile(context.Background()))
+		require.Equal(t, 0, gate.callCount(), "first zone must not evaluate health gate")
+
+		pods, err := c.kubeClient.CoreV1().Pods(testNamespace).List(context.Background(), metav1.ListOptions{})
+		require.NoError(t, err)
+		deleted := 0
+		for _, name := range []string{"ingester-zone-a-0", "ingester-zone-a-1", "ingester-zone-a-2"} {
+			found := false
+			for _, p := range pods.Items {
+				if p.Name == name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				deleted++
+			}
+		}
+		require.Equal(t, testMaxUnavailable, deleted)
+	})
+
+	t.Run("gate blocks next zone", func(t *testing.T) {
+		gate := &mockHealthGate{shouldPause: true}
+		objects := []runtime.Object{
+			mockStatefulSet("ingester-zone-a", withHealthCheck),
+			mockStatefulSet("ingester-zone-b", withPrevRevision(), withHealthCheck),
+			mockStatefulSetPod("ingester-zone-a-0", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-1", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-2", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
+		}
+		c := newControllerWithHealthGate(t, objects, gate)
+		require.NoError(t, c.reconcile(context.Background()))
+		require.Equal(t, 1, gate.callCount())
+		require.Equal(t, "ingester-zone-b", gate.lastReq.NextSTS.Name)
+
+		for _, name := range []string{"ingester-zone-b-0", "ingester-zone-b-1", "ingester-zone-b-2"} {
+			_, err := c.kubeClient.CoreV1().Pods(testNamespace).Get(context.Background(), name, metav1.GetOptions{})
+			require.NoError(t, err, name)
+		}
+	})
+
+	t.Run("pass allows next zone", func(t *testing.T) {
+		gate := &mockHealthGate{shouldPause: false}
+		objects := []runtime.Object{
+			mockStatefulSet("ingester-zone-a", withHealthCheck),
+			mockStatefulSet("ingester-zone-b", withPrevRevision(), withHealthCheck),
+			mockStatefulSetPod("ingester-zone-a-0", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-1", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-2", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
+		}
+		c := newControllerWithHealthGate(t, objects, gate)
+		require.NoError(t, c.reconcile(context.Background()))
+		require.Equal(t, 1, gate.callCount())
+
+		pods, err := c.kubeClient.CoreV1().Pods(testNamespace).List(context.Background(), metav1.ListOptions{})
+		require.NoError(t, err)
+		remainingB := 0
+		for _, p := range pods.Items {
+			if strings.HasPrefix(p.Name, "ingester-zone-b") {
+				remainingB++
+			}
+		}
+		require.Equal(t, 3-testMaxUnavailable, remainingB)
+	})
+
+	t.Run("mid-zone not gated again", func(t *testing.T) {
+		gate := &mockHealthGate{shouldPause: true}
+		objects := []runtime.Object{
+			mockStatefulSet("ingester-zone-a", withHealthCheck),
+			mockStatefulSet("ingester-zone-b", withPrevRevision(), withHealthCheck),
+			mockStatefulSetPod("ingester-zone-a-0", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-1", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-2", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-0", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
+		}
+		c := newControllerWithHealthGate(t, objects, gate)
+		require.NoError(t, c.reconcile(context.Background()))
+		require.Equal(t, 0, gate.callCount())
+	})
+
+	t.Run("no annotation skips gate", func(t *testing.T) {
+		gate := &mockHealthGate{shouldPause: true}
+		objects := []runtime.Object{
+			mockStatefulSet("ingester-zone-a"),
+			mockStatefulSet("ingester-zone-b", withPrevRevision()),
+			mockStatefulSetPod("ingester-zone-a-0", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-1", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-2", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
+		}
+		c := newControllerWithHealthGate(t, objects, gate)
+		require.NoError(t, c.reconcile(context.Background()))
+		require.Equal(t, 0, gate.callCount())
+	})
+
+	t.Run("pause continues mid-roll zone", func(t *testing.T) {
+		gate := &mockHealthGate{shouldPause: true}
+		objects := []runtime.Object{
+			mockStatefulSet("ingester-zone-a", withHealthCheck),
+			mockStatefulSet("ingester-zone-b", withPrevRevision(), withHealthCheck),
+			mockStatefulSet("ingester-zone-c", withPrevRevision(), withHealthCheck),
+			mockStatefulSetPod("ingester-zone-a-0", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-1", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-2", testLastRevisionHash),
+			// zone-b has not started — health gate pauses it.
+			mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
+			// zone-c mid-roll (sorts after b): must still progress after b is paused.
+			mockStatefulSetPod("ingester-zone-c-0", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-c-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-c-2", testPrevRevisionHash),
+		}
+		c := newControllerWithHealthGate(t, objects, gate)
+		require.NoError(t, c.reconcile(context.Background()))
+		require.GreaterOrEqual(t, gate.callCount(), 1)
+		pods, err := c.kubeClient.CoreV1().Pods(testNamespace).List(context.Background(), metav1.ListOptions{})
+		require.NoError(t, err)
+		remainingC := 0
+		for _, p := range pods.Items {
+			if strings.HasPrefix(p.Name, "ingester-zone-c") {
+				remainingC++
+			}
+		}
+		require.Less(t, remainingC, 3, "mid-roll zone-c should continue deleting pods despite zone-b pause")
+		// zone-b must remain untouched
+		for _, name := range []string{"ingester-zone-b-0", "ingester-zone-b-1", "ingester-zone-b-2"} {
+			_, err := c.kubeClient.CoreV1().Pods(testNamespace).Get(context.Background(), name, metav1.GetOptions{})
+			require.NoError(t, err, name)
+		}
+	})
+}
+
+func newControllerWithHealthGate(t *testing.T, objects []runtime.Object, gate HealthGate) *RolloutController {
+	t.Helper()
+	kubeClient := fake.NewClientset(objects...)
+	reg := prometheus.NewPedanticRegistry()
+	c := NewRolloutController(kubeClient, nil, nil, nil, testClusterDomain, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger(), &mockEvictionController{})
+	c.SetHealthCheck(gate, nil)
+	require.NoError(t, c.Init())
+	t.Cleanup(c.Stop)
+	return c
+}

--- a/pkg/controller/health_test.go
+++ b/pkg/controller/health_test.go
@@ -209,7 +209,7 @@ func newControllerWithHealthGate(t *testing.T, objects []runtime.Object, gate He
 	t.Helper()
 	kubeClient := fake.NewClientset(objects...)
 	reg := prometheus.NewPedanticRegistry()
-	c := NewRolloutController(kubeClient, nil, nil, nil, testClusterDomain, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger(), &mockEvictionController{})
+	c := NewRolloutController(kubeClient, nil, nil, nil, testClusterDomain, testNamespace, NewPodInformerFactory(kubeClient, testNamespace), nil, 5*time.Second, reg, log.NewNopLogger(), &mockEvictionController{})
 	c.SetHealthCheck(gate, nil)
 	require.NoError(t, c.Init())
 	t.Cleanup(c.Stop)

--- a/pkg/controller/health_test.go
+++ b/pkg/controller/health_test.go
@@ -20,10 +20,11 @@ import (
 )
 
 type mockHealthGate struct {
-	mu          sync.Mutex
-	calls       int
-	shouldPause bool
-	lastReq     healthcheck.Request
+	mu           sync.Mutex
+	calls        int
+	shouldPause  bool
+	requeueAfter time.Duration
+	lastReq      healthcheck.Request
 }
 
 func (m *mockHealthGate) Evaluate(_ context.Context, req healthcheck.Request) healthcheck.Decision {
@@ -31,7 +32,7 @@ func (m *mockHealthGate) Evaluate(_ context.Context, req healthcheck.Request) he
 	defer m.mu.Unlock()
 	m.calls++
 	m.lastReq = req
-	return healthcheck.Decision{ShouldPause: m.shouldPause, Reason: "mock"}
+	return healthcheck.Decision{ShouldPause: m.shouldPause, Reason: "mock", RequeueAfter: m.requeueAfter}
 }
 
 func (m *mockHealthGate) callCount() int {
@@ -84,7 +85,7 @@ func TestRolloutController_HealthCheckGating(t *testing.T) {
 	})
 
 	t.Run("gate blocks next zone", func(t *testing.T) {
-		gate := &mockHealthGate{shouldPause: true}
+		gate := &mockHealthGate{shouldPause: true, requeueAfter: time.Minute}
 		objects := []runtime.Object{
 			mockStatefulSet("ingester-zone-a", withHealthCheck),
 			mockStatefulSet("ingester-zone-b", withPrevRevision(), withHealthCheck),
@@ -99,6 +100,12 @@ func TestRolloutController_HealthCheckGating(t *testing.T) {
 		require.NoError(t, c.reconcile(context.Background()))
 		require.Equal(t, 1, gate.callCount())
 		require.Equal(t, "ingester-zone-b", gate.lastReq.NextSTS.Name)
+		c.healthTimerMu.Lock()
+		timerScheduled := c.healthTimer != nil
+		timerDelay := time.Until(c.healthTimerAt)
+		c.healthTimerMu.Unlock()
+		require.True(t, timerScheduled)
+		require.InDelta(t, time.Minute, timerDelay, float64(time.Second))
 
 		for _, name := range []string{"ingester-zone-b-0", "ingester-zone-b-1", "ingester-zone-b-2"} {
 			_, err := c.kubeClient.CoreV1().Pods(testNamespace).Get(context.Background(), name, metav1.GetOptions{})
@@ -203,6 +210,28 @@ func TestRolloutController_HealthCheckGating(t *testing.T) {
 			require.NoError(t, err, name)
 		}
 	})
+}
+
+func TestRolloutController_HealthRequeueTimerEnqueuesReconcile(t *testing.T) {
+	c := &RolloutController{
+		logger:       log.NewNopLogger(),
+		stopCh:       make(chan struct{}),
+		healthWakeCh: make(chan struct{}, 1),
+	}
+	t.Cleanup(c.Stop)
+
+	c.scheduleHealthRequeue(10*time.Millisecond, "ingester", "ingester-zone-b")
+
+	select {
+	case <-c.healthWakeCh:
+	case <-time.After(time.Second):
+		t.Fatal("health requeue timer did not wake the controller")
+	}
+	require.True(t, c.shouldReconcile.Load())
+	c.healthTimerMu.Lock()
+	defer c.healthTimerMu.Unlock()
+	require.Nil(t, c.healthTimer)
+	require.True(t, c.healthTimerAt.IsZero())
 }
 
 func newControllerWithHealthGate(t *testing.T, objects []runtime.Object, gate HealthGate) *RolloutController {

--- a/pkg/healthcheck/cache.go
+++ b/pkg/healthcheck/cache.go
@@ -1,0 +1,72 @@
+package healthcheck
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// configCache holds RolloutHealthCheck configs keyed by name.
+type configCache struct {
+	entries map[string]*Config
+	lock    sync.RWMutex
+}
+
+func newConfigCache() *configCache {
+	return &configCache{
+		entries: map[string]*Config{},
+	}
+}
+
+func (c *configCache) addOrUpdateRaw(obj *unstructured.Unstructured) (bool, int64, error) {
+	cfg, err := ParseAndValidate(obj)
+	if err != nil {
+		return false, -1, err
+	}
+	updated, generation := c.addOrUpdate(cfg)
+	return updated, generation, nil
+}
+
+func (c *configCache) addOrUpdate(cfg *Config) (bool, int64) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	oldCfg, found := c.entries[cfg.Name]
+	if found && oldCfg.Generation >= cfg.Generation {
+		return false, oldCfg.Generation
+	}
+	c.entries[cfg.Name] = cfg
+	return true, cfg.Generation
+}
+
+func (c *configCache) delete(generation int64, name string) (bool, int64) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	oldCfg, found := c.entries[name]
+	if !found {
+		return false, -1
+	}
+	if oldCfg.Generation > generation {
+		return false, oldCfg.Generation
+	}
+	delete(c.entries, name)
+	return true, oldCfg.Generation
+}
+
+// Get returns the cached config for name, or nil if missing.
+func (c *configCache) Get(name string) *Config {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.entries[name]
+}
+
+func (c *configCache) invalidate(name string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	delete(c.entries, name)
+}
+
+func (c *configCache) size() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return len(c.entries)
+}

--- a/pkg/healthcheck/cache.go
+++ b/pkg/healthcheck/cache.go
@@ -64,9 +64,3 @@ func (c *configCache) invalidate(name string) {
 	defer c.lock.Unlock()
 	delete(c.entries, name)
 }
-
-func (c *configCache) size() int {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-	return len(c.entries)
-}

--- a/pkg/healthcheck/config.go
+++ b/pkg/healthcheck/config.go
@@ -1,0 +1,270 @@
+package healthcheck
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	RolloutHealthCheckKind       = "RolloutHealthCheck"
+	RolloutHealthChecksPlural    = "rollouthealthchecks"
+	RolloutHealthChecksSpecGroup = "rollout-operator.grafana.com"
+	RolloutHealthChecksVersion   = "v1"
+
+	placeholderTargetMatchers = "${targetMatchers}"
+	placeholderRange          = "${range}"
+	placeholderCurrent        = "${current}"
+	placeholderBaseline       = "${baseline}"
+
+	defaultCurrentRange  = 5 * time.Minute
+	defaultBaselineRange = 10 * time.Minute
+	defaultQueryTimeout  = 10 * time.Second
+	defaultQueryRetries  = 3
+)
+
+// FailureAction controls how a failed or no-data check affects the rollout.
+type FailureAction string
+
+const (
+	ActionPause    FailureAction = "Pause"
+	ActionWarn     FailureAction = "Warn"
+	ActionDisabled FailureAction = "Disabled"
+)
+
+// Check is a single PromQL health check within a RolloutHealthCheck.
+type Check struct {
+	Name          string
+	CurrentRange  time.Duration
+	BaselineRange time.Duration
+	QueryTimeout  time.Duration
+	QueryRetries  int
+	OnFailure     FailureAction
+	OnNoData      FailureAction
+	Disabled      bool
+	Query         string
+	SuccessQuery  string
+}
+
+// Config is the parsed RolloutHealthCheck custom resource.
+type Config struct {
+	Name          string
+	Generation    int64
+	Selector      labels.Selector
+	PrometheusURL string
+	Checks        []Check
+}
+
+// MatchesLabels returns true if this Config's selector matches the given labels.
+func (c *Config) MatchesLabels(set labels.Set) bool {
+	if c.Selector == nil {
+		return false
+	}
+	return c.Selector.Matches(set)
+}
+
+// ParseAndValidate parses an unstructured RolloutHealthCheck into a Config.
+func ParseAndValidate(obj *unstructured.Unstructured) (*Config, error) {
+	if obj.GetKind() != RolloutHealthCheckKind {
+		return nil, fmt.Errorf("unexpected object kind - expecting %s", RolloutHealthCheckKind)
+	}
+
+	cfg := &Config{
+		Name:       obj.GetName(),
+		Generation: obj.GetGeneration(),
+	}
+
+	prometheusURL, found, err := unstructured.NestedString(obj.Object, "spec", "prometheusURL")
+	if err != nil {
+		return nil, fmt.Errorf("invalid prometheusURL: %w", err)
+	}
+	if !found || strings.TrimSpace(prometheusURL) == "" {
+		return nil, errors.New("invalid value: prometheusURL is required")
+	}
+	cfg.PrometheusURL = strings.TrimSpace(prometheusURL)
+	parsedURL, err := url.Parse(cfg.PrometheusURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid value: prometheusURL is not a valid URL: %w", err)
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return nil, errors.New("invalid value: prometheusURL scheme must be http or https")
+	}
+	if parsedURL.Host == "" {
+		return nil, errors.New("invalid value: prometheusURL must include a host")
+	}
+
+	if mlMap, found, err := unstructured.NestedStringMap(obj.Object, "spec", "selector", "matchLabels"); err != nil {
+		return nil, fmt.Errorf("invalid value: selector is not valid, got %v", err)
+	} else if !found || len(mlMap) == 0 {
+		return nil, errors.New("invalid value: selector.matchLabels is required")
+	} else {
+		cfg.Selector = labels.SelectorFromSet(mlMap)
+	}
+
+	rawChecks, found, err := unstructured.NestedSlice(obj.Object, "spec", "checks")
+	if err != nil {
+		return nil, fmt.Errorf("invalid checks: %w", err)
+	}
+	if !found || len(rawChecks) == 0 {
+		return nil, errors.New("invalid value: checks must contain at least one entry")
+	}
+
+	seenNames := map[string]struct{}{}
+	for i, raw := range rawChecks {
+		checkMap, ok := raw.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid value: checks[%d] must be an object", i)
+		}
+		check, err := parseCheck(checkMap, i)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := seenNames[check.Name]; exists {
+			return nil, fmt.Errorf("invalid value: duplicate check name %q", check.Name)
+		}
+		seenNames[check.Name] = struct{}{}
+		cfg.Checks = append(cfg.Checks, check)
+	}
+
+	return cfg, nil
+}
+
+func parseCheck(m map[string]interface{}, index int) (Check, error) {
+	check := Check{
+		CurrentRange:  defaultCurrentRange,
+		BaselineRange: defaultBaselineRange,
+		QueryTimeout:  defaultQueryTimeout,
+		QueryRetries:  defaultQueryRetries,
+		OnFailure:     ActionPause,
+		OnNoData:      ActionPause,
+	}
+
+	name, ok := m["name"].(string)
+	if !ok || strings.TrimSpace(name) == "" {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].name is required", index)
+	}
+	check.Name = strings.TrimSpace(name)
+
+	query, ok := m["query"].(string)
+	if !ok || strings.TrimSpace(query) == "" {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].query is required", index)
+	}
+	check.Query = query
+	if !strings.Contains(check.Query, placeholderTargetMatchers) {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].query must contain %s", index, placeholderTargetMatchers)
+	}
+	if !strings.Contains(check.Query, placeholderRange) {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].query must contain %s", index, placeholderRange)
+	}
+
+	successQuery, ok := m["successQuery"].(string)
+	if !ok || strings.TrimSpace(successQuery) == "" {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].successQuery is required", index)
+	}
+	check.SuccessQuery = successQuery
+	if !strings.Contains(check.SuccessQuery, placeholderCurrent) {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].successQuery must contain %s", index, placeholderCurrent)
+	}
+	if !strings.Contains(check.SuccessQuery, placeholderBaseline) {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].successQuery must contain %s", index, placeholderBaseline)
+	}
+
+	if v, found := m["currentRange"]; found {
+		d, err := parseDurationField(v, "currentRange", index)
+		if err != nil {
+			return Check{}, err
+		}
+		check.CurrentRange = d
+	}
+	if v, found := m["baselineRange"]; found {
+		d, err := parseDurationField(v, "baselineRange", index)
+		if err != nil {
+			return Check{}, err
+		}
+		check.BaselineRange = d
+	}
+	if v, found := m["queryTimeout"]; found {
+		d, err := parseDurationField(v, "queryTimeout", index)
+		if err != nil {
+			return Check{}, err
+		}
+		check.QueryTimeout = d
+	}
+	if v, found := m["queryRetries"]; found {
+		n, ok := asInt(v)
+		if !ok || n < 0 {
+			return Check{}, fmt.Errorf("invalid value: checks[%d].queryRetries must be >= 0", index)
+		}
+		check.QueryRetries = n
+	}
+	if v, found := m["onFailure"]; found {
+		action, err := parseFailureAction(v, "onFailure", index)
+		if err != nil {
+			return Check{}, err
+		}
+		check.OnFailure = action
+	}
+	if v, found := m["onNoData"]; found {
+		action, err := parseFailureAction(v, "onNoData", index)
+		if err != nil {
+			return Check{}, err
+		}
+		check.OnNoData = action
+	}
+	if v, found := m["disabled"]; found {
+		disabled, ok := v.(bool)
+		if !ok {
+			return Check{}, fmt.Errorf("invalid value: checks[%d].disabled must be a boolean", index)
+		}
+		check.Disabled = disabled
+	}
+
+	return check, nil
+}
+
+func parseDurationField(v interface{}, field string, index int) (time.Duration, error) {
+	s, ok := v.(string)
+	if !ok || strings.TrimSpace(s) == "" {
+		return 0, fmt.Errorf("invalid value: checks[%d].%s must be a duration string", index, field)
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid value: checks[%d].%s is not a valid duration: %w", index, field, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("invalid value: checks[%d].%s must be > 0", index, field)
+	}
+	return d, nil
+}
+
+func parseFailureAction(v interface{}, field string, index int) (FailureAction, error) {
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("invalid value: checks[%d].%s must be a string", index, field)
+	}
+	switch FailureAction(s) {
+	case ActionPause, ActionWarn, ActionDisabled:
+		return FailureAction(s), nil
+	default:
+		return "", fmt.Errorf("invalid value: checks[%d].%s must be Pause, Warn, or Disabled", index, field)
+	}
+}
+
+func asInt(v interface{}) (int, bool) {
+	switch n := v.(type) {
+	case int64:
+		return int(n), true
+	case int:
+		return n, true
+	case float64:
+		if n == float64(int(n)) {
+			return int(n), true
+		}
+	}
+	return 0, false
+}

--- a/pkg/healthcheck/config.go
+++ b/pkg/healthcheck/config.go
@@ -22,13 +22,19 @@ const (
 	placeholderCurrent        = "${current}"
 	placeholderBaseline       = "${baseline}"
 
-	defaultCurrentRange  = 5 * time.Minute
-	defaultBaselineRange = 10 * time.Minute
-	defaultQueryTimeout  = 10 * time.Second
-	defaultQueryRetries  = 3
+	defaultCurrentRange         = 5 * time.Minute
+	defaultBaselineRange        = 10 * time.Minute
+	defaultQueryTimeout         = 10 * time.Second
+	defaultErrorRetryInterval   = 10 * time.Second
+	defaultErrorMaxAttempts     = 3
+	defaultNoDataRetryInterval  = 30 * time.Second
+	defaultNoDataMaxAttempts    = 3
+	defaultReevaluationInterval = 2*time.Minute + 30*time.Second
+	defaultConsecutiveFailures  = 3
+	defaultConsecutiveSuccesses = 1
 )
 
-// FailureAction controls how a failed or no-data check affects the rollout.
+// FailureAction controls how a failed, no-data, or exhausted check affects the rollout.
 type FailureAction string
 
 const (
@@ -37,15 +43,30 @@ const (
 	ActionDisabled FailureAction = "Disabled"
 )
 
+// RetryPolicy controls retries for query errors or no-data responses.
+type RetryPolicy struct {
+	RetryInterval   time.Duration
+	MaxAttempts     int
+	ExhaustedAction FailureAction
+}
+
+// FailurePolicy controls how consecutive success/failure evaluations accumulate.
+type FailurePolicy struct {
+	ReevaluationInterval time.Duration
+	ConsecutiveFailures  int
+	ConsecutiveSuccesses int
+	ExceededAction       FailureAction
+}
+
 // Check is a single PromQL health check within a RolloutHealthCheck.
 type Check struct {
 	Name          string
 	CurrentRange  time.Duration
 	BaselineRange time.Duration
 	QueryTimeout  time.Duration
-	QueryRetries  int
-	OnFailure     FailureAction
-	OnNoData      FailureAction
+	ErrorPolicy   RetryPolicy
+	FailurePolicy FailurePolicy
+	NoDataPolicy  RetryPolicy
 	Disabled      bool
 	Query         string
 	SuccessQuery  string
@@ -139,9 +160,22 @@ func parseCheck(m map[string]interface{}, index int) (Check, error) {
 		CurrentRange:  defaultCurrentRange,
 		BaselineRange: defaultBaselineRange,
 		QueryTimeout:  defaultQueryTimeout,
-		QueryRetries:  defaultQueryRetries,
-		OnFailure:     ActionPause,
-		OnNoData:      ActionPause,
+		ErrorPolicy: RetryPolicy{
+			RetryInterval:   defaultErrorRetryInterval,
+			MaxAttempts:     defaultErrorMaxAttempts,
+			ExhaustedAction: ActionPause,
+		},
+		FailurePolicy: FailurePolicy{
+			ReevaluationInterval: defaultReevaluationInterval,
+			ConsecutiveFailures:  defaultConsecutiveFailures,
+			ConsecutiveSuccesses: defaultConsecutiveSuccesses,
+			ExceededAction:       ActionPause,
+		},
+		NoDataPolicy: RetryPolicy{
+			RetryInterval:   defaultNoDataRetryInterval,
+			MaxAttempts:     defaultNoDataMaxAttempts,
+			ExhaustedAction: ActionPause,
+		},
 	}
 
 	name, ok := m["name"].(string)
@@ -188,34 +222,6 @@ func parseCheck(m map[string]interface{}, index int) (Check, error) {
 		}
 		check.BaselineRange = d
 	}
-	if v, found := m["queryTimeout"]; found {
-		d, err := parseDurationField(v, "queryTimeout", index)
-		if err != nil {
-			return Check{}, err
-		}
-		check.QueryTimeout = d
-	}
-	if v, found := m["queryRetries"]; found {
-		n, ok := asInt(v)
-		if !ok || n < 0 {
-			return Check{}, fmt.Errorf("invalid value: checks[%d].queryRetries must be >= 0", index)
-		}
-		check.QueryRetries = n
-	}
-	if v, found := m["onFailure"]; found {
-		action, err := parseFailureAction(v, "onFailure", index)
-		if err != nil {
-			return Check{}, err
-		}
-		check.OnFailure = action
-	}
-	if v, found := m["onNoData"]; found {
-		action, err := parseFailureAction(v, "onNoData", index)
-		if err != nil {
-			return Check{}, err
-		}
-		check.OnNoData = action
-	}
 	if v, found := m["disabled"]; found {
 		disabled, ok := v.(bool)
 		if !ok {
@@ -223,8 +229,96 @@ func parseCheck(m map[string]interface{}, index int) (Check, error) {
 		}
 		check.Disabled = disabled
 	}
+	if v, found := m["errorPolicy"]; found {
+		policy, err := parseRetryPolicy(v, "errorPolicy", index, check.ErrorPolicy)
+		if err != nil {
+			return Check{}, err
+		}
+		check.ErrorPolicy = policy
+	}
+	if v, found := m["noDataPolicy"]; found {
+		policy, err := parseRetryPolicy(v, "noDataPolicy", index, check.NoDataPolicy)
+		if err != nil {
+			return Check{}, err
+		}
+		check.NoDataPolicy = policy
+	}
+	if v, found := m["failurePolicy"]; found {
+		policy, err := parseFailurePolicy(v, index, check.FailurePolicy)
+		if err != nil {
+			return Check{}, err
+		}
+		check.FailurePolicy = policy
+	}
 
 	return check, nil
+}
+
+func parseRetryPolicy(v interface{}, field string, index int, defaults RetryPolicy) (RetryPolicy, error) {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return RetryPolicy{}, fmt.Errorf("invalid value: checks[%d].%s must be an object", index, field)
+	}
+	policy := defaults
+	if raw, found := m["retryInterval"]; found {
+		d, err := parseDurationField(raw, field+".retryInterval", index)
+		if err != nil {
+			return RetryPolicy{}, err
+		}
+		policy.RetryInterval = d
+	}
+	if raw, found := m["maxAttempts"]; found {
+		n, ok := asInt(raw)
+		if !ok || n < 1 {
+			return RetryPolicy{}, fmt.Errorf("invalid value: checks[%d].%s.maxAttempts must be >= 1", index, field)
+		}
+		policy.MaxAttempts = n
+	}
+	if raw, found := m["exhaustedAction"]; found {
+		action, err := parseFailureAction(raw, field+".exhaustedAction", index)
+		if err != nil {
+			return RetryPolicy{}, err
+		}
+		policy.ExhaustedAction = action
+	}
+	return policy, nil
+}
+
+func parseFailurePolicy(v interface{}, index int, defaults FailurePolicy) (FailurePolicy, error) {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return FailurePolicy{}, fmt.Errorf("invalid value: checks[%d].failurePolicy must be an object", index)
+	}
+	policy := defaults
+	if raw, found := m["reevaluationInterval"]; found {
+		d, err := parseDurationField(raw, "failurePolicy.reevaluationInterval", index)
+		if err != nil {
+			return FailurePolicy{}, err
+		}
+		policy.ReevaluationInterval = d
+	}
+	if raw, found := m["consecutiveFailures"]; found {
+		n, ok := asInt(raw)
+		if !ok || n < 1 {
+			return FailurePolicy{}, fmt.Errorf("invalid value: checks[%d].failurePolicy.consecutiveFailures must be >= 1", index)
+		}
+		policy.ConsecutiveFailures = n
+	}
+	if raw, found := m["consecutiveSuccesses"]; found {
+		n, ok := asInt(raw)
+		if !ok || n < 1 {
+			return FailurePolicy{}, fmt.Errorf("invalid value: checks[%d].failurePolicy.consecutiveSuccesses must be >= 1", index)
+		}
+		policy.ConsecutiveSuccesses = n
+	}
+	if raw, found := m["exceededAction"]; found {
+		action, err := parseFailureAction(raw, "failurePolicy.exceededAction", index)
+		if err != nil {
+			return FailurePolicy{}, err
+		}
+		policy.ExceededAction = action
+	}
+	return policy, nil
 }
 
 func parseDurationField(v interface{}, field string, index int) (time.Duration, error) {
@@ -260,7 +354,7 @@ func asInt(v interface{}) (int, bool) {
 	case int64:
 		return int(n), true
 	case int:
-		return n, true
+		return int(n), true
 	case float64:
 		if n == float64(int(n)) {
 			return int(n), true

--- a/pkg/healthcheck/config_test.go
+++ b/pkg/healthcheck/config_test.go
@@ -1,0 +1,115 @@
+package healthcheck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestParseAndValidate(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name":         "errors",
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool 1) + (${current} < bool (2 * ${baseline})) > bool 0`,
+				},
+			},
+		})
+		cfg, err := ParseAndValidate(obj)
+		require.NoError(t, err)
+		require.Equal(t, "ingester-cell-health", cfg.Name)
+		require.Equal(t, "http://prometheus:9090", cfg.PrometheusURL)
+		require.Len(t, cfg.Checks, 1)
+		require.Equal(t, ActionPause, cfg.Checks[0].OnFailure)
+		require.Equal(t, defaultCurrentRange, cfg.Checks[0].CurrentRange)
+	})
+
+	t.Run("missing placeholders", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name":         "errors",
+					"query":        `scalar(1)`,
+					"successQuery": `${current} < bool 1`,
+				},
+			},
+		})
+		_, err := ParseAndValidate(obj)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), placeholderTargetMatchers)
+	})
+
+	t.Run("duplicate check names", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name":         "errors",
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool (${baseline}))`,
+				},
+				map[string]interface{}{
+					"name":         "errors",
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool (${baseline}))`,
+				},
+			},
+		})
+		_, err := ParseAndValidate(obj)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "duplicate")
+	})
+
+	t.Run("invalid onFailure", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name":         "errors",
+					"onFailure":    "Nope",
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool (${baseline}))`,
+				},
+			},
+		})
+		_, err := ParseAndValidate(obj)
+		require.Error(t, err)
+	})
+}
+
+func TestParseStartedAtAnnotation(t *testing.T) {
+	require.True(t, ParseStartedAtAnnotation("", "rev").IsZero())
+	require.True(t, ParseStartedAtAnnotation("other=2026-01-01T00:00:00Z", "rev").IsZero())
+	ts := ParseStartedAtAnnotation("rev=2026-01-02T03:04:05Z", "rev")
+	require.False(t, ts.IsZero())
+	require.Equal(t, "rev=2026-01-02T03:04:05Z", FormatStartedAtAnnotation("rev", ts))
+}
+
+func mockHealthCheckUnstructured(spec map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": RolloutHealthChecksSpecGroup + "/" + RolloutHealthChecksVersion,
+		"kind":       RolloutHealthCheckKind,
+		"metadata": map[string]interface{}{
+			"name":       "ingester-cell-health",
+			"generation": int64(1),
+		},
+		"spec": spec,
+	}}
+}

--- a/pkg/healthcheck/config_test.go
+++ b/pkg/healthcheck/config_test.go
@@ -2,13 +2,14 @@ package healthcheck
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestParseAndValidate(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
+	t.Run("valid defaults", func(t *testing.T) {
 		obj := mockHealthCheckUnstructured(map[string]interface{}{
 			"selector": map[string]interface{}{
 				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
@@ -27,8 +28,57 @@ func TestParseAndValidate(t *testing.T) {
 		require.Equal(t, "ingester-cell-health", cfg.Name)
 		require.Equal(t, "http://prometheus:9090", cfg.PrometheusURL)
 		require.Len(t, cfg.Checks, 1)
-		require.Equal(t, ActionPause, cfg.Checks[0].OnFailure)
+		require.Equal(t, ActionPause, cfg.Checks[0].FailurePolicy.ExceededAction)
+		require.Equal(t, ActionPause, cfg.Checks[0].ErrorPolicy.ExhaustedAction)
+		require.Equal(t, ActionPause, cfg.Checks[0].NoDataPolicy.ExhaustedAction)
 		require.Equal(t, defaultCurrentRange, cfg.Checks[0].CurrentRange)
+		require.Equal(t, defaultConsecutiveFailures, cfg.Checks[0].FailurePolicy.ConsecutiveFailures)
+		require.Equal(t, defaultErrorRetryInterval, cfg.Checks[0].ErrorPolicy.RetryInterval)
+		require.Equal(t, defaultNoDataRetryInterval, cfg.Checks[0].NoDataPolicy.RetryInterval)
+	})
+
+	t.Run("explicit policies", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name": "errors",
+					"errorPolicy": map[string]interface{}{
+						"retryInterval":   "5s",
+						"maxAttempts":     int64(2),
+						"exhaustedAction": "Warn",
+					},
+					"failurePolicy": map[string]interface{}{
+						"reevaluationInterval": "1m",
+						"consecutiveFailures":  int64(2),
+						"consecutiveSuccesses": int64(2),
+						"exceededAction":       "Pause",
+					},
+					"noDataPolicy": map[string]interface{}{
+						"retryInterval":   "15s",
+						"maxAttempts":     int64(4),
+						"exhaustedAction": "Disabled",
+					},
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool (${baseline}))`,
+				},
+			},
+		})
+		cfg, err := ParseAndValidate(obj)
+		require.NoError(t, err)
+		c := cfg.Checks[0]
+		require.Equal(t, 5*time.Second, c.ErrorPolicy.RetryInterval)
+		require.Equal(t, 2, c.ErrorPolicy.MaxAttempts)
+		require.Equal(t, ActionWarn, c.ErrorPolicy.ExhaustedAction)
+		require.Equal(t, time.Minute, c.FailurePolicy.ReevaluationInterval)
+		require.Equal(t, 2, c.FailurePolicy.ConsecutiveFailures)
+		require.Equal(t, 2, c.FailurePolicy.ConsecutiveSuccesses)
+		require.Equal(t, 15*time.Second, c.NoDataPolicy.RetryInterval)
+		require.Equal(t, 4, c.NoDataPolicy.MaxAttempts)
+		require.Equal(t, ActionDisabled, c.NoDataPolicy.ExhaustedAction)
 	})
 
 	t.Run("missing placeholders", func(t *testing.T) {
@@ -74,7 +124,7 @@ func TestParseAndValidate(t *testing.T) {
 		require.Contains(t, err.Error(), "duplicate")
 	})
 
-	t.Run("invalid onFailure", func(t *testing.T) {
+	t.Run("invalid exhaustedAction", func(t *testing.T) {
 		obj := mockHealthCheckUnstructured(map[string]interface{}{
 			"selector": map[string]interface{}{
 				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
@@ -82,8 +132,10 @@ func TestParseAndValidate(t *testing.T) {
 			"prometheusURL": "http://prometheus:9090",
 			"checks": []interface{}{
 				map[string]interface{}{
-					"name":         "errors",
-					"onFailure":    "Nope",
+					"name": "errors",
+					"errorPolicy": map[string]interface{}{
+						"exhaustedAction": "Nope",
+					},
 					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
 					"successQuery": `(${current} < bool (${baseline}))`,
 				},

--- a/pkg/healthcheck/evaluator.go
+++ b/pkg/healthcheck/evaluator.go
@@ -1,0 +1,323 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/api"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+// Querier abstracts the Prometheus instant-query API for tests.
+type Querier interface {
+	Query(ctx context.Context, query string, ts time.Time) (model.Value, v1.Warnings, error)
+}
+
+type prometheusQuerier struct {
+	api v1.API
+}
+
+func (q *prometheusQuerier) Query(ctx context.Context, query string, ts time.Time) (model.Value, v1.Warnings, error) {
+	return q.api.Query(ctx, query, ts)
+}
+
+// NewPrometheusQuerier builds a Querier against the given Prometheus base URL.
+func NewPrometheusQuerier(prometheusURL string) (Querier, error) {
+	client, err := api.NewClient(api.Config{Address: prometheusURL})
+	if err != nil {
+		return nil, err
+	}
+	return &prometheusQuerier{api: v1.NewAPI(client)}, nil
+}
+
+// QuerierFactory creates a Querier for a Prometheus URL. Overridable in tests.
+type QuerierFactory func(prometheusURL string) (Querier, error)
+
+// EvaluationResult is the raw outcome of evaluating a single check.
+type EvaluationResult string
+
+const (
+	ResultPass   EvaluationResult = "pass"
+	ResultFail   EvaluationResult = "fail"
+	ResultNoData EvaluationResult = "no_data"
+	ResultError  EvaluationResult = "error"
+)
+
+// CheckOutcome is the action taken after mapping an EvaluationResult through onFailure/onNoData.
+type CheckOutcome string
+
+const (
+	OutcomePass    CheckOutcome = "pass"
+	OutcomePause   CheckOutcome = "pause"
+	OutcomeWarn    CheckOutcome = "warn"
+	OutcomeSkipped CheckOutcome = "skipped"
+)
+
+// EvaluateRequest holds inputs for evaluating a RolloutHealthCheck against a rollout group.
+type EvaluateRequest struct {
+	Config          *Config
+	Namespace       string
+	RolloutGroup    string
+	CandidatePods   []string
+	StablePods      []string
+	BaselineTime    time.Time
+	Now             time.Time
+}
+
+// EvaluateResponse is the aggregate result of all checks.
+type EvaluateResponse struct {
+	Outcome      CheckOutcome
+	FailedCheck  string
+	Message      string
+	CheckResults map[string]EvaluationResult
+}
+
+// Evaluator runs PromQL health checks.
+type Evaluator struct {
+	factory QuerierFactory
+	metrics *Metrics
+	logger  log.Logger
+}
+
+// NewEvaluator creates an Evaluator. factory may be nil to use NewPrometheusQuerier.
+func NewEvaluator(factory QuerierFactory, metrics *Metrics, logger log.Logger) *Evaluator {
+	if factory == nil {
+		factory = NewPrometheusQuerier
+	}
+	return &Evaluator{factory: factory, metrics: metrics, logger: logger}
+}
+
+// Evaluate runs all enabled checks in cfg. Returns OutcomePause when any check requires pausing.
+func (e *Evaluator) Evaluate(ctx context.Context, req EvaluateRequest) EvaluateResponse {
+	resp := EvaluateResponse{
+		Outcome:      OutcomePass,
+		CheckResults: map[string]EvaluationResult{},
+	}
+	if req.Config == nil {
+		return resp
+	}
+	if req.Now.IsZero() {
+		req.Now = time.Now()
+	}
+
+	querier, err := e.factory(req.Config.PrometheusURL)
+	if err != nil {
+		msg := fmt.Sprintf("failed to create Prometheus client for %q: %v", req.Config.PrometheusURL, err)
+		level.Error(e.logger).Log("msg", msg, "rollout_group", req.RolloutGroup)
+		resp.Outcome = OutcomePause
+		resp.Message = msg
+		return resp
+	}
+
+	candidateMatchers := buildTargetMatchers(req.Namespace, req.CandidatePods)
+	stableMatchers := buildTargetMatchers(req.Namespace, req.StablePods)
+
+	for _, check := range req.Config.Checks {
+		if check.Disabled {
+			resp.CheckResults[check.Name] = ResultPass
+			e.observeEvaluation(req.RolloutGroup, check.Name, "skipped")
+			continue
+		}
+
+		result, msg := e.evaluateCheck(ctx, querier, check, candidateMatchers, stableMatchers, req)
+		resp.CheckResults[check.Name] = result
+		e.observeEvaluation(req.RolloutGroup, check.Name, string(result))
+
+		outcome := mapResultToOutcome(result, check)
+		if outcome == OutcomeSkipped || outcome == OutcomePass {
+			continue
+		}
+		if outcome == OutcomeWarn {
+			if resp.Outcome == OutcomePass {
+				resp.Outcome = OutcomeWarn
+				resp.FailedCheck = check.Name
+				resp.Message = msg
+			}
+			continue
+		}
+		// Pause wins over Warn.
+		resp.Outcome = OutcomePause
+		resp.FailedCheck = check.Name
+		resp.Message = msg
+		return resp
+	}
+
+	return resp
+}
+
+func mapResultToOutcome(result EvaluationResult, check Check) CheckOutcome {
+	switch result {
+	case ResultPass:
+		return OutcomePass
+	case ResultFail:
+		return actionToOutcome(check.OnFailure)
+	case ResultNoData:
+		return actionToOutcome(check.OnNoData)
+	case ResultError:
+		// Unreachable / query errors always pause unless the check is fully disabled (handled earlier).
+		return actionToOutcome(check.OnFailure)
+	default:
+		return OutcomePause
+	}
+}
+
+func actionToOutcome(action FailureAction) CheckOutcome {
+	switch action {
+	case ActionWarn:
+		return OutcomeWarn
+	case ActionDisabled:
+		return OutcomeSkipped
+	default:
+		return OutcomePause
+	}
+}
+
+func (e *Evaluator) evaluateCheck(ctx context.Context, querier Querier, check Check, candidateMatchers, stableMatchers string, req EvaluateRequest) (EvaluationResult, string) {
+	currentQuery := substituteQuery(check.Query, candidateMatchers, formatDuration(check.CurrentRange))
+	baselineQuery := substituteQuery(check.Query, stableMatchers, formatDuration(check.BaselineRange))
+
+	currentVal, err := e.queryScalar(ctx, querier, currentQuery, req.Now, req.RolloutGroup, check, "current")
+	if err != nil {
+		return ResultError, fmt.Sprintf("check %q current query failed: %v", check.Name, err)
+	}
+	if currentVal == nil {
+		return ResultNoData, fmt.Sprintf("check %q current query returned no data", check.Name)
+	}
+
+	baselineTS := req.BaselineTime
+	if baselineTS.IsZero() {
+		baselineTS = req.Now
+	}
+	baselineVal, err := e.queryScalar(ctx, querier, baselineQuery, baselineTS, req.RolloutGroup, check, "baseline")
+	if err != nil {
+		return ResultError, fmt.Sprintf("check %q baseline query failed: %v", check.Name, err)
+	}
+	if baselineVal == nil {
+		return ResultNoData, fmt.Sprintf("check %q baseline query returned no data", check.Name)
+	}
+
+	successQuery := substituteSuccessQuery(check.SuccessQuery, *currentVal, *baselineVal)
+	successVal, err := e.queryScalar(ctx, querier, successQuery, req.Now, req.RolloutGroup, check, "success")
+	if err != nil {
+		return ResultError, fmt.Sprintf("check %q success query failed: %v", check.Name, err)
+	}
+	if successVal == nil {
+		return ResultNoData, fmt.Sprintf("check %q success query returned no data", check.Name)
+	}
+	if *successVal == 1 {
+		return ResultPass, ""
+	}
+	if *successVal == 0 {
+		return ResultFail, fmt.Sprintf("check %q failed (current=%v baseline=%v)", check.Name, *currentVal, *baselineVal)
+	}
+	return ResultFail, fmt.Sprintf("check %q success query returned unexpected scalar %v (want 0 or 1)", check.Name, *successVal)
+}
+
+func (e *Evaluator) queryScalar(ctx context.Context, querier Querier, query string, ts time.Time, rolloutGroup string, check Check, queryType string) (*float64, error) {
+	var lastErr error
+	attempts := check.QueryRetries + 1
+	for attempt := 0; attempt < attempts; attempt++ {
+		qctx, cancel := context.WithTimeout(ctx, check.QueryTimeout)
+		start := time.Now()
+		value, warnings, err := querier.Query(qctx, query, ts)
+		cancel()
+		if e.metrics != nil {
+			e.metrics.QueryDuration.WithLabelValues(rolloutGroup, check.Name, queryType).Observe(time.Since(start).Seconds())
+		}
+		if len(warnings) > 0 {
+			level.Warn(e.logger).Log("msg", "prometheus query warnings", "check", check.Name, "query_type", queryType, "warnings", strings.Join(warnings, "; "))
+		}
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		scalar, err := valueToScalar(value)
+		if err != nil {
+			return nil, err
+		}
+		return scalar, nil
+	}
+	return nil, lastErr
+}
+
+func (e *Evaluator) observeEvaluation(rolloutGroup, check, result string) {
+	if e.metrics == nil {
+		return
+	}
+	e.metrics.EvaluationsTotal.WithLabelValues(rolloutGroup, check, result).Inc()
+}
+
+func valueToScalar(value model.Value) (*float64, error) {
+	if value == nil {
+		return nil, nil
+	}
+	switch v := value.(type) {
+	case *model.Scalar:
+		if v == nil {
+			return nil, nil
+		}
+		f := float64(v.Value)
+		return &f, nil
+	case model.Vector:
+		if len(v) == 0 {
+			return nil, nil
+		}
+		if len(v) != 1 {
+			return nil, fmt.Errorf("expected scalar or single-sample vector, got vector of length %d", len(v))
+		}
+		f := float64(v[0].Value)
+		return &f, nil
+	default:
+		return nil, fmt.Errorf("expected scalar result, got %s", value.Type())
+	}
+}
+
+func substituteQuery(query, targetMatchers, rangeStr string) string {
+	out := strings.ReplaceAll(query, placeholderTargetMatchers, targetMatchers)
+	out = strings.ReplaceAll(out, placeholderRange, rangeStr)
+	return out
+}
+
+func substituteSuccessQuery(query string, current, baseline float64) string {
+	out := strings.ReplaceAll(query, placeholderCurrent, formatFloat(current))
+	out = strings.ReplaceAll(out, placeholderBaseline, formatFloat(baseline))
+	return out
+}
+
+func formatFloat(f float64) string {
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+func formatDuration(d time.Duration) string {
+	// Prefer compact Prometheus-style durations for common values.
+	if d%time.Hour == 0 && d >= time.Hour {
+		return fmt.Sprintf("%dh", int(d/time.Hour))
+	}
+	if d%time.Minute == 0 && d >= time.Minute {
+		return fmt.Sprintf("%dm", int(d/time.Minute))
+	}
+	if d%time.Second == 0 && d >= time.Second {
+		return fmt.Sprintf("%ds", int(d/time.Second))
+	}
+	return d.String()
+}
+
+// buildTargetMatchers returns PromQL label matchers for namespace and pod names.
+func buildTargetMatchers(namespace string, podNames []string) string {
+	quotedNS := strconv.Quote(namespace)
+	if len(podNames) == 0 {
+		return fmt.Sprintf(`namespace=%s,pod=~"^$"`, quotedNS)
+	}
+	parts := make([]string, 0, len(podNames))
+	for _, name := range podNames {
+		parts = append(parts, regexp.QuoteMeta(name))
+	}
+	return fmt.Sprintf(`namespace=%s,pod=~"%s"`, quotedNS, strings.Join(parts, "|"))
+}

--- a/pkg/healthcheck/evaluator.go
+++ b/pkg/healthcheck/evaluator.go
@@ -62,13 +62,13 @@ const (
 
 // EvaluateRequest holds inputs for evaluating a RolloutHealthCheck against a rollout group.
 type EvaluateRequest struct {
-	Config          *Config
-	Namespace       string
-	RolloutGroup    string
-	CandidatePods   []string
-	StablePods      []string
-	BaselineTime    time.Time
-	Now             time.Time
+	Config        *Config
+	Namespace     string
+	RolloutGroup  string
+	CandidatePods []string
+	StablePods    []string
+	BaselineTime  time.Time
+	Now           time.Time
 }
 
 // EvaluateResponse is the aggregate result of all checks.

--- a/pkg/healthcheck/evaluator.go
+++ b/pkg/healthcheck/evaluator.go
@@ -81,9 +81,12 @@ type EvaluateRequest struct {
 
 // CheckEvaluation is the raw result of one check.
 type CheckEvaluation struct {
-	Name    string
-	Result  EvaluationResult
-	Message string
+	Name          string
+	Result        EvaluationResult
+	Message       string
+	CurrentValue  *float64
+	BaselineValue *float64
+	QueryType     string
 }
 
 // EvaluateResponse is the aggregate raw result of all checks.
@@ -121,11 +124,23 @@ func (e *Evaluator) Evaluate(ctx context.Context, req EvaluateRequest) EvaluateR
 	if req.Now.IsZero() {
 		req.Now = time.Now()
 	}
-
+	level.Info(e.logger).Log(
+		"msg", "health check evaluation started",
+		"rollout_group", req.RolloutGroup,
+		"policy", req.Config.Name,
+		"candidate_pods", len(req.CandidatePods.Names),
+		"stable_pods", len(req.StablePods.Names),
+		"checks", len(req.Config.Checks),
+	)
 	querier, err := e.factory(req.Config.PrometheusURL)
 	if err != nil {
-		msg := fmt.Sprintf("failed to create Prometheus client for %q: %v", req.Config.PrometheusURL, err)
-		level.Error(e.logger).Log("msg", msg, "rollout_group", req.RolloutGroup)
+		msg := fmt.Sprintf("failed to create Prometheus client: %v", err)
+		level.Error(e.logger).Log(
+			"msg", "prometheus client unavailable",
+			"rollout_group", req.RolloutGroup,
+			"policy", req.Config.Name,
+			"err", err,
+		)
 		resp.ClientError = msg
 		return resp
 	}
@@ -142,24 +157,28 @@ func (e *Evaluator) Evaluate(ctx context.Context, req EvaluateRequest) EvaluateR
 			continue
 		}
 
-		result, msg := e.evaluateCheck(ctx, querier, check, candidateMatchers, stableMatchers, req)
-		ev := CheckEvaluation{Name: check.Name, Result: result, Message: msg}
+		ev := e.evaluateCheck(ctx, querier, check, candidateMatchers, stableMatchers, req)
 		resp.Checks = append(resp.Checks, ev)
-		resp.Results[check.Name] = result
-		e.observeEvaluation(req.RolloutGroup, check.Name, string(result))
+		resp.Results[check.Name] = ev.Result
+		e.observeEvaluation(req.RolloutGroup, check.Name, string(ev.Result))
 	}
 
 	return resp
 }
 
-func (e *Evaluator) evaluateCheck(ctx context.Context, querier Querier, check Check, candidateMatchers, stableMatchers string, req EvaluateRequest) (EvaluationResult, string) {
+func (e *Evaluator) evaluateCheck(ctx context.Context, querier Querier, check Check, candidateMatchers, stableMatchers string, req EvaluateRequest) CheckEvaluation {
+	ev := CheckEvaluation{Name: check.Name}
 	currentQuery := substituteQuery(check.Query, candidateMatchers, formatDuration(check.CurrentRange))
 	baselineQuery := substituteQuery(check.Query, stableMatchers, formatDuration(check.BaselineRange))
 
 	currentVal, result, errMsg := e.queryScalarOnce(ctx, querier, currentQuery, req.Now, req.RolloutGroup, check, "current")
 	if result != ResultPass {
-		return result, fmt.Sprintf("check %q current query: %s", check.Name, errMsg)
+		ev.Result = result
+		ev.Message = fmt.Sprintf("check %q current query: %s", check.Name, errMsg)
+		ev.QueryType = "current"
+		return ev
 	}
+	ev.CurrentValue = currentVal
 
 	baselineTS := req.BaselineTime
 	if baselineTS.IsZero() {
@@ -167,21 +186,33 @@ func (e *Evaluator) evaluateCheck(ctx context.Context, querier Querier, check Ch
 	}
 	baselineVal, result, errMsg := e.queryScalarOnce(ctx, querier, baselineQuery, baselineTS, req.RolloutGroup, check, "baseline")
 	if result != ResultPass {
-		return result, fmt.Sprintf("check %q baseline query: %s", check.Name, errMsg)
+		ev.Result = result
+		ev.Message = fmt.Sprintf("check %q baseline query: %s", check.Name, errMsg)
+		ev.QueryType = "baseline"
+		return ev
 	}
+	ev.BaselineValue = baselineVal
 
 	successQuery := substituteSuccessQuery(check.SuccessQuery, *currentVal, *baselineVal)
 	successVal, result, errMsg := e.queryScalarOnce(ctx, querier, successQuery, req.Now, req.RolloutGroup, check, "success")
 	if result != ResultPass {
-		return result, fmt.Sprintf("check %q success query: %s", check.Name, errMsg)
+		ev.Result = result
+		ev.Message = fmt.Sprintf("check %q success query: %s", check.Name, errMsg)
+		ev.QueryType = "success"
+		return ev
 	}
 	if *successVal == 1 {
-		return ResultPass, ""
+		ev.Result = ResultPass
+		return ev
 	}
 	if *successVal == 0 {
-		return ResultFail, fmt.Sprintf("check %q failed (current=%v baseline=%v)", check.Name, *currentVal, *baselineVal)
+		ev.Result = ResultFail
+		ev.Message = fmt.Sprintf("check %q failed (current=%v baseline=%v)", check.Name, *currentVal, *baselineVal)
+		return ev
 	}
-	return ResultFail, fmt.Sprintf("check %q success query returned unexpected scalar %v (want 0 or 1)", check.Name, *successVal)
+	ev.Result = ResultFail
+	ev.Message = fmt.Sprintf("check %q success query returned unexpected scalar %v (want 0 or 1)", check.Name, *successVal)
+	return ev
 }
 
 // queryScalarOnce performs a single Prometheus query. Retries are applied by Gate across reconciles
@@ -201,6 +232,13 @@ func (e *Evaluator) queryScalarOnce(ctx context.Context, querier Querier, query 
 		if ctx.Err() != nil {
 			return nil, ResultError, fmt.Sprintf("interrupted: %v", err)
 		}
+		level.Warn(e.logger).Log(
+			"msg", "prometheus query failed",
+			"rollout_group", rolloutGroup,
+			"check", check.Name,
+			"query_type", queryType,
+			"err", err,
+		)
 		return nil, ResultError, err.Error()
 	}
 

--- a/pkg/healthcheck/evaluator.go
+++ b/pkg/healthcheck/evaluator.go
@@ -40,17 +40,18 @@ func NewPrometheusQuerier(prometheusURL string) (Querier, error) {
 // QuerierFactory creates a Querier for a Prometheus URL. Overridable in tests.
 type QuerierFactory func(prometheusURL string) (Querier, error)
 
-// EvaluationResult is the raw outcome of evaluating a single check.
+// EvaluationResult is the raw outcome of evaluating a single check before policy mapping.
 type EvaluationResult string
 
 const (
-	ResultPass   EvaluationResult = "pass"
-	ResultFail   EvaluationResult = "fail"
-	ResultNoData EvaluationResult = "no_data"
-	ResultError  EvaluationResult = "error"
+	ResultPass    EvaluationResult = "pass"
+	ResultFail    EvaluationResult = "fail"
+	ResultNoData  EvaluationResult = "no_data"
+	ResultError   EvaluationResult = "error"
+	ResultSkipped EvaluationResult = "skipped"
 )
 
-// CheckOutcome is the action taken after mapping an EvaluationResult through onFailure/onNoData.
+// CheckOutcome is the action taken after mapping an EvaluationResult through policies.
 type CheckOutcome string
 
 const (
@@ -60,23 +61,37 @@ const (
 	OutcomeSkipped CheckOutcome = "skipped"
 )
 
+// TargetPods describes pods for ${targetMatchers} substitution.
+type TargetPods struct {
+	Names []string
+	// Zones are StatefulSet / zone identifiers (typically the pod "name" label).
+	Zones []string
+}
+
 // EvaluateRequest holds inputs for evaluating a RolloutHealthCheck against a rollout group.
 type EvaluateRequest struct {
 	Config        *Config
 	Namespace     string
 	RolloutGroup  string
-	CandidatePods []string
-	StablePods    []string
+	CandidatePods TargetPods
+	StablePods    TargetPods
 	BaselineTime  time.Time
 	Now           time.Time
 }
 
-// EvaluateResponse is the aggregate result of all checks.
+// CheckEvaluation is the raw result of one check.
+type CheckEvaluation struct {
+	Name    string
+	Result  EvaluationResult
+	Message string
+}
+
+// EvaluateResponse is the aggregate raw result of all checks.
 type EvaluateResponse struct {
-	Outcome      CheckOutcome
-	FailedCheck  string
-	Message      string
-	CheckResults map[string]EvaluationResult
+	Checks  []CheckEvaluation
+	Results map[string]EvaluationResult
+	// ClientError is set when the Prometheus client could not be created.
+	ClientError string
 }
 
 // Evaluator runs PromQL health checks.
@@ -94,11 +109,11 @@ func NewEvaluator(factory QuerierFactory, metrics *Metrics, logger log.Logger) *
 	return &Evaluator{factory: factory, metrics: metrics, logger: logger}
 }
 
-// Evaluate runs all enabled checks in cfg. Returns OutcomePause when any check requires pausing.
+// Evaluate runs all enabled checks and returns raw results. Policy mapping and retries across
+// reconciles are handled by Gate so evaluation does not block the controller on sleep.
 func (e *Evaluator) Evaluate(ctx context.Context, req EvaluateRequest) EvaluateResponse {
 	resp := EvaluateResponse{
-		Outcome:      OutcomePass,
-		CheckResults: map[string]EvaluationResult{},
+		Results: map[string]EvaluationResult{},
 	}
 	if req.Config == nil {
 		return resp
@@ -111,8 +126,7 @@ func (e *Evaluator) Evaluate(ctx context.Context, req EvaluateRequest) EvaluateR
 	if err != nil {
 		msg := fmt.Sprintf("failed to create Prometheus client for %q: %v", req.Config.PrometheusURL, err)
 		level.Error(e.logger).Log("msg", msg, "rollout_group", req.RolloutGroup)
-		resp.Outcome = OutcomePause
-		resp.Message = msg
+		resp.ClientError = msg
 		return resp
 	}
 
@@ -121,95 +135,45 @@ func (e *Evaluator) Evaluate(ctx context.Context, req EvaluateRequest) EvaluateR
 
 	for _, check := range req.Config.Checks {
 		if check.Disabled {
-			resp.CheckResults[check.Name] = ResultPass
-			e.observeEvaluation(req.RolloutGroup, check.Name, "skipped")
+			ev := CheckEvaluation{Name: check.Name, Result: ResultSkipped}
+			resp.Checks = append(resp.Checks, ev)
+			resp.Results[check.Name] = ResultSkipped
+			e.observeEvaluation(req.RolloutGroup, check.Name, string(ResultSkipped))
 			continue
 		}
 
 		result, msg := e.evaluateCheck(ctx, querier, check, candidateMatchers, stableMatchers, req)
-		resp.CheckResults[check.Name] = result
+		ev := CheckEvaluation{Name: check.Name, Result: result, Message: msg}
+		resp.Checks = append(resp.Checks, ev)
+		resp.Results[check.Name] = result
 		e.observeEvaluation(req.RolloutGroup, check.Name, string(result))
-
-		outcome := mapResultToOutcome(result, check)
-		if outcome == OutcomeSkipped || outcome == OutcomePass {
-			continue
-		}
-		if outcome == OutcomeWarn {
-			if resp.Outcome == OutcomePass {
-				resp.Outcome = OutcomeWarn
-				resp.FailedCheck = check.Name
-				resp.Message = msg
-			}
-			continue
-		}
-		// Pause wins over Warn.
-		resp.Outcome = OutcomePause
-		resp.FailedCheck = check.Name
-		resp.Message = msg
-		return resp
 	}
 
 	return resp
-}
-
-func mapResultToOutcome(result EvaluationResult, check Check) CheckOutcome {
-	switch result {
-	case ResultPass:
-		return OutcomePass
-	case ResultFail:
-		return actionToOutcome(check.OnFailure)
-	case ResultNoData:
-		return actionToOutcome(check.OnNoData)
-	case ResultError:
-		// Unreachable / query errors always pause unless the check is fully disabled (handled earlier).
-		return actionToOutcome(check.OnFailure)
-	default:
-		return OutcomePause
-	}
-}
-
-func actionToOutcome(action FailureAction) CheckOutcome {
-	switch action {
-	case ActionWarn:
-		return OutcomeWarn
-	case ActionDisabled:
-		return OutcomeSkipped
-	default:
-		return OutcomePause
-	}
 }
 
 func (e *Evaluator) evaluateCheck(ctx context.Context, querier Querier, check Check, candidateMatchers, stableMatchers string, req EvaluateRequest) (EvaluationResult, string) {
 	currentQuery := substituteQuery(check.Query, candidateMatchers, formatDuration(check.CurrentRange))
 	baselineQuery := substituteQuery(check.Query, stableMatchers, formatDuration(check.BaselineRange))
 
-	currentVal, err := e.queryScalar(ctx, querier, currentQuery, req.Now, req.RolloutGroup, check, "current")
-	if err != nil {
-		return ResultError, fmt.Sprintf("check %q current query failed: %v", check.Name, err)
-	}
-	if currentVal == nil {
-		return ResultNoData, fmt.Sprintf("check %q current query returned no data", check.Name)
+	currentVal, result, errMsg := e.queryScalarOnce(ctx, querier, currentQuery, req.Now, req.RolloutGroup, check, "current")
+	if result != ResultPass {
+		return result, fmt.Sprintf("check %q current query: %s", check.Name, errMsg)
 	}
 
 	baselineTS := req.BaselineTime
 	if baselineTS.IsZero() {
 		baselineTS = req.Now
 	}
-	baselineVal, err := e.queryScalar(ctx, querier, baselineQuery, baselineTS, req.RolloutGroup, check, "baseline")
-	if err != nil {
-		return ResultError, fmt.Sprintf("check %q baseline query failed: %v", check.Name, err)
-	}
-	if baselineVal == nil {
-		return ResultNoData, fmt.Sprintf("check %q baseline query returned no data", check.Name)
+	baselineVal, result, errMsg := e.queryScalarOnce(ctx, querier, baselineQuery, baselineTS, req.RolloutGroup, check, "baseline")
+	if result != ResultPass {
+		return result, fmt.Sprintf("check %q baseline query: %s", check.Name, errMsg)
 	}
 
 	successQuery := substituteSuccessQuery(check.SuccessQuery, *currentVal, *baselineVal)
-	successVal, err := e.queryScalar(ctx, querier, successQuery, req.Now, req.RolloutGroup, check, "success")
-	if err != nil {
-		return ResultError, fmt.Sprintf("check %q success query failed: %v", check.Name, err)
-	}
-	if successVal == nil {
-		return ResultNoData, fmt.Sprintf("check %q success query returned no data", check.Name)
+	successVal, result, errMsg := e.queryScalarOnce(ctx, querier, successQuery, req.Now, req.RolloutGroup, check, "success")
+	if result != ResultPass {
+		return result, fmt.Sprintf("check %q success query: %s", check.Name, errMsg)
 	}
 	if *successVal == 1 {
 		return ResultPass, ""
@@ -220,31 +184,34 @@ func (e *Evaluator) evaluateCheck(ctx context.Context, querier Querier, check Ch
 	return ResultFail, fmt.Sprintf("check %q success query returned unexpected scalar %v (want 0 or 1)", check.Name, *successVal)
 }
 
-func (e *Evaluator) queryScalar(ctx context.Context, querier Querier, query string, ts time.Time, rolloutGroup string, check Check, queryType string) (*float64, error) {
-	var lastErr error
-	attempts := check.QueryRetries + 1
-	for attempt := 0; attempt < attempts; attempt++ {
-		qctx, cancel := context.WithTimeout(ctx, check.QueryTimeout)
-		start := time.Now()
-		value, warnings, err := querier.Query(qctx, query, ts)
-		cancel()
-		if e.metrics != nil {
-			e.metrics.QueryDuration.WithLabelValues(rolloutGroup, check.Name, queryType).Observe(time.Since(start).Seconds())
-		}
-		if len(warnings) > 0 {
-			level.Warn(e.logger).Log("msg", "prometheus query warnings", "check", check.Name, "query_type", queryType, "warnings", strings.Join(warnings, "; "))
-		}
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		scalar, err := valueToScalar(value)
-		if err != nil {
-			return nil, err
-		}
-		return scalar, nil
+// queryScalarOnce performs a single Prometheus query. Retries are applied by Gate across reconciles
+// using errorPolicy / noDataPolicy so the controller reconcile loop is not blocked on sleep.
+func (e *Evaluator) queryScalarOnce(ctx context.Context, querier Querier, query string, ts time.Time, rolloutGroup string, check Check, queryType string) (*float64, EvaluationResult, string) {
+	qctx, cancel := context.WithTimeout(ctx, check.QueryTimeout)
+	start := time.Now()
+	value, warnings, err := querier.Query(qctx, query, ts)
+	cancel()
+	if e.metrics != nil {
+		e.metrics.QueryDuration.WithLabelValues(rolloutGroup, check.Name, queryType).Observe(time.Since(start).Seconds())
 	}
-	return nil, lastErr
+	if len(warnings) > 0 {
+		level.Warn(e.logger).Log("msg", "prometheus query warnings", "check", check.Name, "query_type", queryType, "warnings", strings.Join(warnings, "; "))
+	}
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ResultError, fmt.Sprintf("interrupted: %v", err)
+		}
+		return nil, ResultError, err.Error()
+	}
+
+	scalar, err := valueToScalar(value)
+	if err != nil {
+		return nil, ResultError, err.Error()
+	}
+	if scalar == nil {
+		return nil, ResultNoData, "no data"
+	}
+	return scalar, ResultPass, ""
 }
 
 func (e *Evaluator) observeEvaluation(rolloutGroup, check, result string) {
@@ -309,15 +276,52 @@ func formatDuration(d time.Duration) string {
 	return d.String()
 }
 
-// buildTargetMatchers returns PromQL label matchers for namespace and pod names.
-func buildTargetMatchers(namespace string, podNames []string) string {
+// buildTargetMatchers returns PromQL label matchers for namespace, zone (name), and pods.
+func buildTargetMatchers(namespace string, targets TargetPods) string {
 	quotedNS := strconv.Quote(namespace)
-	if len(podNames) == 0 {
-		return fmt.Sprintf(`namespace=%s,pod=~"^$"`, quotedNS)
+	parts := []string{fmt.Sprintf("namespace=%s", quotedNS)}
+	if len(targets.Zones) > 0 {
+		parts = append(parts, fmt.Sprintf(`name=~"%s"`, joinRegex(targets.Zones)))
 	}
-	parts := make([]string, 0, len(podNames))
-	for _, name := range podNames {
-		parts = append(parts, regexp.QuoteMeta(name))
+	if len(targets.Names) == 0 {
+		parts = append(parts, `pod=~"^$"`)
+	} else {
+		parts = append(parts, fmt.Sprintf(`pod=~"%s"`, joinRegex(targets.Names)))
 	}
-	return fmt.Sprintf(`namespace=%s,pod=~"%s"`, quotedNS, strings.Join(parts, "|"))
+	return strings.Join(parts, ",")
+}
+
+func joinRegex(values []string) string {
+	parts := make([]string, 0, len(values))
+	for _, v := range values {
+		parts = append(parts, regexp.QuoteMeta(v))
+	}
+	return strings.Join(parts, "|")
+}
+
+func uniqueNonEmpty(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+func actionToOutcome(action FailureAction) CheckOutcome {
+	switch action {
+	case ActionWarn:
+		return OutcomeWarn
+	case ActionDisabled:
+		return OutcomeSkipped
+	default:
+		return OutcomePause
+	}
 }

--- a/pkg/healthcheck/evaluator.go
+++ b/pkg/healthcheck/evaluator.go
@@ -276,13 +276,12 @@ func formatDuration(d time.Duration) string {
 	return d.String()
 }
 
-// buildTargetMatchers returns PromQL label matchers for namespace, zone (name), and pods.
+// buildTargetMatchers returns matchers common to application and kube-state-metrics
+// series. Pod names already identify the candidate/stable workloads; adding the
+// application-specific "name" label would make kube-state-metrics checks return no data.
 func buildTargetMatchers(namespace string, targets TargetPods) string {
 	quotedNS := strconv.Quote(namespace)
 	parts := []string{fmt.Sprintf("namespace=%s", quotedNS)}
-	if len(targets.Zones) > 0 {
-		parts = append(parts, fmt.Sprintf(`name=~"%s"`, joinRegex(targets.Zones)))
-	}
 	if len(targets.Names) == 0 {
 		parts = append(parts, `pod=~"^$"`)
 	} else {

--- a/pkg/healthcheck/evaluator_test.go
+++ b/pkg/healthcheck/evaluator_test.go
@@ -1,0 +1,171 @@
+package healthcheck
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type fakeQuerier struct {
+	mu       sync.Mutex
+	calls    []string
+	sequence []func() (model.Value, error)
+	seqIdx   int
+}
+
+func (f *fakeQuerier) Query(_ context.Context, query string, _ time.Time) (model.Value, v1.Warnings, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, query)
+	if f.seqIdx >= len(f.sequence) {
+		return &model.Scalar{Value: 0}, nil, nil
+	}
+	fn := f.sequence[f.seqIdx]
+	f.seqIdx++
+	val, err := fn()
+	return val, nil, err
+}
+
+func scalar(v float64) model.Value {
+	return &model.Scalar{Value: model.SampleValue(v), Timestamp: model.Now()}
+}
+
+func TestEvaluator_PassFailNoDataError(t *testing.T) {
+	baseCfg := &Config{
+		Name:          "hc",
+		PrometheusURL: "http://prometheus",
+		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
+		Checks: []Check{{
+			Name:          "errors",
+			CurrentRange:  time.Minute,
+			BaselineRange: 2 * time.Minute,
+			QueryTimeout:  time.Second,
+			QueryRetries:  0,
+			OnFailure:     ActionPause,
+			OnNoData:      ActionPause,
+			Query:         `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+			SuccessQuery:  `(${current} < bool 1) or (${current} < bool (2 * ${baseline}))`,
+		}},
+	}
+
+	t.Run("pass", func(t *testing.T) {
+		q := &fakeQuerier{sequence: []func() (model.Value, error){
+			func() (model.Value, error) { return scalar(0.1), nil },
+			func() (model.Value, error) { return scalar(0.2), nil },
+			func() (model.Value, error) { return scalar(1), nil },
+		}}
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		resp := e.Evaluate(context.Background(), EvaluateRequest{
+			Config:        baseCfg,
+			Namespace:     "ns",
+			RolloutGroup:  "ingester",
+			CandidatePods: []string{"ingester-zone-a-0"},
+			StablePods:    []string{"ingester-zone-b-0"},
+			Now:           time.Now(),
+			BaselineTime:  time.Now().Add(-time.Hour),
+		})
+		require.Equal(t, OutcomePass, resp.Outcome)
+		require.Equal(t, ResultPass, resp.CheckResults["errors"])
+		require.Len(t, q.calls, 3)
+		require.True(t, strings.Contains(q.calls[0], `pod=~"ingester-zone-a-0"`))
+		require.True(t, strings.Contains(q.calls[0], `[1m]`))
+		require.True(t, strings.Contains(q.calls[1], `pod=~"ingester-zone-b-0"`))
+		require.True(t, strings.Contains(q.calls[1], `[2m]`))
+		require.True(t, strings.Contains(q.calls[2], "0.1"))
+		require.True(t, strings.Contains(q.calls[2], "0.2"))
+	})
+
+	t.Run("fail pauses", func(t *testing.T) {
+		q := &fakeQuerier{sequence: []func() (model.Value, error){
+			func() (model.Value, error) { return scalar(5), nil },
+			func() (model.Value, error) { return scalar(0.1), nil },
+			func() (model.Value, error) { return scalar(0), nil },
+		}}
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: baseCfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
+		require.Equal(t, OutcomePause, resp.Outcome)
+		require.Equal(t, ResultFail, resp.CheckResults["errors"])
+	})
+
+	t.Run("no data pauses", func(t *testing.T) {
+		q := &fakeQuerier{sequence: []func() (model.Value, error){
+			func() (model.Value, error) { return model.Vector{}, nil },
+		}}
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: baseCfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
+		require.Equal(t, OutcomePause, resp.Outcome)
+		require.Equal(t, ResultNoData, resp.CheckResults["errors"])
+	})
+
+	t.Run("error pauses", func(t *testing.T) {
+		q := &fakeQuerier{sequence: []func() (model.Value, error){
+			func() (model.Value, error) { return nil, errors.New("boom") },
+		}}
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: baseCfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
+		require.Equal(t, OutcomePause, resp.Outcome)
+		require.Equal(t, ResultError, resp.CheckResults["errors"])
+	})
+
+	t.Run("warn on failure", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Checks = append([]Check(nil), baseCfg.Checks...)
+		cfg.Checks[0].OnFailure = ActionWarn
+		q := &fakeQuerier{sequence: []func() (model.Value, error){
+			func() (model.Value, error) { return scalar(5), nil },
+			func() (model.Value, error) { return scalar(0.1), nil },
+			func() (model.Value, error) { return scalar(0), nil },
+		}}
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: &cfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
+		require.Equal(t, OutcomeWarn, resp.Outcome)
+	})
+
+	t.Run("retries then succeeds", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Checks = append([]Check(nil), baseCfg.Checks...)
+		cfg.Checks[0].QueryRetries = 2
+		attempts := 0
+		q := &fakeQuerier{sequence: []func() (model.Value, error){
+			func() (model.Value, error) {
+				attempts++
+				return nil, errors.New("transient")
+			},
+			func() (model.Value, error) {
+				attempts++
+				return scalar(0.1), nil
+			},
+			func() (model.Value, error) { return scalar(0.2), nil },
+			func() (model.Value, error) { return scalar(1), nil },
+		}}
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: &cfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
+		require.Equal(t, OutcomePass, resp.Outcome)
+		require.Equal(t, 2, attempts)
+	})
+
+	t.Run("disabled check skipped", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Checks = append([]Check(nil), baseCfg.Checks...)
+		cfg.Checks[0].Disabled = true
+		q := &fakeQuerier{}
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: &cfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
+		require.Equal(t, OutcomePass, resp.Outcome)
+		require.Empty(t, q.calls)
+	})
+}
+
+func TestBuildTargetMatchers(t *testing.T) {
+	require.Equal(t, `namespace="ns",pod=~"^$"`, buildTargetMatchers("ns", nil))
+	require.Equal(t, `namespace="ns",pod=~"a-0|b-1"`, buildTargetMatchers("ns", []string{"a-0", "b-1"}))
+}

--- a/pkg/healthcheck/evaluator_test.go
+++ b/pkg/healthcheck/evaluator_test.go
@@ -1,6 +1,7 @@
 package healthcheck
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -125,9 +126,14 @@ func TestEvaluator_PassFailNoDataError(t *testing.T) {
 		q := &fakeQuerier{sequence: []func() (model.Value, error){
 			func() (model.Value, error) { return nil, errors.New("boom") },
 		}}
-		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		var logs bytes.Buffer
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewLogfmtLogger(&logs))
 		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: baseCfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
 		require.Equal(t, ResultError, resp.Results["errors"])
+		require.Contains(t, logs.String(), "msg=\"prometheus query failed\"")
+		require.Contains(t, logs.String(), "query_type=current")
+		require.Contains(t, logs.String(), "err=boom")
+		require.NotContains(t, logs.String(), baseCfg.Checks[0].Query)
 	})
 
 	t.Run("disabled check skipped", func(t *testing.T) {

--- a/pkg/healthcheck/evaluator_test.go
+++ b/pkg/healthcheck/evaluator_test.go
@@ -39,22 +39,39 @@ func scalar(v float64) model.Value {
 	return &model.Scalar{Value: model.SampleValue(v), Timestamp: model.Now()}
 }
 
+func testCheck() Check {
+	return Check{
+		Name:          "errors",
+		CurrentRange:  time.Minute,
+		BaselineRange: 2 * time.Minute,
+		QueryTimeout:  time.Second,
+		ErrorPolicy: RetryPolicy{
+			RetryInterval:   0,
+			MaxAttempts:     1,
+			ExhaustedAction: ActionPause,
+		},
+		NoDataPolicy: RetryPolicy{
+			RetryInterval:   0,
+			MaxAttempts:     1,
+			ExhaustedAction: ActionPause,
+		},
+		FailurePolicy: FailurePolicy{
+			ReevaluationInterval: time.Millisecond,
+			ConsecutiveFailures:  1,
+			ConsecutiveSuccesses: 1,
+			ExceededAction:       ActionPause,
+		},
+		Query:        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+		SuccessQuery: `(${current} < bool 1) or (${current} < bool (2 * ${baseline}))`,
+	}
+}
+
 func TestEvaluator_PassFailNoDataError(t *testing.T) {
 	baseCfg := &Config{
 		Name:          "hc",
 		PrometheusURL: "http://prometheus",
 		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
-		Checks: []Check{{
-			Name:          "errors",
-			CurrentRange:  time.Minute,
-			BaselineRange: 2 * time.Minute,
-			QueryTimeout:  time.Second,
-			QueryRetries:  0,
-			OnFailure:     ActionPause,
-			OnNoData:      ActionPause,
-			Query:         `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
-			SuccessQuery:  `(${current} < bool 1) or (${current} < bool (2 * ${baseline}))`,
-		}},
+		Checks:        []Check{testCheck()},
 	}
 
 	t.Run("pass", func(t *testing.T) {
@@ -68,15 +85,15 @@ func TestEvaluator_PassFailNoDataError(t *testing.T) {
 			Config:        baseCfg,
 			Namespace:     "ns",
 			RolloutGroup:  "ingester",
-			CandidatePods: []string{"ingester-zone-a-0"},
-			StablePods:    []string{"ingester-zone-b-0"},
+			CandidatePods: TargetPods{Names: []string{"ingester-zone-a-0"}, Zones: []string{"ingester-zone-a"}},
+			StablePods:    TargetPods{Names: []string{"ingester-zone-b-0"}, Zones: []string{"ingester-zone-b"}},
 			Now:           time.Now(),
 			BaselineTime:  time.Now().Add(-time.Hour),
 		})
-		require.Equal(t, OutcomePass, resp.Outcome)
-		require.Equal(t, ResultPass, resp.CheckResults["errors"])
+		require.Equal(t, ResultPass, resp.Results["errors"])
 		require.Len(t, q.calls, 3)
 		require.True(t, strings.Contains(q.calls[0], `pod=~"ingester-zone-a-0"`))
+		require.True(t, strings.Contains(q.calls[0], `name=~"ingester-zone-a"`))
 		require.True(t, strings.Contains(q.calls[0], `[1m]`))
 		require.True(t, strings.Contains(q.calls[1], `pod=~"ingester-zone-b-0"`))
 		require.True(t, strings.Contains(q.calls[1], `[2m]`))
@@ -84,7 +101,7 @@ func TestEvaluator_PassFailNoDataError(t *testing.T) {
 		require.True(t, strings.Contains(q.calls[2], "0.2"))
 	})
 
-	t.Run("fail pauses", func(t *testing.T) {
+	t.Run("fail", func(t *testing.T) {
 		q := &fakeQuerier{sequence: []func() (model.Value, error){
 			func() (model.Value, error) { return scalar(5), nil },
 			func() (model.Value, error) { return scalar(0.1), nil },
@@ -92,65 +109,25 @@ func TestEvaluator_PassFailNoDataError(t *testing.T) {
 		}}
 		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
 		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: baseCfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
-		require.Equal(t, OutcomePause, resp.Outcome)
-		require.Equal(t, ResultFail, resp.CheckResults["errors"])
+		require.Equal(t, ResultFail, resp.Results["errors"])
 	})
 
-	t.Run("no data pauses", func(t *testing.T) {
+	t.Run("no data", func(t *testing.T) {
 		q := &fakeQuerier{sequence: []func() (model.Value, error){
 			func() (model.Value, error) { return model.Vector{}, nil },
 		}}
 		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
 		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: baseCfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
-		require.Equal(t, OutcomePause, resp.Outcome)
-		require.Equal(t, ResultNoData, resp.CheckResults["errors"])
+		require.Equal(t, ResultNoData, resp.Results["errors"])
 	})
 
-	t.Run("error pauses", func(t *testing.T) {
+	t.Run("error", func(t *testing.T) {
 		q := &fakeQuerier{sequence: []func() (model.Value, error){
 			func() (model.Value, error) { return nil, errors.New("boom") },
 		}}
 		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
 		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: baseCfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
-		require.Equal(t, OutcomePause, resp.Outcome)
-		require.Equal(t, ResultError, resp.CheckResults["errors"])
-	})
-
-	t.Run("warn on failure", func(t *testing.T) {
-		cfg := *baseCfg
-		cfg.Checks = append([]Check(nil), baseCfg.Checks...)
-		cfg.Checks[0].OnFailure = ActionWarn
-		q := &fakeQuerier{sequence: []func() (model.Value, error){
-			func() (model.Value, error) { return scalar(5), nil },
-			func() (model.Value, error) { return scalar(0.1), nil },
-			func() (model.Value, error) { return scalar(0), nil },
-		}}
-		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
-		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: &cfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
-		require.Equal(t, OutcomeWarn, resp.Outcome)
-	})
-
-	t.Run("retries then succeeds", func(t *testing.T) {
-		cfg := *baseCfg
-		cfg.Checks = append([]Check(nil), baseCfg.Checks...)
-		cfg.Checks[0].QueryRetries = 2
-		attempts := 0
-		q := &fakeQuerier{sequence: []func() (model.Value, error){
-			func() (model.Value, error) {
-				attempts++
-				return nil, errors.New("transient")
-			},
-			func() (model.Value, error) {
-				attempts++
-				return scalar(0.1), nil
-			},
-			func() (model.Value, error) { return scalar(0.2), nil },
-			func() (model.Value, error) { return scalar(1), nil },
-		}}
-		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
-		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: &cfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
-		require.Equal(t, OutcomePass, resp.Outcome)
-		require.Equal(t, 2, attempts)
+		require.Equal(t, ResultError, resp.Results["errors"])
 	})
 
 	t.Run("disabled check skipped", func(t *testing.T) {
@@ -160,12 +137,15 @@ func TestEvaluator_PassFailNoDataError(t *testing.T) {
 		q := &fakeQuerier{}
 		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
 		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: &cfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
-		require.Equal(t, OutcomePass, resp.Outcome)
+		require.Equal(t, ResultSkipped, resp.Results["errors"])
 		require.Empty(t, q.calls)
 	})
 }
 
 func TestBuildTargetMatchers(t *testing.T) {
-	require.Equal(t, `namespace="ns",pod=~"^$"`, buildTargetMatchers("ns", nil))
-	require.Equal(t, `namespace="ns",pod=~"a-0|b-1"`, buildTargetMatchers("ns", []string{"a-0", "b-1"}))
+	require.Equal(t, `namespace="ns",pod=~"^$"`, buildTargetMatchers("ns", TargetPods{}))
+	require.Equal(t, `namespace="ns",name=~"a|b",pod=~"a-0|b-1"`, buildTargetMatchers("ns", TargetPods{
+		Names: []string{"a-0", "b-1"},
+		Zones: []string{"a", "b"},
+	}))
 }

--- a/pkg/healthcheck/evaluator_test.go
+++ b/pkg/healthcheck/evaluator_test.go
@@ -93,7 +93,7 @@ func TestEvaluator_PassFailNoDataError(t *testing.T) {
 		require.Equal(t, ResultPass, resp.Results["errors"])
 		require.Len(t, q.calls, 3)
 		require.True(t, strings.Contains(q.calls[0], `pod=~"ingester-zone-a-0"`))
-		require.True(t, strings.Contains(q.calls[0], `name=~"ingester-zone-a"`))
+		require.NotContains(t, q.calls[0], `name=~`)
 		require.True(t, strings.Contains(q.calls[0], `[1m]`))
 		require.True(t, strings.Contains(q.calls[1], `pod=~"ingester-zone-b-0"`))
 		require.True(t, strings.Contains(q.calls[1], `[2m]`))
@@ -144,7 +144,7 @@ func TestEvaluator_PassFailNoDataError(t *testing.T) {
 
 func TestBuildTargetMatchers(t *testing.T) {
 	require.Equal(t, `namespace="ns",pod=~"^$"`, buildTargetMatchers("ns", TargetPods{}))
-	require.Equal(t, `namespace="ns",name=~"a|b",pod=~"a-0|b-1"`, buildTargetMatchers("ns", TargetPods{
+	require.Equal(t, `namespace="ns",pod=~"a-0|b-1"`, buildTargetMatchers("ns", TargetPods{
 		Names: []string{"a-0", "b-1"},
 		Zones: []string{"a", "b"},
 	}))

--- a/pkg/healthcheck/gate.go
+++ b/pkg/healthcheck/gate.go
@@ -1,0 +1,203 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+const (
+	eventBlocked       = "RolloutBlockedByHealthCheck"
+	eventMisconfigured = "RolloutHealthCheckMisconfigured"
+	eventWarn          = "RolloutHealthCheckWarn"
+)
+
+// ConfigProvider looks up a RolloutHealthCheck by name.
+type ConfigProvider interface {
+	Get(name string) *Config
+}
+
+// Gate decides whether progression to the next zone should pause for health checks.
+type Gate struct {
+	provider  ConfigProvider
+	evaluator *Evaluator
+	metrics   *Metrics
+	recorder  record.EventRecorder
+	logger    log.Logger
+
+	// Tracks rollout groups currently reported as misconfigured so the counter and
+	// events are not re-emitted on every reconcile while the binding stays broken.
+	misconfiguredGroups sync.Map
+}
+
+// NewGate creates a health-check gate.
+func NewGate(provider ConfigProvider, evaluator *Evaluator, metrics *Metrics, recorder record.EventRecorder, logger log.Logger) *Gate {
+	return &Gate{
+		provider:  provider,
+		evaluator: evaluator,
+		metrics:   metrics,
+		recorder:  recorder,
+		logger:    logger,
+	}
+}
+
+// Decision is the gate result for a single between-zone transition.
+type Decision struct {
+	// ShouldPause is true when the next zone must not start rolling yet.
+	ShouldPause bool
+	// Reason is a human-readable explanation when ShouldPause or a warning/misconfiguration occurred.
+	Reason string
+}
+
+// Request is the input for a between-zone gate evaluation.
+type Request struct {
+	RolloutGroup  string
+	Namespace     string
+	Sets          []*appsv1.StatefulSet
+	NextSTS       *appsv1.StatefulSet
+	CandidatePods []*corev1.Pod
+	StablePods    []*corev1.Pod
+	BaselineTime  time.Time
+}
+
+// Evaluate resolves the RolloutHealthCheck annotation on NextSTS and evaluates checks.
+// Missing / mismatched bindings proceed (ShouldPause=false) but emit misconfiguration signals.
+func (g *Gate) Evaluate(ctx context.Context, req Request) Decision {
+	checkName := strings.TrimSpace(req.NextSTS.Annotations[config.RolloutHealthCheckAnnotationKey])
+	if checkName == "" {
+		g.setBlocked(req.RolloutGroup, false)
+		return Decision{}
+	}
+
+	cfg := g.provider.Get(checkName)
+	if cfg == nil {
+		msg := fmt.Sprintf("RolloutHealthCheck %q referenced by annotation %s was not found", checkName, config.RolloutHealthCheckAnnotationKey)
+		g.reportMisconfigured(req, msg)
+		return Decision{Reason: msg}
+	}
+
+	if !cfg.MatchesLabels(labels.Set(req.NextSTS.Labels)) {
+		msg := fmt.Sprintf("RolloutHealthCheck %q selector does not match StatefulSet %s", checkName, req.NextSTS.Name)
+		g.reportMisconfigured(req, msg)
+		return Decision{Reason: msg}
+	}
+
+	resp := g.evaluator.Evaluate(ctx, EvaluateRequest{
+		Config:        cfg,
+		Namespace:     req.Namespace,
+		RolloutGroup:  req.RolloutGroup,
+		CandidatePods: podNames(req.CandidatePods),
+		StablePods:    podNames(req.StablePods),
+		BaselineTime:  req.BaselineTime,
+		Now:           time.Now(),
+	})
+
+	switch resp.Outcome {
+	case OutcomePause:
+		msg := resp.Message
+		if msg == "" {
+			msg = fmt.Sprintf("health check %q paused rollout of group %s", resp.FailedCheck, req.RolloutGroup)
+		}
+		level.Warn(g.logger).Log("msg", "rollout blocked by health check", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "check", resp.FailedCheck, "detail", msg)
+		g.event(req.NextSTS, corev1.EventTypeWarning, eventBlocked, msg)
+		g.clearMisconfigured(req.RolloutGroup)
+		g.setBlocked(req.RolloutGroup, true)
+		return Decision{ShouldPause: true, Reason: msg}
+	case OutcomeWarn:
+		msg := resp.Message
+		if msg == "" {
+			msg = fmt.Sprintf("health check %q warned for group %s", resp.FailedCheck, req.RolloutGroup)
+		}
+		level.Warn(g.logger).Log("msg", "health check warning", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "check", resp.FailedCheck, "detail", msg)
+		g.event(req.NextSTS, corev1.EventTypeWarning, eventWarn, msg)
+		g.clearMisconfigured(req.RolloutGroup)
+		g.setBlocked(req.RolloutGroup, false)
+		return Decision{Reason: msg}
+	default:
+		g.clearMisconfigured(req.RolloutGroup)
+		g.setBlocked(req.RolloutGroup, false)
+		return Decision{}
+	}
+}
+
+func (g *Gate) reportMisconfigured(req Request, msg string) {
+	level.Error(g.logger).Log("msg", "rollout health check misconfigured", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "detail", msg)
+	_, already := g.misconfiguredGroups.LoadOrStore(req.RolloutGroup, struct{}{})
+	if !already {
+		g.event(req.NextSTS, corev1.EventTypeWarning, eventMisconfigured, msg)
+		if g.metrics != nil {
+			g.metrics.MisconfiguredTotal.WithLabelValues(req.RolloutGroup).Inc()
+		}
+	}
+	if g.metrics != nil {
+		g.metrics.Misconfigured.WithLabelValues(req.RolloutGroup).Set(1)
+	}
+	g.setBlocked(req.RolloutGroup, false)
+}
+
+func (g *Gate) clearMisconfigured(rolloutGroup string) {
+	if _, loaded := g.misconfiguredGroups.LoadAndDelete(rolloutGroup); loaded || g.metrics != nil {
+		if g.metrics != nil {
+			g.metrics.Misconfigured.WithLabelValues(rolloutGroup).Set(0)
+		}
+	}
+}
+
+func (g *Gate) setBlocked(rolloutGroup string, blocked bool) {
+	if g.metrics == nil {
+		return
+	}
+	val := 0.0
+	if blocked {
+		val = 1
+	}
+	g.metrics.Blocked.WithLabelValues(rolloutGroup).Set(val)
+}
+
+func (g *Gate) event(sts *appsv1.StatefulSet, eventType, reason, message string) {
+	if g.recorder == nil || sts == nil {
+		return
+	}
+	g.recorder.Event(sts, eventType, reason, message)
+}
+
+func podNames(pods []*corev1.Pod) []string {
+	names := make([]string, 0, len(pods))
+	for _, p := range pods {
+		names = append(names, p.Name)
+	}
+	return names
+}
+
+// ParseStartedAtAnnotation parses "<updateRevision>=<RFC3339>" from the annotation value.
+// Returns zero time if missing or mismatched revision.
+func ParseStartedAtAnnotation(value, updateRevision string) time.Time {
+	if value == "" || updateRevision == "" {
+		return time.Time{}
+	}
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 || parts[0] != updateRevision {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, parts[1])
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// FormatStartedAtAnnotation builds the annotation value for a revision start time.
+func FormatStartedAtAnnotation(updateRevision string, t time.Time) string {
+	return updateRevision + "=" + t.UTC().Format(time.RFC3339)
+}

--- a/pkg/healthcheck/gate.go
+++ b/pkg/healthcheck/gate.go
@@ -74,6 +74,8 @@ type Decision struct {
 	ShouldPause bool
 	// Reason is a human-readable explanation when ShouldPause or a warning/misconfiguration occurred.
 	Reason string
+	// RequeueAfter is the delay until a paused decision should be evaluated again.
+	RequeueAfter time.Duration
 }
 
 // Request is the input for a between-zone gate evaluation.
@@ -133,28 +135,63 @@ func (g *Gate) Evaluate(ctx context.Context, req Request) Decision {
 
 	if resp.ClientError != "" {
 		// Client construction failure is not per-check; pause safely.
-		return g.finalize(req, Decision{ShouldPause: true, Reason: resp.ClientError}, true)
+		return g.finalize(req, Decision{
+			ShouldPause:  true,
+			Reason:       resp.ClientError,
+			RequeueAfter: minimumErrorRetryInterval(cfg),
+		}, true)
 	}
 
-	decision := g.applyPolicies(req.RolloutGroup, cfg, resp, now)
+	policyNow := now
+	if req.Now.IsZero() {
+		policyNow = time.Now()
+	}
+	decision := g.applyPolicies(req.RolloutGroup, cfg, resp, policyNow)
 	return g.finalize(req, decision, true)
 }
 
 func (g *Gate) finalize(req Request, decision Decision, emitEvent bool) Decision {
+	if !emitEvent {
+		g.setBlocked(req.RolloutGroup, decision.ShouldPause)
+		return decision
+	}
+
+	action := "proceed"
 	if decision.ShouldPause {
-		level.Warn(g.logger).Log("msg", "rollout blocked by health check", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "detail", decision.Reason)
-		if emitEvent {
-			g.event(req.NextSTS, corev1.EventTypeWarning, eventBlocked, decision.Reason)
-		}
+		action = "pause"
+		level.Warn(g.logger).Log(
+			"msg", "health check evaluation completed",
+			"rollout_group", req.RolloutGroup,
+			"policy", strings.TrimSpace(req.NextSTS.Annotations[config.RolloutHealthCheckAnnotationKey]),
+			"statefulset", req.NextSTS.Name,
+			"action", action,
+			"requeue_after", decision.RequeueAfter,
+			"detail", decision.Reason,
+		)
+		g.event(req.NextSTS, corev1.EventTypeWarning, eventBlocked, decision.Reason)
 		g.clearMisconfigured(req.RolloutGroup)
 		g.setBlocked(req.RolloutGroup, true)
 		return decision
 	}
 	if decision.Reason != "" {
-		level.Warn(g.logger).Log("msg", "health check warning", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "detail", decision.Reason)
-		if emitEvent {
-			g.event(req.NextSTS, corev1.EventTypeWarning, eventWarn, decision.Reason)
-		}
+		action = "warn"
+		level.Warn(g.logger).Log(
+			"msg", "health check evaluation completed",
+			"rollout_group", req.RolloutGroup,
+			"policy", strings.TrimSpace(req.NextSTS.Annotations[config.RolloutHealthCheckAnnotationKey]),
+			"statefulset", req.NextSTS.Name,
+			"action", action,
+			"detail", decision.Reason,
+		)
+		g.event(req.NextSTS, corev1.EventTypeWarning, eventWarn, decision.Reason)
+	} else {
+		level.Info(g.logger).Log(
+			"msg", "health check evaluation completed",
+			"rollout_group", req.RolloutGroup,
+			"policy", strings.TrimSpace(req.NextSTS.Annotations[config.RolloutHealthCheckAnnotationKey]),
+			"statefulset", req.NextSTS.Name,
+			"action", action,
+		)
 	}
 	g.clearMisconfigured(req.RolloutGroup)
 	g.setBlocked(req.RolloutGroup, false)
@@ -179,6 +216,7 @@ func (g *Gate) applyPolicies(rolloutGroup string, cfg *Config, resp EvaluateResp
 			continue
 		}
 		outcome, msg := g.applyCheckPolicy(rolloutGroup, cfg.Name, check, ev, now)
+		g.logPolicyOutcome(rolloutGroup, cfg.Name, check, ev, outcome)
 		switch outcome {
 		case OutcomePause:
 			shouldPause = true
@@ -193,7 +231,11 @@ func (g *Gate) applyPolicies(rolloutGroup string, cfg *Config, resp EvaluateResp
 	}
 
 	if shouldPause {
-		return Decision{ShouldPause: true, Reason: pauseReason}
+		return Decision{
+			ShouldPause:  true,
+			Reason:       pauseReason,
+			RequeueAfter: g.nextEvaluationDelay(rolloutGroup, cfg, now),
+		}
 	}
 	if warnReason != "" {
 		return Decision{Reason: warnReason}
@@ -340,12 +382,100 @@ func (g *Gate) cachedDecision(rolloutGroup string, cfg *Config, now time.Time) (
 		return Decision{}, false
 	}
 	if shouldPause {
-		return Decision{ShouldPause: true, Reason: pauseReason}, true
+		return Decision{
+			ShouldPause:  true,
+			Reason:       pauseReason,
+			RequeueAfter: g.nextEvaluationDelayLocked(rolloutGroup, cfg, now),
+		}, true
 	}
 	if warnReason != "" {
 		return Decision{Reason: warnReason}, true
 	}
 	return Decision{}, true
+}
+
+func (g *Gate) nextEvaluationDelay(rolloutGroup string, cfg *Config, now time.Time) time.Duration {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.nextEvaluationDelayLocked(rolloutGroup, cfg, now)
+}
+
+func (g *Gate) nextEvaluationDelayLocked(rolloutGroup string, cfg *Config, now time.Time) time.Duration {
+	var earliest time.Time
+	for _, check := range cfg.Checks {
+		if check.Disabled {
+			continue
+		}
+		prog := g.progress[progressKey(rolloutGroup, cfg.Name, check.Name)]
+		if prog == nil || prog.lastEvalAt.IsZero() {
+			continue
+		}
+		due := prog.lastEvalAt.Add(holdInterval(check, prog.lastResult))
+		if earliest.IsZero() || due.Before(earliest) {
+			earliest = due
+		}
+	}
+	if earliest.IsZero() || !earliest.After(now) {
+		return 0
+	}
+	return earliest.Sub(now)
+}
+
+func minimumErrorRetryInterval(cfg *Config) time.Duration {
+	var interval time.Duration
+	for _, check := range cfg.Checks {
+		if check.Disabled {
+			continue
+		}
+		if interval == 0 || check.ErrorPolicy.RetryInterval < interval {
+			interval = check.ErrorPolicy.RetryInterval
+		}
+	}
+	return interval
+}
+
+func (g *Gate) logPolicyOutcome(rolloutGroup, policy string, check Check, ev CheckEvaluation, outcome CheckOutcome) {
+	key := progressKey(rolloutGroup, policy, check.Name)
+	g.mu.Lock()
+	prog := g.progress[key]
+	var snapshot checkProgress
+	if prog != nil {
+		snapshot = *prog
+	}
+	g.mu.Unlock()
+
+	logFn := level.Info
+	if outcome == OutcomeSkipped {
+		logFn = level.Debug
+	}
+	keyvals := []interface{}{
+		"msg", "health check policy applied",
+		"rollout_group", rolloutGroup,
+		"policy", policy,
+		"check", check.Name,
+		"result", ev.Result,
+		"action", outcome,
+		"consecutive_successes", snapshot.consecutiveSuccesses,
+		"required_successes", check.FailurePolicy.ConsecutiveSuccesses,
+		"consecutive_failures", snapshot.consecutiveFailures,
+		"allowed_failures", check.FailurePolicy.ConsecutiveFailures,
+	}
+	if ev.CurrentValue != nil {
+		keyvals = append(keyvals, "current_value", *ev.CurrentValue)
+	}
+	if ev.BaselineValue != nil {
+		keyvals = append(keyvals, "baseline_value", *ev.BaselineValue)
+	}
+	if ev.QueryType != "" {
+		keyvals = append(keyvals, "query_type", ev.QueryType)
+	}
+	switch ev.Result {
+	case ResultError:
+		keyvals = append(keyvals, "attempt", snapshot.errorAttempts, "max_attempts", check.ErrorPolicy.MaxAttempts)
+	case ResultNoData:
+		keyvals = append(keyvals, "attempt", snapshot.noDataAttempts, "max_attempts", check.NoDataPolicy.MaxAttempts)
+	}
+	logFn(g.logger).Log(keyvals...)
 }
 
 func holdInterval(check Check, last EvaluationResult) time.Duration {

--- a/pkg/healthcheck/gate.go
+++ b/pkg/healthcheck/gate.go
@@ -28,6 +28,17 @@ type ConfigProvider interface {
 	Get(name string) *Config
 }
 
+type checkProgress struct {
+	consecutiveFailures  int
+	consecutiveSuccesses int
+	errorAttempts        int
+	noDataAttempts       int
+	lastEvalAt           time.Time
+	lastOutcome          CheckOutcome
+	lastMessage          string
+	lastResult           EvaluationResult
+}
+
 // Gate decides whether progression to the next zone should pause for health checks.
 type Gate struct {
 	provider  ConfigProvider
@@ -35,6 +46,10 @@ type Gate struct {
 	metrics   *Metrics
 	recorder  record.EventRecorder
 	logger    log.Logger
+
+	mu sync.Mutex
+	// progress tracks consecutive pass/fail / retry state per rolloutGroup/config/check.
+	progress map[string]*checkProgress
 
 	// Tracks rollout groups currently reported as misconfigured so the counter and
 	// events are not re-emitted on every reconcile while the binding stays broken.
@@ -49,6 +64,7 @@ func NewGate(provider ConfigProvider, evaluator *Evaluator, metrics *Metrics, re
 		metrics:   metrics,
 		recorder:  recorder,
 		logger:    logger,
+		progress:  map[string]*checkProgress{},
 	}
 }
 
@@ -69,6 +85,7 @@ type Request struct {
 	CandidatePods []*corev1.Pod
 	StablePods    []*corev1.Pod
 	BaselineTime  time.Time
+	Now           time.Time
 }
 
 // Evaluate resolves the RolloutHealthCheck annotation on NextSTS and evaluates checks.
@@ -76,6 +93,7 @@ type Request struct {
 func (g *Gate) Evaluate(ctx context.Context, req Request) Decision {
 	checkName := strings.TrimSpace(req.NextSTS.Annotations[config.RolloutHealthCheckAnnotationKey])
 	if checkName == "" {
+		g.clearGroupProgress(req.RolloutGroup)
 		g.setBlocked(req.RolloutGroup, false)
 		return Decision{}
 	}
@@ -93,42 +111,273 @@ func (g *Gate) Evaluate(ctx context.Context, req Request) Decision {
 		return Decision{Reason: msg}
 	}
 
+	now := req.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	// Skip Prometheus queries while every check is still inside its retry/reevaluation window.
+	if cached, ok := g.cachedDecision(req.RolloutGroup, cfg, now); ok {
+		return g.finalize(req, cached, false)
+	}
+
 	resp := g.evaluator.Evaluate(ctx, EvaluateRequest{
 		Config:        cfg,
 		Namespace:     req.Namespace,
 		RolloutGroup:  req.RolloutGroup,
-		CandidatePods: podNames(req.CandidatePods),
-		StablePods:    podNames(req.StablePods),
+		CandidatePods: targetPodsFromCore(req.CandidatePods),
+		StablePods:    targetPodsFromCore(req.StablePods),
 		BaselineTime:  req.BaselineTime,
-		Now:           time.Now(),
+		Now:           now,
 	})
 
-	switch resp.Outcome {
-	case OutcomePause:
-		msg := resp.Message
-		if msg == "" {
-			msg = fmt.Sprintf("health check %q paused rollout of group %s", resp.FailedCheck, req.RolloutGroup)
+	if resp.ClientError != "" {
+		// Client construction failure is not per-check; pause safely.
+		return g.finalize(req, Decision{ShouldPause: true, Reason: resp.ClientError}, true)
+	}
+
+	decision := g.applyPolicies(req.RolloutGroup, cfg, resp, now)
+	return g.finalize(req, decision, true)
+}
+
+func (g *Gate) finalize(req Request, decision Decision, emitEvent bool) Decision {
+	if decision.ShouldPause {
+		level.Warn(g.logger).Log("msg", "rollout blocked by health check", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "detail", decision.Reason)
+		if emitEvent {
+			g.event(req.NextSTS, corev1.EventTypeWarning, eventBlocked, decision.Reason)
 		}
-		level.Warn(g.logger).Log("msg", "rollout blocked by health check", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "check", resp.FailedCheck, "detail", msg)
-		g.event(req.NextSTS, corev1.EventTypeWarning, eventBlocked, msg)
 		g.clearMisconfigured(req.RolloutGroup)
 		g.setBlocked(req.RolloutGroup, true)
-		return Decision{ShouldPause: true, Reason: msg}
-	case OutcomeWarn:
-		msg := resp.Message
-		if msg == "" {
-			msg = fmt.Sprintf("health check %q warned for group %s", resp.FailedCheck, req.RolloutGroup)
-		}
-		level.Warn(g.logger).Log("msg", "health check warning", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "check", resp.FailedCheck, "detail", msg)
-		g.event(req.NextSTS, corev1.EventTypeWarning, eventWarn, msg)
-		g.clearMisconfigured(req.RolloutGroup)
-		g.setBlocked(req.RolloutGroup, false)
-		return Decision{Reason: msg}
-	default:
-		g.clearMisconfigured(req.RolloutGroup)
-		g.setBlocked(req.RolloutGroup, false)
-		return Decision{}
+		return decision
 	}
+	if decision.Reason != "" {
+		level.Warn(g.logger).Log("msg", "health check warning", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "detail", decision.Reason)
+		if emitEvent {
+			g.event(req.NextSTS, corev1.EventTypeWarning, eventWarn, decision.Reason)
+		}
+	}
+	g.clearMisconfigured(req.RolloutGroup)
+	g.setBlocked(req.RolloutGroup, false)
+	return decision
+}
+
+func (g *Gate) applyPolicies(rolloutGroup string, cfg *Config, resp EvaluateResponse, now time.Time) Decision {
+	checkByName := map[string]Check{}
+	for _, c := range cfg.Checks {
+		checkByName[c.Name] = c
+	}
+
+	var (
+		shouldPause bool
+		warnReason  string
+		pauseReason string
+	)
+
+	for _, ev := range resp.Checks {
+		check, ok := checkByName[ev.Name]
+		if !ok {
+			continue
+		}
+		outcome, msg := g.applyCheckPolicy(rolloutGroup, cfg.Name, check, ev, now)
+		switch outcome {
+		case OutcomePause:
+			shouldPause = true
+			if pauseReason == "" {
+				pauseReason = msg
+			}
+		case OutcomeWarn:
+			if warnReason == "" {
+				warnReason = msg
+			}
+		}
+	}
+
+	if shouldPause {
+		return Decision{ShouldPause: true, Reason: pauseReason}
+	}
+	if warnReason != "" {
+		return Decision{Reason: warnReason}
+	}
+	return Decision{}
+}
+
+func (g *Gate) applyCheckPolicy(rolloutGroup, configName string, check Check, ev CheckEvaluation, now time.Time) (CheckOutcome, string) {
+	key := progressKey(rolloutGroup, configName, check.Name)
+
+	switch ev.Result {
+	case ResultSkipped:
+		g.clearProgress(key)
+		return OutcomeSkipped, ""
+	case ResultError:
+		return g.applyRetryPolicy(key, check.ErrorPolicy, ResultError, ev.Message, now, "error")
+	case ResultNoData:
+		return g.applyRetryPolicy(key, check.NoDataPolicy, ResultNoData, ev.Message, now, "no-data")
+	case ResultPass, ResultFail:
+		return g.applyFailurePolicy(key, check, ev, now)
+	default:
+		return OutcomePause, ev.Message
+	}
+}
+
+func (g *Gate) applyRetryPolicy(key string, policy RetryPolicy, result EvaluationResult, message string, now time.Time, kind string) (CheckOutcome, string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	prog := g.progress[key]
+	if prog == nil {
+		prog = &checkProgress{}
+		g.progress[key] = prog
+	}
+
+	attempts := &prog.errorAttempts
+	if result == ResultNoData {
+		attempts = &prog.noDataAttempts
+	}
+	*attempts++
+
+	prog.lastEvalAt = now
+	prog.lastResult = result
+	msg := message
+	if msg == "" {
+		msg = fmt.Sprintf("%s on health check", kind)
+	}
+
+	if *attempts < policy.MaxAttempts {
+		prog.lastOutcome = OutcomePause
+		prog.lastMessage = fmt.Sprintf("%s (attempt %d/%d)", msg, *attempts, policy.MaxAttempts)
+		return OutcomePause, prog.lastMessage
+	}
+
+	outcome := actionToOutcome(policy.ExhaustedAction)
+	prog.lastOutcome = outcome
+	prog.lastMessage = fmt.Sprintf("%s after %d attempts", msg, *attempts)
+	return outcome, prog.lastMessage
+}
+
+func (g *Gate) applyFailurePolicy(key string, check Check, ev CheckEvaluation, now time.Time) (CheckOutcome, string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	prog := g.progress[key]
+	if prog == nil {
+		prog = &checkProgress{}
+		g.progress[key] = prog
+	}
+
+	// Fresh query results always update counters. reevaluationInterval only gates whether
+	// Evaluate re-queries (via cachedDecision), not whether new results are applied.
+	prog.lastEvalAt = now
+	prog.lastResult = ev.Result
+	prog.errorAttempts = 0
+	prog.noDataAttempts = 0
+	msg := ev.Message
+
+	if ev.Result == ResultPass {
+		prog.consecutiveSuccesses++
+		prog.consecutiveFailures = 0
+		if prog.consecutiveSuccesses >= check.FailurePolicy.ConsecutiveSuccesses {
+			prog.lastOutcome = OutcomePass
+			prog.lastMessage = ""
+			return OutcomePass, ""
+		}
+		prog.lastOutcome = OutcomePause
+		prog.lastMessage = fmt.Sprintf("check %q needs %d consecutive successes (have %d)", check.Name, check.FailurePolicy.ConsecutiveSuccesses, prog.consecutiveSuccesses)
+		return OutcomePause, prog.lastMessage
+	}
+
+	prog.consecutiveFailures++
+	prog.consecutiveSuccesses = 0
+	if msg == "" {
+		msg = fmt.Sprintf("check %q failed", check.Name)
+	}
+	if prog.consecutiveFailures >= check.FailurePolicy.ConsecutiveFailures {
+		outcome := actionToOutcome(check.FailurePolicy.ExceededAction)
+		prog.lastOutcome = outcome
+		prog.lastMessage = msg
+		return outcome, msg
+	}
+	prog.lastOutcome = OutcomePause
+	prog.lastMessage = fmt.Sprintf("%s (%d/%d consecutive failures)", msg, prog.consecutiveFailures, check.FailurePolicy.ConsecutiveFailures)
+	return OutcomePause, prog.lastMessage
+}
+
+func (g *Gate) cachedDecision(rolloutGroup string, cfg *Config, now time.Time) (Decision, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	var (
+		sawAny      bool
+		shouldPause bool
+		warnReason  string
+		pauseReason string
+	)
+	for _, check := range cfg.Checks {
+		if check.Disabled {
+			continue
+		}
+		prog := g.progress[progressKey(rolloutGroup, cfg.Name, check.Name)]
+		if prog == nil || prog.lastEvalAt.IsZero() {
+			return Decision{}, false
+		}
+		interval := holdInterval(check, prog.lastResult)
+		if !now.Before(prog.lastEvalAt.Add(interval)) {
+			return Decision{}, false
+		}
+		sawAny = true
+		switch prog.lastOutcome {
+		case OutcomePause:
+			shouldPause = true
+			if pauseReason == "" {
+				pauseReason = prog.lastMessage
+			}
+		case OutcomeWarn:
+			if warnReason == "" {
+				warnReason = prog.lastMessage
+			}
+		}
+	}
+	if !sawAny {
+		return Decision{}, false
+	}
+	if shouldPause {
+		return Decision{ShouldPause: true, Reason: pauseReason}, true
+	}
+	if warnReason != "" {
+		return Decision{Reason: warnReason}, true
+	}
+	return Decision{}, true
+}
+
+func holdInterval(check Check, last EvaluationResult) time.Duration {
+	switch last {
+	case ResultError:
+		return check.ErrorPolicy.RetryInterval
+	case ResultNoData:
+		return check.NoDataPolicy.RetryInterval
+	default:
+		return check.FailurePolicy.ReevaluationInterval
+	}
+}
+
+func (g *Gate) clearProgress(key string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.progress, key)
+}
+
+func (g *Gate) clearGroupProgress(rolloutGroup string) {
+	prefix := rolloutGroup + "/"
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for k := range g.progress {
+		if strings.HasPrefix(k, prefix) {
+			delete(g.progress, k)
+		}
+	}
+}
+
+func progressKey(rolloutGroup, configName, checkName string) string {
+	return rolloutGroup + "/" + configName + "/" + checkName
 }
 
 func (g *Gate) reportMisconfigured(req Request, msg string) {
@@ -172,12 +421,16 @@ func (g *Gate) event(sts *appsv1.StatefulSet, eventType, reason, message string)
 	g.recorder.Event(sts, eventType, reason, message)
 }
 
-func podNames(pods []*corev1.Pod) []string {
+func targetPodsFromCore(pods []*corev1.Pod) TargetPods {
 	names := make([]string, 0, len(pods))
+	zones := make([]string, 0, len(pods))
 	for _, p := range pods {
 		names = append(names, p.Name)
+		if z := p.Labels["name"]; z != "" {
+			zones = append(zones, z)
+		}
 	}
-	return names
+	return TargetPods{Names: names, Zones: uniqueNonEmpty(zones)}
 }
 
 // ParseStartedAtAnnotation parses "<updateRevision>=<RFC3339>" from the annotation value.

--- a/pkg/healthcheck/gate_test.go
+++ b/pkg/healthcheck/gate_test.go
@@ -1,0 +1,78 @@
+package healthcheck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+type staticProvider struct {
+	cfg *Config
+}
+
+func (s staticProvider) Get(name string) *Config {
+	if s.cfg != nil && s.cfg.Name == name {
+		return s.cfg
+	}
+	return nil
+}
+
+func TestGate_MisconfiguredProceeds(t *testing.T) {
+	recorder := record.NewFakeRecorder(10)
+	eval := NewEvaluator(func(string) (Querier, error) {
+		t.Fatal("should not query")
+		return nil, nil
+	}, nil, log.NewNopLogger())
+	gate := NewGate(staticProvider{}, eval, nil, recorder, log.NewNopLogger())
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ingester-zone-b",
+			Annotations: map[string]string{
+				config.RolloutHealthCheckAnnotationKey: "missing",
+			},
+			Labels: map[string]string{"rollout-group": "ingester"},
+		},
+	}
+	decision := gate.Evaluate(context.Background(), Request{
+		RolloutGroup: "ingester",
+		Namespace:    "ns",
+		Sets:         []*appsv1.StatefulSet{sts},
+		NextSTS:      sts,
+	})
+	require.False(t, decision.ShouldPause)
+	require.Contains(t, decision.Reason, "was not found")
+}
+
+func TestGate_SelectorMismatchProceeds(t *testing.T) {
+	recorder := record.NewFakeRecorder(10)
+	cfg := &Config{
+		Name:     "hc",
+		Selector: labels.SelectorFromSet(labels.Set{"rollout-group": "other"}),
+	}
+	gate := NewGate(staticProvider{cfg: cfg}, NewEvaluator(nil, nil, log.NewNopLogger()), nil, recorder, log.NewNopLogger())
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ingester-zone-b",
+			Annotations: map[string]string{
+				config.RolloutHealthCheckAnnotationKey: "hc",
+			},
+			Labels: map[string]string{"rollout-group": "ingester"},
+		},
+	}
+	decision := gate.Evaluate(context.Background(), Request{
+		RolloutGroup: "ingester",
+		Sets:         []*appsv1.StatefulSet{sts},
+		NextSTS:      sts,
+	})
+	require.False(t, decision.ShouldPause)
+	require.Contains(t, decision.Reason, "selector does not match")
+}

--- a/pkg/healthcheck/gate_test.go
+++ b/pkg/healthcheck/gate_test.go
@@ -2,9 +2,12 @@ package healthcheck
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,4 +78,164 @@ func TestGate_SelectorMismatchProceeds(t *testing.T) {
 	})
 	require.False(t, decision.ShouldPause)
 	require.Contains(t, decision.Reason, "selector does not match")
+}
+
+func TestGate_ConsecutiveFailures(t *testing.T) {
+	check := testCheck()
+	check.FailurePolicy.ConsecutiveFailures = 3
+	check.FailurePolicy.ConsecutiveSuccesses = 1
+	check.FailurePolicy.ReevaluationInterval = time.Millisecond
+	cfg := &Config{
+		Name:          "hc",
+		PrometheusURL: "http://prometheus",
+		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
+		Checks:        []Check{check},
+	}
+
+	failSeq := func() []func() (model.Value, error) {
+		return []func() (model.Value, error){
+			func() (model.Value, error) { return scalar(5), nil },
+			func() (model.Value, error) { return scalar(0.1), nil },
+			func() (model.Value, error) { return scalar(0), nil },
+		}
+	}
+
+	q := &fakeQuerier{sequence: failSeq()}
+	gate := NewGate(staticProvider{cfg: cfg}, NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger()), nil, record.NewFakeRecorder(10), log.NewNopLogger())
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ingester-zone-b",
+			Annotations: map[string]string{config.RolloutHealthCheckAnnotationKey: "hc"},
+			Labels:      map[string]string{"rollout-group": "ingester"},
+		},
+	}
+
+	now := time.Now()
+	for i := 1; i <= 3; i++ {
+		q.sequence = failSeq()
+		q.seqIdx = 0
+		time.Sleep(2 * time.Millisecond)
+		decision := gate.Evaluate(context.Background(), Request{
+			RolloutGroup: "ingester",
+			Namespace:    "ns",
+			NextSTS:      sts,
+			Now:          now.Add(time.Duration(i) * time.Second),
+		})
+		require.True(t, decision.ShouldPause, "iteration %d", i)
+		if i < 3 {
+			require.Contains(t, decision.Reason, "consecutive failures")
+		}
+	}
+}
+
+func TestGate_WarnOnFailureExceeded(t *testing.T) {
+	check := testCheck()
+	check.FailurePolicy.ConsecutiveFailures = 1
+	check.FailurePolicy.ExceededAction = ActionWarn
+	check.FailurePolicy.ReevaluationInterval = time.Millisecond
+	cfg := &Config{
+		Name:          "hc",
+		PrometheusURL: "http://prometheus",
+		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
+		Checks:        []Check{check},
+	}
+	q := &fakeQuerier{sequence: []func() (model.Value, error){
+		func() (model.Value, error) { return scalar(5), nil },
+		func() (model.Value, error) { return scalar(0.1), nil },
+		func() (model.Value, error) { return scalar(0), nil },
+	}}
+	gate := NewGate(staticProvider{cfg: cfg}, NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger()), nil, record.NewFakeRecorder(10), log.NewNopLogger())
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ingester-zone-b",
+			Annotations: map[string]string{config.RolloutHealthCheckAnnotationKey: "hc"},
+			Labels:      map[string]string{"rollout-group": "ingester"},
+		},
+	}
+	decision := gate.Evaluate(context.Background(), Request{RolloutGroup: "ingester", Namespace: "ns", NextSTS: sts, Now: time.Now()})
+	require.False(t, decision.ShouldPause)
+	require.NotEmpty(t, decision.Reason)
+}
+
+func TestGate_ErrorRetriesAcrossReconciles(t *testing.T) {
+	check := testCheck()
+	check.ErrorPolicy.MaxAttempts = 3
+	check.ErrorPolicy.RetryInterval = time.Millisecond
+	check.ErrorPolicy.ExhaustedAction = ActionPause
+	cfg := &Config{
+		Name:          "hc",
+		PrometheusURL: "http://prometheus",
+		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
+		Checks:        []Check{check},
+	}
+	q := &fakeQuerier{sequence: []func() (model.Value, error){
+		func() (model.Value, error) { return nil, errors.New("boom") },
+	}}
+	gate := NewGate(staticProvider{cfg: cfg}, NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger()), nil, record.NewFakeRecorder(10), log.NewNopLogger())
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ingester-zone-b",
+			Annotations: map[string]string{config.RolloutHealthCheckAnnotationKey: "hc"},
+			Labels:      map[string]string{"rollout-group": "ingester"},
+		},
+	}
+	now := time.Now()
+	for i := 1; i <= 3; i++ {
+		q.seqIdx = 0
+		q.sequence = []func() (model.Value, error){
+			func() (model.Value, error) { return nil, errors.New("boom") },
+		}
+		decision := gate.Evaluate(context.Background(), Request{
+			RolloutGroup: "ingester",
+			Namespace:    "ns",
+			NextSTS:      sts,
+			Now:          now.Add(time.Duration(i) * time.Second),
+		})
+		require.True(t, decision.ShouldPause, "attempt %d", i)
+		if i < 3 {
+			require.Contains(t, decision.Reason, "attempt")
+		} else {
+			require.Contains(t, decision.Reason, "after 3 attempts")
+		}
+	}
+}
+
+func TestGate_ConsecutiveSuccessesRequired(t *testing.T) {
+	check := testCheck()
+	check.FailurePolicy.ConsecutiveSuccesses = 2
+	check.FailurePolicy.ConsecutiveFailures = 3
+	check.FailurePolicy.ReevaluationInterval = time.Millisecond
+	cfg := &Config{
+		Name:          "hc",
+		PrometheusURL: "http://prometheus",
+		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
+		Checks:        []Check{check},
+	}
+	passSeq := func() []func() (model.Value, error) {
+		return []func() (model.Value, error){
+			func() (model.Value, error) { return scalar(0.1), nil },
+			func() (model.Value, error) { return scalar(0.2), nil },
+			func() (model.Value, error) { return scalar(1), nil },
+		}
+	}
+	q := &fakeQuerier{sequence: passSeq()}
+	gate := NewGate(staticProvider{cfg: cfg}, NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger()), nil, record.NewFakeRecorder(10), log.NewNopLogger())
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ingester-zone-b",
+			Annotations: map[string]string{config.RolloutHealthCheckAnnotationKey: "hc"},
+			Labels:      map[string]string{"rollout-group": "ingester"},
+		},
+	}
+	now := time.Now()
+	q.sequence = passSeq()
+	decision := gate.Evaluate(context.Background(), Request{RolloutGroup: "ingester", Namespace: "ns", NextSTS: sts, Now: now})
+	require.True(t, decision.ShouldPause)
+	require.Contains(t, decision.Reason, "consecutive successes")
+
+	q.seqIdx = 0
+	q.sequence = passSeq()
+	decision = gate.Evaluate(context.Background(), Request{RolloutGroup: "ingester", Namespace: "ns", NextSTS: sts, Now: now.Add(time.Second)})
+	require.False(t, decision.ShouldPause)
+	require.Empty(t, decision.Reason)
 }

--- a/pkg/healthcheck/gate_test.go
+++ b/pkg/healthcheck/gate_test.go
@@ -1,8 +1,10 @@
 package healthcheck
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -126,6 +128,98 @@ func TestGate_ConsecutiveFailures(t *testing.T) {
 			require.Contains(t, decision.Reason, "consecutive failures")
 		}
 	}
+}
+
+func TestGate_PausedDecisionReturnsNextEvaluationDelay(t *testing.T) {
+	check := testCheck()
+	check.FailurePolicy.ReevaluationInterval = time.Minute
+	cfg := &Config{
+		Name:          "hc",
+		PrometheusURL: "http://prometheus",
+		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
+		Checks:        []Check{check},
+	}
+	failSequence := func() []func() (model.Value, error) {
+		return []func() (model.Value, error){
+			func() (model.Value, error) { return scalar(5), nil },
+			func() (model.Value, error) { return scalar(0.1), nil },
+			func() (model.Value, error) { return scalar(0), nil },
+		}
+	}
+	q := &fakeQuerier{sequence: failSequence()}
+	gate := NewGate(staticProvider{cfg: cfg}, NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger()), nil, nil, log.NewNopLogger())
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ingester-zone-b",
+			Annotations: map[string]string{config.RolloutHealthCheckAnnotationKey: "hc"},
+			Labels:      map[string]string{"rollout-group": "ingester"},
+		},
+	}
+	now := time.Now()
+	req := Request{RolloutGroup: "ingester", Namespace: "ns", NextSTS: sts, Now: now}
+
+	decision := gate.Evaluate(context.Background(), req)
+	require.True(t, decision.ShouldPause)
+	require.Equal(t, time.Minute, decision.RequeueAfter)
+	require.Len(t, q.calls, 3)
+
+	req.Now = now.Add(20 * time.Second)
+	decision = gate.Evaluate(context.Background(), req)
+	require.True(t, decision.ShouldPause)
+	require.Equal(t, 40*time.Second, decision.RequeueAfter)
+	require.Len(t, q.calls, 3, "cached decision must not query before the deadline")
+
+	q.sequence = failSequence()
+	q.seqIdx = 0
+	req.Now = now.Add(time.Minute)
+	decision = gate.Evaluate(context.Background(), req)
+	require.True(t, decision.ShouldPause)
+	require.Equal(t, time.Minute, decision.RequeueAfter)
+	require.Len(t, q.calls, 6)
+}
+
+func TestGate_LogsPolicyOutcomeWithoutQueries(t *testing.T) {
+	check := testCheck()
+	cfg := &Config{
+		Name:          "hc",
+		PrometheusURL: "http://prometheus",
+		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
+		Checks:        []Check{check},
+	}
+	q := &fakeQuerier{sequence: []func() (model.Value, error){
+		func() (model.Value, error) { return scalar(5), nil },
+		func() (model.Value, error) { return scalar(0.1), nil },
+		func() (model.Value, error) { return scalar(0), nil },
+	}}
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	gate := NewGate(staticProvider{cfg: cfg}, NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, logger), nil, nil, logger)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ingester-zone-b",
+			Annotations: map[string]string{config.RolloutHealthCheckAnnotationKey: "hc"},
+			Labels:      map[string]string{"rollout-group": "ingester"},
+		},
+	}
+
+	decision := gate.Evaluate(context.Background(), Request{
+		RolloutGroup: "ingester",
+		Namespace:    "ns",
+		NextSTS:      sts,
+		Now:          time.Now(),
+	})
+
+	require.True(t, decision.ShouldPause)
+	output := logs.String()
+	require.Contains(t, output, "msg=\"health check policy applied\"")
+	require.Contains(t, output, "policy=hc")
+	require.Contains(t, output, "check=errors")
+	require.Contains(t, output, "action=pause")
+	require.Contains(t, output, "current_value=5")
+	require.Contains(t, output, "baseline_value=0.1")
+	require.Contains(t, output, "consecutive_failures=1")
+	require.False(t, strings.Contains(output, check.Query))
+	require.False(t, strings.Contains(output, check.SuccessQuery))
 }
 
 func TestGate_WarnOnFailureExceeded(t *testing.T) {

--- a/pkg/healthcheck/metrics.go
+++ b/pkg/healthcheck/metrics.go
@@ -1,0 +1,59 @@
+package healthcheck
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metrics for RolloutHealthCheck observation and evaluation.
+type Metrics struct {
+	ConfigurationsObserved *prometheus.CounterVec
+	EvaluationsTotal       *prometheus.CounterVec
+	Blocked                *prometheus.GaugeVec
+	MisconfiguredTotal     *prometheus.CounterVec
+	Misconfigured          *prometheus.GaugeVec
+	QueryDuration          *prometheus.HistogramVec
+}
+
+// NewMetrics registers health-check metrics on reg.
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	return &Metrics{
+		ConfigurationsObserved: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "rollout_operator_health_check_configurations_observed_total",
+			Help: "Total number of RolloutHealthCheck configuration events observed by outcome.",
+		}, []string{"outcome"}),
+		EvaluationsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "rollout_operator_health_check_evaluations_total",
+			Help: "Total number of health check evaluations by result.",
+		}, []string{"rollout_group", "check", "result"}),
+		Blocked: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_health_check_blocked",
+			Help: "Whether a rollout group is currently blocked by a health check (1) or not (0).",
+		}, []string{"rollout_group"}),
+		MisconfiguredTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "rollout_operator_health_check_misconfigured_total",
+			Help: "Total number of misconfigured health-check bindings observed for a rollout group.",
+		}, []string{"rollout_group"}),
+		Misconfigured: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_health_check_misconfigured",
+			Help: "Whether a rollout group currently has a misconfigured health-check binding (1) or not (0).",
+		}, []string{"rollout_group"}),
+		QueryDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "rollout_operator_health_check_query_duration_seconds",
+			Help:    "Duration of Prometheus queries issued for health checks.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"rollout_group", "check", "query_type"}),
+	}
+}
+
+// DeleteGroup removes series labeled with the given rollout group.
+func (m *Metrics) DeleteGroup(rolloutGroup string) {
+	if m == nil {
+		return
+	}
+	m.Blocked.DeleteLabelValues(rolloutGroup)
+	m.Misconfigured.DeleteLabelValues(rolloutGroup)
+	m.MisconfiguredTotal.DeleteLabelValues(rolloutGroup)
+	m.EvaluationsTotal.DeletePartialMatch(prometheus.Labels{"rollout_group": rolloutGroup})
+	m.QueryDuration.DeletePartialMatch(prometheus.Labels{"rollout_group": rolloutGroup})
+}

--- a/pkg/healthcheck/observer.go
+++ b/pkg/healthcheck/observer.go
@@ -1,0 +1,153 @@
+package healthcheck
+
+import (
+	"errors"
+	"reflect"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	k8cache "k8s.io/client-go/tools/cache"
+)
+
+const informerSyncInterval = 5 * time.Minute
+
+// Observer watches RolloutHealthCheck objects and keeps an in-memory cache.
+type Observer struct {
+	factory  dynamicinformer.DynamicSharedInformerFactory
+	informer k8cache.SharedIndexInformer
+	cache    *configCache
+	metrics  *Metrics
+	logger   log.Logger
+	stopCh   chan struct{}
+}
+
+// NewObserver creates a namespace-scoped observer for RolloutHealthCheck resources.
+func NewObserver(dyn dynamic.Interface, namespace string, logger log.Logger, metrics *Metrics) *Observer {
+	gvr := schema.GroupVersionResource{
+		Group:    RolloutHealthChecksSpecGroup,
+		Version:  RolloutHealthChecksVersion,
+		Resource: RolloutHealthChecksPlural,
+	}
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dyn, informerSyncInterval, namespace, nil)
+	informer := factory.ForResource(gvr)
+
+	return &Observer{
+		factory:  factory,
+		informer: informer.Informer(),
+		cache:    newConfigCache(),
+		metrics:  metrics,
+		logger:   logger,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// Start begins watching and blocks until the informer cache has synced.
+func (o *Observer) Start() error {
+	_, err := o.informer.AddEventHandler(k8cache.ResourceEventHandlerFuncs{
+		AddFunc:    o.onAdded,
+		UpdateFunc: o.onUpdated,
+		DeleteFunc: o.onDeleted,
+	})
+	if err != nil {
+		return err
+	}
+
+	go o.factory.Start(o.stopCh)
+
+	level.Info(o.logger).Log("msg", "rollout health check informer caches are syncing")
+	if ok := k8cache.WaitForCacheSync(o.stopCh, o.informer.HasSynced); !ok {
+		return errors.New("rollout health check informer caches failed to sync")
+	}
+	level.Info(o.logger).Log("msg", "rollout health check informer caches have synced")
+	return nil
+}
+
+// Stop stops the informer.
+func (o *Observer) Stop() {
+	close(o.stopCh)
+}
+
+// Get returns the cached config for name, or nil if missing / invalid.
+func (o *Observer) Get(name string) *Config {
+	return o.cache.Get(name)
+}
+
+func (o *Observer) addOrUpdate(obj *unstructured.Unstructured) {
+	updated, generation, err := o.cache.addOrUpdateRaw(obj)
+	if err != nil {
+		level.Error(o.logger).Log("msg", "rollout health check configuration error", "name", obj.GetName(), "err", err)
+		// Drop any previously cached valid config so we do not keep evaluating stale rules.
+		o.cache.invalidate(obj.GetName())
+		if o.metrics != nil {
+			o.metrics.ConfigurationsObserved.WithLabelValues("invalid").Inc()
+		}
+		return
+	}
+	if updated {
+		level.Info(o.logger).Log("msg", "rollout health check configuration updated", "name", obj.GetName(), "generation", generation)
+		if o.metrics != nil {
+			o.metrics.ConfigurationsObserved.WithLabelValues("updated").Inc()
+		}
+		return
+	}
+	level.Info(o.logger).Log("msg", "rollout health check configuration update ignored", "name", obj.GetName(), "generation", generation, "ignored-generation", obj.GetGeneration())
+	if o.metrics != nil {
+		o.metrics.ConfigurationsObserved.WithLabelValues("ignored").Inc()
+	}
+}
+
+func (o *Observer) onAdded(obj interface{}) {
+	unstructuredObj, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		if o.metrics != nil {
+			o.metrics.ConfigurationsObserved.WithLabelValues("ignored").Inc()
+		}
+		level.Warn(o.logger).Log("msg", "unexpected object passed through health check informer", "type", reflect.TypeOf(obj))
+		return
+	}
+	o.addOrUpdate(unstructuredObj)
+}
+
+func (o *Observer) onUpdated(old, new interface{}) {
+	_, oldOK := old.(*unstructured.Unstructured)
+	newCfg, newOK := new.(*unstructured.Unstructured)
+	if !oldOK || !newOK {
+		if o.metrics != nil {
+			o.metrics.ConfigurationsObserved.WithLabelValues("ignored").Inc()
+		}
+		level.Warn(o.logger).Log("msg", "unexpected object passed through health check informer", "old_type", reflect.TypeOf(old), "new_type", reflect.TypeOf(new))
+		return
+	}
+	o.addOrUpdate(newCfg)
+}
+
+func (o *Observer) onDeleted(obj interface{}) {
+	if tombstone, ok := obj.(k8cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	oldCfg, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		if o.metrics != nil {
+			o.metrics.ConfigurationsObserved.WithLabelValues("ignored").Inc()
+		}
+		level.Warn(o.logger).Log("msg", "unexpected object passed through health check informer", "type", reflect.TypeOf(obj))
+		return
+	}
+	success, generation := o.cache.delete(oldCfg.GetGeneration(), oldCfg.GetName())
+	if success {
+		if o.metrics != nil {
+			o.metrics.ConfigurationsObserved.WithLabelValues("deleted").Inc()
+		}
+		level.Info(o.logger).Log("msg", "rollout health check configuration deleted", "name", oldCfg.GetName(), "generation", generation)
+		return
+	}
+	if o.metrics != nil {
+		o.metrics.ConfigurationsObserved.WithLabelValues("delete-ignored").Inc()
+	}
+	level.Info(o.logger).Log("msg", "rollout health check configuration delete ignored", "name", oldCfg.GetName(), "generation", generation, "ignored-generation", oldCfg.GetGeneration())
+}

--- a/vendor/github.com/prometheus/client_golang/api/client.go
+++ b/vendor/github.com/prometheus/client_golang/api/client.go
@@ -1,0 +1,156 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package api provides clients for the HTTP APIs.
+package api
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+)
+
+// DefaultRoundTripper is used if no RoundTripper is set in Config.
+var DefaultRoundTripper http.RoundTripper = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	DialContext: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext,
+	TLSHandshakeTimeout: 10 * time.Second,
+}
+
+// Config defines configuration parameters for a new client.
+type Config struct {
+	// The address of the Prometheus to connect to.
+	Address string
+
+	// Client is used by the Client to drive HTTP requests. If not provided,
+	// a new one based on the provided RoundTripper (or DefaultRoundTripper) will be used.
+	Client *http.Client
+
+	// RoundTripper is used by the Client to drive HTTP requests. If not
+	// provided, DefaultRoundTripper will be used.
+	RoundTripper http.RoundTripper
+}
+
+func (cfg *Config) roundTripper() http.RoundTripper {
+	if cfg.RoundTripper == nil {
+		return DefaultRoundTripper
+	}
+	return cfg.RoundTripper
+}
+
+func (cfg *Config) client() http.Client {
+	if cfg.Client == nil {
+		return http.Client{
+			Transport: cfg.roundTripper(),
+		}
+	}
+	return *cfg.Client
+}
+
+func (cfg *Config) validate() error {
+	if cfg.Client != nil && cfg.RoundTripper != nil {
+		return errors.New("api.Config.RoundTripper and api.Config.Client are mutually exclusive")
+	}
+	return nil
+}
+
+// Client is the interface for an API client.
+type Client interface {
+	URL(ep string, args map[string]string) *url.URL
+	Do(context.Context, *http.Request) (*http.Response, []byte, error)
+}
+
+type CloseIdler interface {
+	CloseIdleConnections()
+}
+
+// NewClient returns a new Client.
+//
+// It is safe to use the returned Client from multiple goroutines.
+func NewClient(cfg Config) (Client, error) {
+	u, err := url.Parse(cfg.Address)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	return &httpClient{
+		endpoint: u,
+		client:   cfg.client(),
+	}, nil
+}
+
+type httpClient struct {
+	endpoint *url.URL
+	client   http.Client
+}
+
+func (c *httpClient) URL(ep string, args map[string]string) *url.URL {
+	p := path.Join(c.endpoint.Path, ep)
+
+	for arg, val := range args {
+		arg = ":" + arg
+		p = strings.ReplaceAll(p, arg, val)
+	}
+
+	u := *c.endpoint
+	u.Path = p
+
+	return &u
+}
+
+func (c *httpClient) CloseIdleConnections() {
+	c.client.CloseIdleConnections()
+}
+
+func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var body []byte
+	done := make(chan error, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, err := buf.ReadFrom(resp.Body)
+		body = buf.Bytes()
+		done <- err
+	}()
+
+	select {
+	case <-ctx.Done():
+		resp.Body.Close()
+		<-done
+		return resp, nil, ctx.Err()
+	case err = <-done:
+		resp.Body.Close()
+		return resp, body, err
+	}
+}

--- a/vendor/github.com/prometheus/client_golang/api/client.go
+++ b/vendor/github.com/prometheus/client_golang/api/client.go
@@ -27,13 +27,18 @@ import (
 )
 
 // DefaultRoundTripper is used if no RoundTripper is set in Config.
+// refer https://github.com/golang/go/blob/master/src/net/http/transport.go#L46
 var DefaultRoundTripper http.RoundTripper = &http.Transport{
 	Proxy: http.ProxyFromEnvironment,
 	DialContext: (&net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}).DialContext,
-	TLSHandshakeTimeout: 10 * time.Second,
+	ForceAttemptHTTP2:     true,
+	MaxIdleConns:          100,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   10 * time.Second,
+	ExpectContinueTimeout: 1 * time.Second,
 }
 
 // Config defines configuration parameters for a new client.
@@ -136,21 +141,21 @@ func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response,
 	}
 
 	var body []byte
-	done := make(chan error, 1)
+	done := make(chan struct{})
+	var readErr error
 	go func() {
+		defer close(done)
 		var buf bytes.Buffer
-		_, err := buf.ReadFrom(resp.Body)
+		_, readErr = buf.ReadFrom(resp.Body)
 		body = buf.Bytes()
-		done <- err
 	}()
 
 	select {
 	case <-ctx.Done():
 		resp.Body.Close()
-		<-done
 		return resp, nil, ctx.Err()
-	case err = <-done:
+	case <-done:
 		resp.Body.Close()
-		return resp, body, err
+		return resp, body, readErr
 	}
 }

--- a/vendor/github.com/prometheus/client_golang/api/prometheus/v1/api.go
+++ b/vendor/github.com/prometheus/client_golang/api/prometheus/v1/api.go
@@ -1,0 +1,1502 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v1 provides bindings to the Prometheus HTTP API v1:
+// http://prometheus.io/docs/querying/api/
+package v1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+	"unsafe"
+
+	json "github.com/json-iterator/go"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/client_golang/api"
+)
+
+func init() {
+	json.RegisterTypeEncoderFunc("model.SamplePair", marshalSamplePairJSON, marshalJSONIsEmpty)
+	json.RegisterTypeDecoderFunc("model.SamplePair", unmarshalSamplePairJSON)
+	json.RegisterTypeEncoderFunc("model.SampleHistogramPair", marshalSampleHistogramPairJSON, marshalJSONIsEmpty)
+	json.RegisterTypeDecoderFunc("model.SampleHistogramPair", unmarshalSampleHistogramPairJSON)
+	json.RegisterTypeEncoderFunc("model.SampleStream", marshalSampleStreamJSON, marshalJSONIsEmpty) // Only needed for benchmark.
+	json.RegisterTypeDecoderFunc("model.SampleStream", unmarshalSampleStreamJSON)                   // Only needed for benchmark.
+}
+
+func unmarshalSamplePairJSON(ptr unsafe.Pointer, iter *json.Iterator) {
+	p := (*model.SamplePair)(ptr)
+	if !iter.ReadArray() {
+		iter.ReportError("unmarshal model.SamplePair", "SamplePair must be [timestamp, value]")
+		return
+	}
+	t := iter.ReadNumber()
+	if err := p.Timestamp.UnmarshalJSON([]byte(t)); err != nil {
+		iter.ReportError("unmarshal model.SamplePair", err.Error())
+		return
+	}
+	if !iter.ReadArray() {
+		iter.ReportError("unmarshal model.SamplePair", "SamplePair missing value")
+		return
+	}
+
+	f, err := strconv.ParseFloat(iter.ReadString(), 64)
+	if err != nil {
+		iter.ReportError("unmarshal model.SamplePair", err.Error())
+		return
+	}
+	p.Value = model.SampleValue(f)
+
+	if iter.ReadArray() {
+		iter.ReportError("unmarshal model.SamplePair", "SamplePair has too many values, must be [timestamp, value]")
+		return
+	}
+}
+
+func marshalSamplePairJSON(ptr unsafe.Pointer, stream *json.Stream) {
+	p := *((*model.SamplePair)(ptr))
+	stream.WriteArrayStart()
+	marshalTimestamp(p.Timestamp, stream)
+	stream.WriteMore()
+	marshalFloat(float64(p.Value), stream)
+	stream.WriteArrayEnd()
+}
+
+func unmarshalSampleHistogramPairJSON(ptr unsafe.Pointer, iter *json.Iterator) {
+	p := (*model.SampleHistogramPair)(ptr)
+	if !iter.ReadArray() {
+		iter.ReportError("unmarshal model.SampleHistogramPair", "SampleHistogramPair must be [timestamp, {histogram}]")
+		return
+	}
+	t := iter.ReadNumber()
+	if err := p.Timestamp.UnmarshalJSON([]byte(t)); err != nil {
+		iter.ReportError("unmarshal model.SampleHistogramPair", err.Error())
+		return
+	}
+	if !iter.ReadArray() {
+		iter.ReportError("unmarshal model.SampleHistogramPair", "SamplePair missing histogram")
+		return
+	}
+	h := &model.SampleHistogram{}
+	p.Histogram = h
+	for key := iter.ReadObject(); key != ""; key = iter.ReadObject() {
+		switch key {
+		case "count":
+			f, err := strconv.ParseFloat(iter.ReadString(), 64)
+			if err != nil {
+				iter.ReportError("unmarshal model.SampleHistogramPair", "count of histogram is not a float")
+				return
+			}
+			h.Count = model.FloatString(f)
+		case "sum":
+			f, err := strconv.ParseFloat(iter.ReadString(), 64)
+			if err != nil {
+				iter.ReportError("unmarshal model.SampleHistogramPair", "sum of histogram is not a float")
+				return
+			}
+			h.Sum = model.FloatString(f)
+		case "buckets":
+			for iter.ReadArray() {
+				b, err := unmarshalHistogramBucket(iter)
+				if err != nil {
+					iter.ReportError("unmarshal model.HistogramBucket", err.Error())
+					return
+				}
+				h.Buckets = append(h.Buckets, b)
+			}
+		default:
+			iter.ReportError("unmarshal model.SampleHistogramPair", fmt.Sprint("unexpected key in histogram:", key))
+			return
+		}
+	}
+	if iter.ReadArray() {
+		iter.ReportError("unmarshal model.SampleHistogramPair", "SampleHistogramPair has too many values, must be [timestamp, {histogram}]")
+		return
+	}
+}
+
+func marshalSampleHistogramPairJSON(ptr unsafe.Pointer, stream *json.Stream) {
+	p := *((*model.SampleHistogramPair)(ptr))
+	stream.WriteArrayStart()
+	marshalTimestamp(p.Timestamp, stream)
+	stream.WriteMore()
+	marshalHistogram(*p.Histogram, stream)
+	stream.WriteArrayEnd()
+}
+
+func unmarshalSampleStreamJSON(ptr unsafe.Pointer, iter *json.Iterator) {
+	ss := (*model.SampleStream)(ptr)
+	for key := iter.ReadObject(); key != ""; key = iter.ReadObject() {
+		switch key {
+		case "metric":
+			metricString := iter.ReadAny().ToString()
+			if err := json.UnmarshalFromString(metricString, &ss.Metric); err != nil {
+				iter.ReportError("unmarshal model.SampleStream", err.Error())
+				return
+			}
+		case "values":
+			for iter.ReadArray() {
+				v := model.SamplePair{}
+				unmarshalSamplePairJSON(unsafe.Pointer(&v), iter)
+				ss.Values = append(ss.Values, v)
+			}
+		case "histograms":
+			for iter.ReadArray() {
+				h := model.SampleHistogramPair{}
+				unmarshalSampleHistogramPairJSON(unsafe.Pointer(&h), iter)
+				ss.Histograms = append(ss.Histograms, h)
+			}
+		default:
+			iter.ReportError("unmarshal model.SampleStream", fmt.Sprint("unexpected key:", key))
+			return
+		}
+	}
+}
+
+func marshalSampleStreamJSON(ptr unsafe.Pointer, stream *json.Stream) {
+	ss := *((*model.SampleStream)(ptr))
+	stream.WriteObjectStart()
+	stream.WriteObjectField(`metric`)
+	m, err := json.ConfigCompatibleWithStandardLibrary.Marshal(ss.Metric)
+	if err != nil {
+		stream.Error = err
+		return
+	}
+	stream.SetBuffer(append(stream.Buffer(), m...))
+	if len(ss.Values) > 0 {
+		stream.WriteMore()
+		stream.WriteObjectField(`values`)
+		stream.WriteArrayStart()
+		for i, v := range ss.Values {
+			if i > 0 {
+				stream.WriteMore()
+			}
+			marshalSamplePairJSON(unsafe.Pointer(&v), stream)
+		}
+		stream.WriteArrayEnd()
+	}
+	if len(ss.Histograms) > 0 {
+		stream.WriteMore()
+		stream.WriteObjectField(`histograms`)
+		stream.WriteArrayStart()
+		for i, h := range ss.Histograms {
+			if i > 0 {
+				stream.WriteMore()
+			}
+			marshalSampleHistogramPairJSON(unsafe.Pointer(&h), stream)
+		}
+		stream.WriteArrayEnd()
+	}
+	stream.WriteObjectEnd()
+}
+
+func marshalFloat(v float64, stream *json.Stream) {
+	stream.WriteRaw(`"`)
+	// Taken from https://github.com/json-iterator/go/blob/master/stream_float.go#L71 as a workaround
+	// to https://github.com/json-iterator/go/issues/365 (json-iterator, to follow json standard, doesn't allow inf/nan).
+	buf := stream.Buffer()
+	abs := math.Abs(v)
+	fmt := byte('f')
+	// Note: Must use float32 comparisons for underlying float32 value to get precise cutoffs right.
+	if abs != 0 {
+		if abs < 1e-6 || abs >= 1e21 {
+			fmt = 'e'
+		}
+	}
+	buf = strconv.AppendFloat(buf, v, fmt, -1, 64)
+	stream.SetBuffer(buf)
+	stream.WriteRaw(`"`)
+}
+
+func marshalTimestamp(timestamp model.Time, stream *json.Stream) {
+	t := int64(timestamp)
+	// Write out the timestamp as a float divided by 1000.
+	// This is ~3x faster than converting to a float.
+	if t < 0 {
+		stream.WriteRaw(`-`)
+		t = -t
+	}
+	stream.WriteInt64(t / 1000)
+	fraction := t % 1000
+	if fraction != 0 {
+		stream.WriteRaw(`.`)
+		if fraction < 100 {
+			stream.WriteRaw(`0`)
+		}
+		if fraction < 10 {
+			stream.WriteRaw(`0`)
+		}
+		stream.WriteInt64(fraction)
+	}
+}
+
+func unmarshalHistogramBucket(iter *json.Iterator) (*model.HistogramBucket, error) {
+	b := model.HistogramBucket{}
+	if !iter.ReadArray() {
+		return nil, errors.New("HistogramBucket must be [boundaries, lower, upper, count]")
+	}
+	boundaries, err := iter.ReadNumber().Int64()
+	if err != nil {
+		return nil, err
+	}
+	b.Boundaries = int32(boundaries)
+	if !iter.ReadArray() {
+		return nil, errors.New("HistogramBucket must be [boundaries, lower, upper, count]")
+	}
+	f, err := strconv.ParseFloat(iter.ReadString(), 64)
+	if err != nil {
+		return nil, err
+	}
+	b.Lower = model.FloatString(f)
+	if !iter.ReadArray() {
+		return nil, errors.New("HistogramBucket must be [boundaries, lower, upper, count]")
+	}
+	f, err = strconv.ParseFloat(iter.ReadString(), 64)
+	if err != nil {
+		return nil, err
+	}
+	b.Upper = model.FloatString(f)
+	if !iter.ReadArray() {
+		return nil, errors.New("HistogramBucket must be [boundaries, lower, upper, count]")
+	}
+	f, err = strconv.ParseFloat(iter.ReadString(), 64)
+	if err != nil {
+		return nil, err
+	}
+	b.Count = model.FloatString(f)
+	if iter.ReadArray() {
+		return nil, errors.New("HistogramBucket has too many values, must be [boundaries, lower, upper, count]")
+	}
+	return &b, nil
+}
+
+// marshalHistogramBucket writes something like: [ 3, "-0.25", "0.25", "3"]
+// See marshalHistogram to understand what the numbers mean
+func marshalHistogramBucket(b model.HistogramBucket, stream *json.Stream) {
+	stream.WriteArrayStart()
+	stream.WriteInt32(b.Boundaries)
+	stream.WriteMore()
+	marshalFloat(float64(b.Lower), stream)
+	stream.WriteMore()
+	marshalFloat(float64(b.Upper), stream)
+	stream.WriteMore()
+	marshalFloat(float64(b.Count), stream)
+	stream.WriteArrayEnd()
+}
+
+// marshalHistogram writes something like:
+//
+//	{
+//	    "count": "42",
+//	    "sum": "34593.34",
+//	    "buckets": [
+//	      [ 3, "-0.25", "0.25", "3"],
+//	      [ 0, "0.25", "0.5", "12"],
+//	      [ 0, "0.5", "1", "21"],
+//	      [ 0, "2", "4", "6"]
+//	    ]
+//	}
+//
+// The 1st element in each bucket array determines if the boundaries are
+// inclusive (AKA closed) or exclusive (AKA open):
+//
+//	0: lower exclusive, upper inclusive
+//	1: lower inclusive, upper exclusive
+//	2: both exclusive
+//	3: both inclusive
+//
+// The 2nd and 3rd elements are the lower and upper boundary. The 4th element is
+// the bucket count.
+func marshalHistogram(h model.SampleHistogram, stream *json.Stream) {
+	stream.WriteObjectStart()
+	stream.WriteObjectField(`count`)
+	marshalFloat(float64(h.Count), stream)
+	stream.WriteMore()
+	stream.WriteObjectField(`sum`)
+	marshalFloat(float64(h.Sum), stream)
+
+	bucketFound := false
+	for _, bucket := range h.Buckets {
+		if bucket.Count == 0 {
+			continue // No need to expose empty buckets in JSON.
+		}
+		stream.WriteMore()
+		if !bucketFound {
+			stream.WriteObjectField(`buckets`)
+			stream.WriteArrayStart()
+		}
+		bucketFound = true
+		marshalHistogramBucket(*bucket, stream)
+	}
+	if bucketFound {
+		stream.WriteArrayEnd()
+	}
+	stream.WriteObjectEnd()
+}
+
+func marshalJSONIsEmpty(ptr unsafe.Pointer) bool {
+	return false
+}
+
+const (
+	apiPrefix = "/api/v1"
+
+	epAlerts          = apiPrefix + "/alerts"
+	epAlertManagers   = apiPrefix + "/alertmanagers"
+	epQuery           = apiPrefix + "/query"
+	epQueryRange      = apiPrefix + "/query_range"
+	epQueryExemplars  = apiPrefix + "/query_exemplars"
+	epLabels          = apiPrefix + "/labels"
+	epLabelValues     = apiPrefix + "/label/:name/values"
+	epSeries          = apiPrefix + "/series"
+	epTargets         = apiPrefix + "/targets"
+	epTargetsMetadata = apiPrefix + "/targets/metadata"
+	epMetadata        = apiPrefix + "/metadata"
+	epRules           = apiPrefix + "/rules"
+	epSnapshot        = apiPrefix + "/admin/tsdb/snapshot"
+	epDeleteSeries    = apiPrefix + "/admin/tsdb/delete_series"
+	epCleanTombstones = apiPrefix + "/admin/tsdb/clean_tombstones"
+	epConfig          = apiPrefix + "/status/config"
+	epFlags           = apiPrefix + "/status/flags"
+	epBuildinfo       = apiPrefix + "/status/buildinfo"
+	epRuntimeinfo     = apiPrefix + "/status/runtimeinfo"
+	epTSDB            = apiPrefix + "/status/tsdb"
+	epWalReplay       = apiPrefix + "/status/walreplay"
+)
+
+// AlertState models the state of an alert.
+type AlertState string
+
+// ErrorType models the different API error types.
+type ErrorType string
+
+// HealthStatus models the health status of a scrape target.
+type HealthStatus string
+
+// RuleType models the type of a rule.
+type RuleType string
+
+// RuleHealth models the health status of a rule.
+type RuleHealth string
+
+// MetricType models the type of a metric.
+type MetricType string
+
+const (
+	// Possible values for AlertState.
+	AlertStateFiring   AlertState = "firing"
+	AlertStateInactive AlertState = "inactive"
+	AlertStatePending  AlertState = "pending"
+
+	// Possible values for ErrorType.
+	ErrBadData     ErrorType = "bad_data"
+	ErrTimeout     ErrorType = "timeout"
+	ErrCanceled    ErrorType = "canceled"
+	ErrExec        ErrorType = "execution"
+	ErrBadResponse ErrorType = "bad_response"
+	ErrServer      ErrorType = "server_error"
+	ErrClient      ErrorType = "client_error"
+
+	// Possible values for HealthStatus.
+	HealthGood    HealthStatus = "up"
+	HealthUnknown HealthStatus = "unknown"
+	HealthBad     HealthStatus = "down"
+
+	// Possible values for RuleType.
+	RuleTypeRecording RuleType = "recording"
+	RuleTypeAlerting  RuleType = "alerting"
+
+	// Possible values for RuleHealth.
+	RuleHealthGood    = "ok"
+	RuleHealthUnknown = "unknown"
+	RuleHealthBad     = "err"
+
+	// Possible values for MetricType
+	MetricTypeCounter        MetricType = "counter"
+	MetricTypeGauge          MetricType = "gauge"
+	MetricTypeHistogram      MetricType = "histogram"
+	MetricTypeGaugeHistogram MetricType = "gaugehistogram"
+	MetricTypeSummary        MetricType = "summary"
+	MetricTypeInfo           MetricType = "info"
+	MetricTypeStateset       MetricType = "stateset"
+	MetricTypeUnknown        MetricType = "unknown"
+)
+
+// Error is an error returned by the API.
+type Error struct {
+	Type   ErrorType
+	Msg    string
+	Detail string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s: %s", e.Type, e.Msg)
+}
+
+// Range represents a sliced time range.
+type Range struct {
+	// The boundaries of the time range.
+	Start, End time.Time
+	// The maximum time between two slices within the boundaries.
+	Step time.Duration
+}
+
+// API provides bindings for Prometheus's v1 API.
+type API interface {
+	// Alerts returns a list of all active alerts.
+	Alerts(ctx context.Context) (AlertsResult, error)
+	// AlertManagers returns an overview of the current state of the Prometheus alert manager discovery.
+	AlertManagers(ctx context.Context) (AlertManagersResult, error)
+	// CleanTombstones removes the deleted data from disk and cleans up the existing tombstones.
+	CleanTombstones(ctx context.Context) error
+	// Config returns the current Prometheus configuration.
+	Config(ctx context.Context) (ConfigResult, error)
+	// DeleteSeries deletes data for a selection of series in a time range.
+	DeleteSeries(ctx context.Context, matches []string, startTime, endTime time.Time) error
+	// Flags returns the flag values that Prometheus was launched with.
+	Flags(ctx context.Context) (FlagsResult, error)
+	// LabelNames returns the unique label names present in the block in sorted order by given time range and matchers.
+	LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]string, Warnings, error)
+	// LabelValues performs a query for the values of the given label, time range and matchers.
+	LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, error)
+	// Query performs a query for the given time.
+	Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, error)
+	// QueryRange performs a query for the given range.
+	QueryRange(ctx context.Context, query string, r Range, opts ...Option) (model.Value, Warnings, error)
+	// QueryExemplars performs a query for exemplars by the given query and time range.
+	QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]ExemplarQueryResult, error)
+	// Buildinfo returns various build information properties about the Prometheus server
+	Buildinfo(ctx context.Context) (BuildinfoResult, error)
+	// Runtimeinfo returns the various runtime information properties about the Prometheus server.
+	Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error)
+	// Series finds series by label matchers.
+	Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, error)
+	// Snapshot creates a snapshot of all current data into snapshots/<datetime>-<rand>
+	// under the TSDB's data directory and returns the directory as response.
+	Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error)
+	// Rules returns a list of alerting and recording rules that are currently loaded.
+	Rules(ctx context.Context) (RulesResult, error)
+	// Targets returns an overview of the current state of the Prometheus target discovery.
+	Targets(ctx context.Context) (TargetsResult, error)
+	// TargetsMetadata returns metadata about metrics currently scraped by the target.
+	TargetsMetadata(ctx context.Context, matchTarget, metric, limit string) ([]MetricMetadata, error)
+	// Metadata returns metadata about metrics currently scraped by the metric name.
+	Metadata(ctx context.Context, metric, limit string) (map[string][]Metadata, error)
+	// TSDB returns the cardinality statistics.
+	TSDB(ctx context.Context, opts ...Option) (TSDBResult, error)
+	// WalReplay returns the current replay status of the wal.
+	WalReplay(ctx context.Context) (WalReplayStatus, error)
+}
+
+// AlertsResult contains the result from querying the alerts endpoint.
+type AlertsResult struct {
+	Alerts []Alert `json:"alerts"`
+}
+
+// AlertManagersResult contains the result from querying the alertmanagers endpoint.
+type AlertManagersResult struct {
+	Active  []AlertManager `json:"activeAlertManagers"`
+	Dropped []AlertManager `json:"droppedAlertManagers"`
+}
+
+// AlertManager models a configured Alert Manager.
+type AlertManager struct {
+	URL string `json:"url"`
+}
+
+// ConfigResult contains the result from querying the config endpoint.
+type ConfigResult struct {
+	YAML string `json:"yaml"`
+}
+
+// FlagsResult contains the result from querying the flag endpoint.
+type FlagsResult map[string]string
+
+// BuildinfoResult contains the results from querying the buildinfo endpoint.
+type BuildinfoResult struct {
+	Version   string `json:"version"`
+	Revision  string `json:"revision"`
+	Branch    string `json:"branch"`
+	BuildUser string `json:"buildUser"`
+	BuildDate string `json:"buildDate"`
+	GoVersion string `json:"goVersion"`
+}
+
+// RuntimeinfoResult contains the result from querying the runtimeinfo endpoint.
+type RuntimeinfoResult struct {
+	StartTime           time.Time `json:"startTime"`
+	CWD                 string    `json:"CWD"`
+	ReloadConfigSuccess bool      `json:"reloadConfigSuccess"`
+	LastConfigTime      time.Time `json:"lastConfigTime"`
+	CorruptionCount     int       `json:"corruptionCount"`
+	GoroutineCount      int       `json:"goroutineCount"`
+	GOMAXPROCS          int       `json:"GOMAXPROCS"`
+	GOGC                string    `json:"GOGC"`
+	GODEBUG             string    `json:"GODEBUG"`
+	StorageRetention    string    `json:"storageRetention"`
+}
+
+// SnapshotResult contains the result from querying the snapshot endpoint.
+type SnapshotResult struct {
+	Name string `json:"name"`
+}
+
+// RulesResult contains the result from querying the rules endpoint.
+type RulesResult struct {
+	Groups []RuleGroup `json:"groups"`
+}
+
+// RuleGroup models a rule group that contains a set of recording and alerting rules.
+type RuleGroup struct {
+	Name     string  `json:"name"`
+	File     string  `json:"file"`
+	Interval float64 `json:"interval"`
+	Rules    Rules   `json:"rules"`
+}
+
+// Recording and alerting rules are stored in the same slice to preserve the order
+// that rules are returned in by the API.
+//
+// Rule types can be determined using a type switch:
+//
+//	switch v := rule.(type) {
+//	case RecordingRule:
+//		fmt.Print("got a recording rule")
+//	case AlertingRule:
+//		fmt.Print("got a alerting rule")
+//	default:
+//		fmt.Printf("unknown rule type %s", v)
+//	}
+type Rules []interface{}
+
+// AlertingRule models a alerting rule.
+type AlertingRule struct {
+	Name           string         `json:"name"`
+	Query          string         `json:"query"`
+	Duration       float64        `json:"duration"`
+	Labels         model.LabelSet `json:"labels"`
+	Annotations    model.LabelSet `json:"annotations"`
+	Alerts         []*Alert       `json:"alerts"`
+	Health         RuleHealth     `json:"health"`
+	LastError      string         `json:"lastError,omitempty"`
+	EvaluationTime float64        `json:"evaluationTime"`
+	LastEvaluation time.Time      `json:"lastEvaluation"`
+	State          string         `json:"state"`
+}
+
+// RecordingRule models a recording rule.
+type RecordingRule struct {
+	Name           string         `json:"name"`
+	Query          string         `json:"query"`
+	Labels         model.LabelSet `json:"labels,omitempty"`
+	Health         RuleHealth     `json:"health"`
+	LastError      string         `json:"lastError,omitempty"`
+	EvaluationTime float64        `json:"evaluationTime"`
+	LastEvaluation time.Time      `json:"lastEvaluation"`
+}
+
+// Alert models an active alert.
+type Alert struct {
+	ActiveAt    time.Time `json:"activeAt"`
+	Annotations model.LabelSet
+	Labels      model.LabelSet
+	State       AlertState
+	Value       string
+}
+
+// TargetsResult contains the result from querying the targets endpoint.
+type TargetsResult struct {
+	Active  []ActiveTarget  `json:"activeTargets"`
+	Dropped []DroppedTarget `json:"droppedTargets"`
+}
+
+// ActiveTarget models an active Prometheus scrape target.
+type ActiveTarget struct {
+	DiscoveredLabels   map[string]string `json:"discoveredLabels"`
+	Labels             model.LabelSet    `json:"labels"`
+	ScrapePool         string            `json:"scrapePool"`
+	ScrapeURL          string            `json:"scrapeUrl"`
+	GlobalURL          string            `json:"globalUrl"`
+	LastError          string            `json:"lastError"`
+	LastScrape         time.Time         `json:"lastScrape"`
+	LastScrapeDuration float64           `json:"lastScrapeDuration"`
+	Health             HealthStatus      `json:"health"`
+}
+
+// DroppedTarget models a dropped Prometheus scrape target.
+type DroppedTarget struct {
+	DiscoveredLabels map[string]string `json:"discoveredLabels"`
+}
+
+// MetricMetadata models the metadata of a metric with its scrape target and name.
+type MetricMetadata struct {
+	Target map[string]string `json:"target"`
+	Metric string            `json:"metric,omitempty"`
+	Type   MetricType        `json:"type"`
+	Help   string            `json:"help"`
+	Unit   string            `json:"unit"`
+}
+
+// Metadata models the metadata of a metric.
+type Metadata struct {
+	Type MetricType `json:"type"`
+	Help string     `json:"help"`
+	Unit string     `json:"unit"`
+}
+
+// queryResult contains result data for a query.
+type queryResult struct {
+	Type   model.ValueType `json:"resultType"`
+	Result interface{}     `json:"result"`
+
+	// The decoded value.
+	v model.Value
+}
+
+// TSDBResult contains the result from querying the tsdb endpoint.
+type TSDBResult struct {
+	HeadStats                   TSDBHeadStats `json:"headStats"`
+	SeriesCountByMetricName     []Stat        `json:"seriesCountByMetricName"`
+	LabelValueCountByLabelName  []Stat        `json:"labelValueCountByLabelName"`
+	MemoryInBytesByLabelName    []Stat        `json:"memoryInBytesByLabelName"`
+	SeriesCountByLabelValuePair []Stat        `json:"seriesCountByLabelValuePair"`
+}
+
+// TSDBHeadStats contains TSDB stats
+type TSDBHeadStats struct {
+	NumSeries     int `json:"numSeries"`
+	NumLabelPairs int `json:"numLabelPairs"`
+	ChunkCount    int `json:"chunkCount"`
+	MinTime       int `json:"minTime"`
+	MaxTime       int `json:"maxTime"`
+}
+
+// WalReplayStatus represents the wal replay status.
+type WalReplayStatus struct {
+	Min     int `json:"min"`
+	Max     int `json:"max"`
+	Current int `json:"current"`
+}
+
+// Stat models information about statistic value.
+type Stat struct {
+	Name  string `json:"name"`
+	Value uint64 `json:"value"`
+}
+
+func (rg *RuleGroup) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Name     string            `json:"name"`
+		File     string            `json:"file"`
+		Interval float64           `json:"interval"`
+		Rules    []json.RawMessage `json:"rules"`
+	}{}
+
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+
+	rg.Name = v.Name
+	rg.File = v.File
+	rg.Interval = v.Interval
+
+	for _, rule := range v.Rules {
+		alertingRule := AlertingRule{}
+		if err := json.Unmarshal(rule, &alertingRule); err == nil {
+			rg.Rules = append(rg.Rules, alertingRule)
+			continue
+		}
+		recordingRule := RecordingRule{}
+		if err := json.Unmarshal(rule, &recordingRule); err == nil {
+			rg.Rules = append(rg.Rules, recordingRule)
+			continue
+		}
+		return errors.New("failed to decode JSON into an alerting or recording rule")
+	}
+
+	return nil
+}
+
+func (r *AlertingRule) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Type string `json:"type"`
+	}{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	if v.Type == "" {
+		return errors.New("type field not present in rule")
+	}
+	if v.Type != string(RuleTypeAlerting) {
+		return fmt.Errorf("expected rule of type %s but got %s", string(RuleTypeAlerting), v.Type)
+	}
+
+	rule := struct {
+		Name           string         `json:"name"`
+		Query          string         `json:"query"`
+		Duration       float64        `json:"duration"`
+		Labels         model.LabelSet `json:"labels"`
+		Annotations    model.LabelSet `json:"annotations"`
+		Alerts         []*Alert       `json:"alerts"`
+		Health         RuleHealth     `json:"health"`
+		LastError      string         `json:"lastError,omitempty"`
+		EvaluationTime float64        `json:"evaluationTime"`
+		LastEvaluation time.Time      `json:"lastEvaluation"`
+		State          string         `json:"state"`
+	}{}
+	if err := json.Unmarshal(b, &rule); err != nil {
+		return err
+	}
+	r.Health = rule.Health
+	r.Annotations = rule.Annotations
+	r.Name = rule.Name
+	r.Query = rule.Query
+	r.Alerts = rule.Alerts
+	r.Duration = rule.Duration
+	r.Labels = rule.Labels
+	r.LastError = rule.LastError
+	r.EvaluationTime = rule.EvaluationTime
+	r.LastEvaluation = rule.LastEvaluation
+	r.State = rule.State
+
+	return nil
+}
+
+func (r *RecordingRule) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Type string `json:"type"`
+	}{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	if v.Type == "" {
+		return errors.New("type field not present in rule")
+	}
+	if v.Type != string(RuleTypeRecording) {
+		return fmt.Errorf("expected rule of type %s but got %s", string(RuleTypeRecording), v.Type)
+	}
+
+	rule := struct {
+		Name           string         `json:"name"`
+		Query          string         `json:"query"`
+		Labels         model.LabelSet `json:"labels,omitempty"`
+		Health         RuleHealth     `json:"health"`
+		LastError      string         `json:"lastError,omitempty"`
+		EvaluationTime float64        `json:"evaluationTime"`
+		LastEvaluation time.Time      `json:"lastEvaluation"`
+	}{}
+	if err := json.Unmarshal(b, &rule); err != nil {
+		return err
+	}
+	r.Health = rule.Health
+	r.Labels = rule.Labels
+	r.Name = rule.Name
+	r.LastError = rule.LastError
+	r.Query = rule.Query
+	r.EvaluationTime = rule.EvaluationTime
+	r.LastEvaluation = rule.LastEvaluation
+
+	return nil
+}
+
+func (qr *queryResult) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Type   model.ValueType `json:"resultType"`
+		Result json.RawMessage `json:"result"`
+	}{}
+
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	switch v.Type {
+	case model.ValScalar:
+		var sv model.Scalar
+		err = json.Unmarshal(v.Result, &sv)
+		qr.v = &sv
+
+	case model.ValVector:
+		var vv model.Vector
+		err = json.Unmarshal(v.Result, &vv)
+		qr.v = vv
+
+	case model.ValMatrix:
+		var mv model.Matrix
+		err = json.Unmarshal(v.Result, &mv)
+		qr.v = mv
+
+	default:
+		err = fmt.Errorf("unexpected value type %q", v.Type)
+	}
+	return err
+}
+
+// Exemplar is additional information associated with a time series.
+type Exemplar struct {
+	Labels    model.LabelSet    `json:"labels"`
+	Value     model.SampleValue `json:"value"`
+	Timestamp model.Time        `json:"timestamp"`
+}
+
+type ExemplarQueryResult struct {
+	SeriesLabels model.LabelSet `json:"seriesLabels"`
+	Exemplars    []Exemplar     `json:"exemplars"`
+}
+
+// NewAPI returns a new API for the client.
+//
+// It is safe to use the returned API from multiple goroutines.
+func NewAPI(c api.Client) API {
+	return &httpAPI{
+		client: &apiClientImpl{
+			client: c,
+		},
+	}
+}
+
+type httpAPI struct {
+	client apiClient
+}
+
+func (h *httpAPI) Alerts(ctx context.Context) (AlertsResult, error) {
+	u := h.client.URL(epAlerts, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return AlertsResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return AlertsResult{}, err
+	}
+
+	var res AlertsResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) AlertManagers(ctx context.Context) (AlertManagersResult, error) {
+	u := h.client.URL(epAlertManagers, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return AlertManagersResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return AlertManagersResult{}, err
+	}
+
+	var res AlertManagersResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) CleanTombstones(ctx context.Context) error {
+	u := h.client.URL(epCleanTombstones, nil)
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	_, _, _, err = h.client.Do(ctx, req)
+	return err
+}
+
+func (h *httpAPI) Config(ctx context.Context) (ConfigResult, error) {
+	u := h.client.URL(epConfig, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return ConfigResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return ConfigResult{}, err
+	}
+
+	var res ConfigResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) DeleteSeries(ctx context.Context, matches []string, startTime, endTime time.Time) error {
+	u := h.client.URL(epDeleteSeries, nil)
+	q := u.Query()
+
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
+
+	if !startTime.IsZero() {
+		q.Set("start", formatTime(startTime))
+	}
+	if !endTime.IsZero() {
+		q.Set("end", formatTime(endTime))
+	}
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	_, _, _, err = h.client.Do(ctx, req)
+	return err
+}
+
+func (h *httpAPI) Flags(ctx context.Context) (FlagsResult, error) {
+	u := h.client.URL(epFlags, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return FlagsResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return FlagsResult{}, err
+	}
+
+	var res FlagsResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) Buildinfo(ctx context.Context) (BuildinfoResult, error) {
+	u := h.client.URL(epBuildinfo, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return BuildinfoResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return BuildinfoResult{}, err
+	}
+
+	var res BuildinfoResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error) {
+	u := h.client.URL(epRuntimeinfo, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return RuntimeinfoResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return RuntimeinfoResult{}, err
+	}
+
+	var res RuntimeinfoResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]string, Warnings, error) {
+	u := h.client.URL(epLabels, nil)
+	q := addOptionalURLParams(u.Query(), opts)
+
+	if !startTime.IsZero() {
+		q.Set("start", formatTime(startTime))
+	}
+	if !endTime.IsZero() {
+		q.Set("end", formatTime(endTime))
+	}
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
+
+	_, body, w, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return nil, w, err
+	}
+	var labelNames []string
+	err = json.Unmarshal(body, &labelNames)
+	return labelNames, w, err
+}
+
+func (h *httpAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, error) {
+	u := h.client.URL(epLabelValues, map[string]string{"name": label})
+	q := addOptionalURLParams(u.Query(), opts)
+
+	if !startTime.IsZero() {
+		q.Set("start", formatTime(startTime))
+	}
+	if !endTime.IsZero() {
+		q.Set("end", formatTime(endTime))
+	}
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	_, body, w, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, w, err
+	}
+	var labelValues model.LabelValues
+	err = json.Unmarshal(body, &labelValues)
+	return labelValues, w, err
+}
+
+// StatsValue is a type for `stats` query parameter.
+type StatsValue string
+
+// AllStatsValue is the query parameter value to return all the query statistics.
+const (
+	AllStatsValue StatsValue = "all"
+)
+
+type apiOptions struct {
+	timeout       time.Duration
+	lookbackDelta time.Duration
+	stats         StatsValue
+	limit         uint64
+}
+
+type Option func(c *apiOptions)
+
+// WithTimeout can be used to provide an optional query evaluation timeout for Query and QueryRange.
+// https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
+func WithTimeout(timeout time.Duration) Option {
+	return func(o *apiOptions) {
+		o.timeout = timeout
+	}
+}
+
+// WithLookbackDelta can be used to provide an optional query lookback delta for Query and QueryRange.
+// This URL variable is not documented on Prometheus HTTP API.
+// https://github.com/prometheus/prometheus/blob/e04913aea2792a5c8bc7b3130c389ca1b027dd9b/promql/engine.go#L162-L167
+func WithLookbackDelta(lookbackDelta time.Duration) Option {
+	return func(o *apiOptions) {
+		o.lookbackDelta = lookbackDelta
+	}
+}
+
+// WithStats can be used to provide an optional per step stats for Query and QueryRange.
+// This URL variable is not documented on Prometheus HTTP API.
+// https://github.com/prometheus/prometheus/blob/e04913aea2792a5c8bc7b3130c389ca1b027dd9b/promql/engine.go#L162-L167
+func WithStats(stats StatsValue) Option {
+	return func(o *apiOptions) {
+		o.stats = stats
+	}
+}
+
+// WithLimit provides an optional maximum number of returned entries for APIs that support limit parameter
+// e.g. https://prometheus.io/docs/prometheus/latest/querying/api/#instant-querie:~:text=%3A%20End%20timestamp.-,limit%3D%3Cnumber%3E,-%3A%20Maximum%20number%20of
+func WithLimit(limit uint64) Option {
+	return func(o *apiOptions) {
+		o.limit = limit
+	}
+}
+
+func addOptionalURLParams(q url.Values, opts []Option) url.Values {
+	opt := &apiOptions{}
+	for _, o := range opts {
+		o(opt)
+	}
+
+	if opt.timeout > 0 {
+		q.Set("timeout", opt.timeout.String())
+	}
+
+	if opt.lookbackDelta > 0 {
+		q.Set("lookback_delta", opt.lookbackDelta.String())
+	}
+
+	if opt.stats != "" {
+		q.Set("stats", string(opt.stats))
+	}
+
+	if opt.limit > 0 {
+		q.Set("limit", strconv.FormatUint(opt.limit, 10))
+	}
+
+	return q
+}
+
+func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, error) {
+	u := h.client.URL(epQuery, nil)
+	q := addOptionalURLParams(u.Query(), opts)
+
+	q.Set("query", query)
+	if !ts.IsZero() {
+		q.Set("time", formatTime(ts))
+	}
+
+	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return nil, warnings, err
+	}
+
+	var qres queryResult
+	return qres.v, warnings, json.Unmarshal(body, &qres)
+}
+
+func (h *httpAPI) QueryRange(ctx context.Context, query string, r Range, opts ...Option) (model.Value, Warnings, error) {
+	u := h.client.URL(epQueryRange, nil)
+	q := addOptionalURLParams(u.Query(), opts)
+
+	q.Set("query", query)
+	q.Set("start", formatTime(r.Start))
+	q.Set("end", formatTime(r.End))
+	q.Set("step", strconv.FormatFloat(r.Step.Seconds(), 'f', -1, 64))
+
+	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return nil, warnings, err
+	}
+
+	var qres queryResult
+	return qres.v, warnings, json.Unmarshal(body, &qres)
+}
+
+func (h *httpAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, error) {
+	u := h.client.URL(epSeries, nil)
+	q := addOptionalURLParams(u.Query(), opts)
+
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
+
+	if !startTime.IsZero() {
+		q.Set("start", formatTime(startTime))
+	}
+	if !endTime.IsZero() {
+		q.Set("end", formatTime(endTime))
+	}
+
+	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return nil, warnings, err
+	}
+
+	var mset []model.LabelSet
+	return mset, warnings, json.Unmarshal(body, &mset)
+}
+
+func (h *httpAPI) Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error) {
+	u := h.client.URL(epSnapshot, nil)
+	q := u.Query()
+
+	q.Set("skip_head", strconv.FormatBool(skipHead))
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return SnapshotResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return SnapshotResult{}, err
+	}
+
+	var res SnapshotResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) Rules(ctx context.Context) (RulesResult, error) {
+	u := h.client.URL(epRules, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return RulesResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return RulesResult{}, err
+	}
+
+	var res RulesResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) Targets(ctx context.Context) (TargetsResult, error) {
+	u := h.client.URL(epTargets, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return TargetsResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return TargetsResult{}, err
+	}
+
+	var res TargetsResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) TargetsMetadata(ctx context.Context, matchTarget, metric, limit string) ([]MetricMetadata, error) {
+	u := h.client.URL(epTargetsMetadata, nil)
+	q := u.Query()
+
+	q.Set("match_target", matchTarget)
+	q.Set("metric", metric)
+	q.Set("limit", limit)
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []MetricMetadata
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]Metadata, error) {
+	u := h.client.URL(epMetadata, nil)
+	q := u.Query()
+
+	q.Set("metric", metric)
+	q.Set("limit", limit)
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var res map[string][]Metadata
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) TSDB(ctx context.Context, opts ...Option) (TSDBResult, error) {
+	u := h.client.URL(epTSDB, nil)
+	q := addOptionalURLParams(u.Query(), opts)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return TSDBResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return TSDBResult{}, err
+	}
+
+	var res TSDBResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) WalReplay(ctx context.Context) (WalReplayStatus, error) {
+	u := h.client.URL(epWalReplay, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return WalReplayStatus{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return WalReplayStatus{}, err
+	}
+
+	var res WalReplayStatus
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]ExemplarQueryResult, error) {
+	u := h.client.URL(epQueryExemplars, nil)
+	q := u.Query()
+
+	q.Set("query", query)
+	if !startTime.IsZero() {
+		q.Set("start", formatTime(startTime))
+	}
+	if !endTime.IsZero() {
+		q.Set("end", formatTime(endTime))
+	}
+
+	_, body, _, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []ExemplarQueryResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+// Warnings is an array of non critical errors
+type Warnings []string
+
+// apiClient wraps a regular client and processes successful API responses.
+// Successful also includes responses that errored at the API level.
+type apiClient interface {
+	URL(ep string, args map[string]string) *url.URL
+	Do(context.Context, *http.Request) (*http.Response, []byte, Warnings, error)
+	DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error)
+}
+
+type apiClientImpl struct {
+	client api.Client
+}
+
+type apiResponse struct {
+	Status    string          `json:"status"`
+	Data      json.RawMessage `json:"data"`
+	ErrorType ErrorType       `json:"errorType"`
+	Error     string          `json:"error"`
+	Warnings  []string        `json:"warnings,omitempty"`
+}
+
+func apiError(code int) bool {
+	// These are the codes that Prometheus sends when it returns an error.
+	return code == http.StatusUnprocessableEntity || code == http.StatusBadRequest
+}
+
+func errorTypeAndMsgFor(resp *http.Response) (ErrorType, string) {
+	switch resp.StatusCode / 100 {
+	case 4:
+		return ErrClient, fmt.Sprintf("client error: %d", resp.StatusCode)
+	case 5:
+		return ErrServer, fmt.Sprintf("server error: %d", resp.StatusCode)
+	}
+	return ErrBadResponse, fmt.Sprintf("bad response code %d", resp.StatusCode)
+}
+
+func (h *apiClientImpl) URL(ep string, args map[string]string) *url.URL {
+	return h.client.URL(ep, args)
+}
+
+func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, Warnings, error) {
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return resp, body, nil, err
+	}
+
+	code := resp.StatusCode
+
+	if code/100 != 2 && !apiError(code) {
+		errorType, errorMsg := errorTypeAndMsgFor(resp)
+		return resp, body, nil, &Error{
+			Type:   errorType,
+			Msg:    errorMsg,
+			Detail: string(body),
+		}
+	}
+
+	var result apiResponse
+
+	if http.StatusNoContent != code {
+		if jsonErr := json.Unmarshal(body, &result); jsonErr != nil {
+			return resp, body, nil, &Error{
+				Type: ErrBadResponse,
+				Msg:  jsonErr.Error(),
+			}
+		}
+	}
+
+	if apiError(code) && result.Status == "success" {
+		err = &Error{
+			Type: ErrBadResponse,
+			Msg:  "inconsistent body for response code",
+		}
+	}
+
+	if result.Status == "error" {
+		err = &Error{
+			Type: result.ErrorType,
+			Msg:  result.Error,
+		}
+	}
+
+	return resp, []byte(result.Data), result.Warnings, err
+}
+
+// DoGetFallback will attempt to do the request as-is, and on a 405 or 501 it
+// will fallback to a GET request.
+func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error) {
+	encodedArgs := args.Encode()
+	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(encodedArgs))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// Following comment originates from https://pkg.go.dev/net/http#Transport
+	// Transport only retries a request upon encountering a network error if the request is
+	// idempotent and either has no body or has its Request.GetBody defined. HTTP requests
+	// are considered idempotent if they have HTTP methods GET, HEAD, OPTIONS, or TRACE; or
+	// if their Header map contains an "Idempotency-Key" or "X-Idempotency-Key" entry. If the
+	// idempotency key value is a zero-length slice, the request is treated as idempotent but
+	// the header is not sent on the wire.
+	req.Header["Idempotency-Key"] = nil
+
+	resp, body, warnings, err := h.Do(ctx, req)
+	if resp != nil && (resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented) {
+		u.RawQuery = encodedArgs
+		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, nil, warnings, err
+		}
+		return h.Do(ctx, req)
+	}
+	return resp, body, warnings, err
+}
+
+func formatTime(t time.Time) string {
+	return strconv.FormatFloat(float64(t.Unix())+float64(t.Nanosecond())/1e9, 'f', -1, 64)
+}

--- a/vendor/github.com/prometheus/client_golang/api/prometheus/v1/api.go
+++ b/vendor/github.com/prometheus/client_golang/api/prometheus/v1/api.go
@@ -380,7 +380,9 @@ const (
 	epBuildinfo       = apiPrefix + "/status/buildinfo"
 	epRuntimeinfo     = apiPrefix + "/status/runtimeinfo"
 	epTSDB            = apiPrefix + "/status/tsdb"
+	epTSDBBlocks      = apiPrefix + "/status/tsdb/blocks"
 	epWalReplay       = apiPrefix + "/status/walreplay"
+	epFormatQuery     = apiPrefix + "/format_query"
 )
 
 // AlertState models the state of an alert.
@@ -475,7 +477,7 @@ type API interface {
 	// Flags returns the flag values that Prometheus was launched with.
 	Flags(ctx context.Context) (FlagsResult, error)
 	// LabelNames returns the unique label names present in the block in sorted order by given time range and matchers.
-	LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]string, Warnings, error)
+	LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelNames, Warnings, error)
 	// LabelValues performs a query for the values of the given label, time range and matchers.
 	LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, error)
 	// Query performs a query for the given time.
@@ -494,7 +496,7 @@ type API interface {
 	// under the TSDB's data directory and returns the directory as response.
 	Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error)
 	// Rules returns a list of alerting and recording rules that are currently loaded.
-	Rules(ctx context.Context) (RulesResult, error)
+	Rules(ctx context.Context, matches []string) (RulesResult, error)
 	// Targets returns an overview of the current state of the Prometheus target discovery.
 	Targets(ctx context.Context) (TargetsResult, error)
 	// TargetsMetadata returns metadata about metrics currently scraped by the target.
@@ -503,8 +505,12 @@ type API interface {
 	Metadata(ctx context.Context, metric, limit string) (map[string][]Metadata, error)
 	// TSDB returns the cardinality statistics.
 	TSDB(ctx context.Context, opts ...Option) (TSDBResult, error)
+	// TSDBBlocks returns the list of currently loaded TSDB blocks and their metadata.
+	TSDBBlocks(ctx context.Context) (TSDBBlocksResult, error)
 	// WalReplay returns the current replay status of the wal.
 	WalReplay(ctx context.Context) (WalReplayStatus, error)
+	// FormatQuery formats a PromQL expression in a prettified way.
+	FormatQuery(ctx context.Context, query string) (string, error)
 }
 
 // AlertsResult contains the result from querying the alerts endpoint.
@@ -586,7 +592,7 @@ type RuleGroup struct {
 //	default:
 //		fmt.Printf("unknown rule type %s", v)
 //	}
-type Rules []interface{}
+type Rules []any
 
 // AlertingRule models a alerting rule.
 type AlertingRule struct {
@@ -666,7 +672,7 @@ type Metadata struct {
 // queryResult contains result data for a query.
 type queryResult struct {
 	Type   model.ValueType `json:"resultType"`
-	Result interface{}     `json:"result"`
+	Result any             `json:"result"`
 
 	// The decoded value.
 	v model.Value
@@ -688,6 +694,40 @@ type TSDBHeadStats struct {
 	ChunkCount    int `json:"chunkCount"`
 	MinTime       int `json:"minTime"`
 	MaxTime       int `json:"maxTime"`
+}
+
+// TSDBBlocksResult contains the results from querying the tsdb blocks endpoint.
+type TSDBBlocksResult struct {
+	Status string         `json:"status"`
+	Data   TSDBBlocksData `json:"data"`
+}
+
+// TSDBBlocksData contains the metadata for the tsdb blocks.
+type TSDBBlocksData struct {
+	Blocks []TSDBBlocksBlockMetadata `json:"blocks"`
+}
+
+// TSDBBlocksBlockMetadata contains the metadata for a single tsdb block.
+type TSDBBlocksBlockMetadata struct {
+	Ulid       string               `json:"ulid"`
+	MinTime    int64                `json:"minTime"`
+	MaxTime    int64                `json:"maxTime"`
+	Stats      TSDBBlocksStats      `json:"stats"`
+	Compaction TSDBBlocksCompaction `json:"compaction"`
+	Version    int                  `json:"version"`
+}
+
+// TSDBBlocksStats contains block stats for a single tsdb block.
+type TSDBBlocksStats struct {
+	NumSamples int `json:"numSamples"`
+	NumSeries  int `json:"numSeries"`
+	NumChunks  int `json:"numChunks"`
+}
+
+// TSDBBlocksCompaction contains block compaction details for a single block.
+type TSDBBlocksCompaction struct {
+	Level   int      `json:"level"`
+	Sources []string `json:"sources"`
 }
 
 // WalReplayStatus represents the wal replay status.
@@ -1024,7 +1064,7 @@ func (h *httpAPI) Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error) {
 	return res, err
 }
 
-func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]string, Warnings, error) {
+func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelNames, Warnings, error) {
 	u := h.client.URL(epLabels, nil)
 	q := addOptionalURLParams(u.Query(), opts)
 
@@ -1042,7 +1082,7 @@ func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, e
 	if err != nil {
 		return nil, w, err
 	}
-	var labelNames []string
+	var labelNames model.LabelNames
 	err = json.Unmarshal(body, &labelNames)
 	return labelNames, w, err
 }
@@ -1235,8 +1275,15 @@ func (h *httpAPI) Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, 
 	return res, err
 }
 
-func (h *httpAPI) Rules(ctx context.Context) (RulesResult, error) {
+func (h *httpAPI) Rules(ctx context.Context, matches []string) (RulesResult, error) {
 	u := h.client.URL(epRules, nil)
+	q := u.Query()
+
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
+
+	u.RawQuery = q.Encode()
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
@@ -1340,6 +1387,24 @@ func (h *httpAPI) TSDB(ctx context.Context, opts ...Option) (TSDBResult, error) 
 	return res, err
 }
 
+func (h *httpAPI) TSDBBlocks(ctx context.Context) (TSDBBlocksResult, error) {
+	u := h.client.URL(epTSDBBlocks, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return TSDBBlocksResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return TSDBBlocksResult{}, err
+	}
+
+	var res TSDBBlocksResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
 func (h *httpAPI) WalReplay(ctx context.Context) (WalReplayStatus, error) {
 	u := h.client.URL(epWalReplay, nil)
 
@@ -1378,6 +1443,19 @@ func (h *httpAPI) QueryExemplars(ctx context.Context, query string, startTime, e
 	var res []ExemplarQueryResult
 	err = json.Unmarshal(body, &res)
 	return res, err
+}
+
+func (h *httpAPI) FormatQuery(ctx context.Context, query string) (string, error) {
+	u := h.client.URL(epFormatQuery, nil)
+	q := u.Query()
+	q.Set("query", query)
+
+	_, body, _, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
 }
 
 // Warnings is an array of non critical errors
@@ -1467,8 +1545,8 @@ func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Respon
 	return resp, []byte(result.Data), result.Warnings, err
 }
 
-// DoGetFallback will attempt to do the request as-is, and on a 405 or 501 it
-// will fallback to a GET request.
+// DoGetFallback will attempt to do the request as-is, and on a 403, 405, or
+// 501 it will fallback to a GET request.
 func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error) {
 	encodedArgs := args.Encode()
 	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(encodedArgs))
@@ -1486,7 +1564,7 @@ func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.
 	req.Header["Idempotency-Key"] = nil
 
 	resp, body, warnings, err := h.Do(ctx, req)
-	if resp != nil && (resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented) {
+	if resp != nil && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented) {
 		u.RawQuery = encodedArgs
 		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
 		if err != nil {

--- a/vendor/k8s.io/client-go/tools/internal/events/interfaces.go
+++ b/vendor/k8s.io/client-go/tools/internal/events/interfaces.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package internal is needed to break an import cycle: record.EventRecorderAdapter
+// needs this interface definition to implement it, but event.NewEventBroadcasterAdapter
+// needs record.NewBroadcaster. Therefore this interface cannot be in event/interfaces.go.
+package internal
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+)
+
+// EventRecorder knows how to record events on behalf of an EventSource.
+type EventRecorder interface {
+	// Eventf constructs an event from the given information and puts it in the queue for sending.
+	// 'regarding' is the object this event is about. Event will make a reference-- or you may also
+	// pass a reference to the object directly.
+	// 'related' is the secondary object for more complex actions. E.g. when regarding object triggers
+	// a creation or deletion of related object.
+	// 'type' of this event, and can be one of Normal, Warning. New types could be added in future
+	// 'reason' is the reason this event is generated. 'reason' should be short and unique; it
+	// should be in UpperCamelCase format (starting with a capital letter). "reason" will be used
+	// to automate handling of events, so imagine people writing switch statements to handle them.
+	// You want to make that easy.
+	// 'action' explains what happened with regarding/what action did the ReportingController
+	// (ReportingController is a type of a Controller reporting an Event, e.g. k8s.io/node-controller, k8s.io/kubelet.)
+	// take in regarding's name; it should be in UpperCamelCase format (starting with a capital letter).
+	// 'note' is intended to be human readable.
+	Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{})
+}
+
+// EventRecorderLogger extends EventRecorder such that a logger can
+// be set for methods in EventRecorder. Normally, those methods
+// uses the global default logger to record errors and debug messages.
+// If that is not desired, use WithLogger to provide a logger instance.
+type EventRecorderLogger interface {
+	EventRecorder
+
+	// WithLogger replaces the context used for logging. This is a cheap call
+	// and meant to be used for contextual logging:
+	//    recorder := ...
+	//    logger := klog.FromContext(ctx)
+	//    recorder.WithLogger(logger).Eventf(...)
+	WithLogger(logger klog.Logger) EventRecorderLogger
+}

--- a/vendor/k8s.io/client-go/tools/record/OWNERS
+++ b/vendor/k8s.io/client-go/tools/record/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-instrumentation-reviewers
+approvers:
+  - sig-instrumentation-approvers

--- a/vendor/k8s.io/client-go/tools/record/doc.go
+++ b/vendor/k8s.io/client-go/tools/record/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package record has all client logic for recording and reporting
+// "k8s.io/api/core/v1".Event events.
+package record

--- a/vendor/k8s.io/client-go/tools/record/event.go
+++ b/vendor/k8s.io/client-go/tools/record/event.go
@@ -1,0 +1,530 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package record
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	restclient "k8s.io/client-go/rest"
+	internalevents "k8s.io/client-go/tools/internal/events"
+	"k8s.io/client-go/tools/record/util"
+	ref "k8s.io/client-go/tools/reference"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+const maxTriesPerEvent = 12
+
+var defaultSleepDuration = 10 * time.Second
+
+const maxQueuedEvents = 1000
+
+// EventSink knows how to store events (client.Client implements it.)
+// EventSink must respect the namespace that will be embedded in 'event'.
+// It is assumed that EventSink will return the same sorts of errors as
+// pkg/client's REST client.
+type EventSink interface {
+	Create(event *v1.Event) (*v1.Event, error)
+	Update(event *v1.Event) (*v1.Event, error)
+	Patch(oldEvent *v1.Event, data []byte) (*v1.Event, error)
+}
+
+// CorrelatorOptions allows you to change the default of the EventSourceObjectSpamFilter
+// and EventAggregator in EventCorrelator
+type CorrelatorOptions struct {
+	// The lru cache size used for both EventSourceObjectSpamFilter and the EventAggregator
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the LRUCacheSize has to be greater than 0.
+	LRUCacheSize int
+	// The burst size used by the token bucket rate filtering in EventSourceObjectSpamFilter
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the BurstSize has to be greater than 0.
+	BurstSize int
+	// The fill rate of the token bucket in queries per second in EventSourceObjectSpamFilter
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the QPS has to be greater than 0.
+	QPS float32
+	// The func used by the EventAggregator to group event keys for aggregation
+	// If not specified (zero value), EventAggregatorByReasonFunc will be used
+	KeyFunc EventAggregatorKeyFunc
+	// The func used by the EventAggregator to produced aggregated message
+	// If not specified (zero value), EventAggregatorByReasonMessageFunc will be used
+	MessageFunc EventAggregatorMessageFunc
+	// The number of events in an interval before aggregation happens by the EventAggregator
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the MaxEvents has to be greater than 0
+	MaxEvents int
+	// The amount of time in seconds that must transpire since the last occurrence of a similar event before it is considered new by the EventAggregator
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the MaxIntervalInSeconds has to be greater than 0
+	MaxIntervalInSeconds int
+	// The clock used by the EventAggregator to allow for testing
+	// If not specified (zero value), clock.RealClock{} will be used
+	Clock clock.PassiveClock
+	// The func used by EventFilterFunc, which returns a key for given event, based on which filtering will take place
+	// If not specified (zero value), getSpamKey will be used
+	SpamKeyFunc EventSpamKeyFunc
+}
+
+// EventRecorder knows how to record events on behalf of an EventSource.
+type EventRecorder interface {
+	// Event constructs an event from the given information and puts it in the queue for sending.
+	// 'object' is the object this event is about. Event will make a reference-- or you may also
+	// pass a reference to the object directly.
+	// 'eventtype' of this event, and can be one of Normal, Warning. New types could be added in future
+	// 'reason' is the reason this event is generated. 'reason' should be short and unique; it
+	// should be in UpperCamelCase format (starting with a capital letter). "reason" will be used
+	// to automate handling of events, so imagine people writing switch statements to handle them.
+	// You want to make that easy.
+	// 'message' is intended to be human readable.
+	//
+	// The resulting event will be created in the same namespace as the reference object.
+	Event(object runtime.Object, eventtype, reason, message string)
+
+	// Eventf is just like Event, but with Sprintf for the message field.
+	Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{})
+
+	// AnnotatedEventf is just like eventf, but with annotations attached
+	AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{})
+}
+
+// EventRecorderLogger extends EventRecorder such that a logger can
+// be set for methods in EventRecorder. Normally, those methods
+// uses the global default logger to record errors and debug messages.
+// If that is not desired, use WithLogger to provide a logger instance.
+type EventRecorderLogger interface {
+	EventRecorder
+
+	// WithLogger replaces the context used for logging. This is a cheap call
+	// and meant to be used for contextual logging:
+	//    recorder := ...
+	//    logger := klog.FromContext(ctx)
+	//    recorder.WithLogger(logger).Eventf(...)
+	WithLogger(logger klog.Logger) EventRecorderLogger
+}
+
+// EventBroadcaster knows how to receive events and send them to any EventSink, watcher, or log.
+type EventBroadcaster interface {
+	// StartEventWatcher starts sending events received from this EventBroadcaster to the given
+	// event handler function. The return value can be ignored or used to stop recording, if
+	// desired.
+	StartEventWatcher(eventHandler func(*v1.Event)) watch.Interface
+
+	// StartRecordingToSink starts sending events received from this EventBroadcaster to the given
+	// sink. The return value can be ignored or used to stop recording, if desired.
+	StartRecordingToSink(sink EventSink) watch.Interface
+
+	// StartLogging starts sending events received from this EventBroadcaster to the given logging
+	// function. The return value can be ignored or used to stop recording, if desired.
+	StartLogging(logf func(format string, args ...interface{})) watch.Interface
+
+	// StartStructuredLogging starts sending events received from this EventBroadcaster to the structured
+	// logging function. The return value can be ignored or used to stop recording, if desired.
+	StartStructuredLogging(verbosity klog.Level) watch.Interface
+
+	// NewRecorder returns an EventRecorder that can be used to send events to this EventBroadcaster
+	// with the event source set to the given event source.
+	NewRecorder(scheme *runtime.Scheme, source v1.EventSource) EventRecorderLogger
+
+	// Shutdown shuts down the broadcaster. Once the broadcaster is shut
+	// down, it will only try to record an event in a sink once before
+	// giving up on it with an error message.
+	Shutdown()
+}
+
+// EventRecorderAdapter is a wrapper around a "k8s.io/client-go/tools/record".EventRecorder
+// implementing the new "k8s.io/client-go/tools/events".EventRecorder interface.
+type EventRecorderAdapter struct {
+	recorder EventRecorderLogger
+}
+
+var _ internalevents.EventRecorder = &EventRecorderAdapter{}
+
+// NewEventRecorderAdapter returns an adapter implementing the new
+// "k8s.io/client-go/tools/events".EventRecorder interface.
+func NewEventRecorderAdapter(recorder EventRecorderLogger) *EventRecorderAdapter {
+	return &EventRecorderAdapter{
+		recorder: recorder,
+	}
+}
+
+// Eventf is a wrapper around v1 Eventf
+func (a *EventRecorderAdapter) Eventf(regarding, _ runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
+	a.recorder.Eventf(regarding, eventtype, reason, note, args...)
+}
+
+func (a *EventRecorderAdapter) WithLogger(logger klog.Logger) internalevents.EventRecorderLogger {
+	return &EventRecorderAdapter{
+		recorder: a.recorder.WithLogger(logger),
+	}
+}
+
+// Creates a new event broadcaster.
+func NewBroadcaster(opts ...BroadcasterOption) EventBroadcaster {
+	c := config{
+		sleepDuration: defaultSleepDuration,
+	}
+	for _, opt := range opts {
+		opt(&c)
+	}
+	eventBroadcaster := &eventBroadcasterImpl{
+		Broadcaster:   watch.NewLongQueueBroadcaster(maxQueuedEvents, watch.DropIfChannelFull),
+		sleepDuration: c.sleepDuration,
+		options:       c.CorrelatorOptions,
+	}
+	ctx := c.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// The are two scenarios where it makes no sense to wait for context cancelation:
+	// - The context was nil.
+	// - The context was context.Background() to begin with.
+	//
+	// Both cases get checked here: we have cancelation if (and only if) there is a channel.
+	haveCtxCancelation := ctx.Done() != nil
+
+	eventBroadcaster.cancelationCtx, eventBroadcaster.cancel = context.WithCancel(ctx)
+
+	if haveCtxCancelation {
+		// Calling Shutdown is not required when a context was provided:
+		// when the context is canceled, this goroutine will shut down
+		// the broadcaster.
+		//
+		// If Shutdown is called first, then this goroutine will
+		// also stop.
+		go func() {
+			<-eventBroadcaster.cancelationCtx.Done()
+			eventBroadcaster.Broadcaster.Shutdown()
+		}()
+	}
+
+	return eventBroadcaster
+}
+
+func NewBroadcasterForTests(sleepDuration time.Duration) EventBroadcaster {
+	return NewBroadcaster(WithSleepDuration(sleepDuration))
+}
+
+func NewBroadcasterWithCorrelatorOptions(options CorrelatorOptions) EventBroadcaster {
+	return NewBroadcaster(WithCorrelatorOptions(options))
+}
+
+func WithCorrelatorOptions(options CorrelatorOptions) BroadcasterOption {
+	return func(c *config) {
+		c.CorrelatorOptions = options
+	}
+}
+
+// WithContext sets a context for the broadcaster. Canceling the context will
+// shut down the broadcaster, Shutdown doesn't need to be called. The context
+// can also be used to provide a logger.
+func WithContext(ctx context.Context) BroadcasterOption {
+	return func(c *config) {
+		c.Context = ctx
+	}
+}
+
+func WithSleepDuration(sleepDuration time.Duration) BroadcasterOption {
+	return func(c *config) {
+		c.sleepDuration = sleepDuration
+	}
+}
+
+type BroadcasterOption func(*config)
+
+type config struct {
+	CorrelatorOptions
+	context.Context
+	sleepDuration time.Duration
+}
+
+type eventBroadcasterImpl struct {
+	*watch.Broadcaster
+	sleepDuration  time.Duration
+	options        CorrelatorOptions
+	cancelationCtx context.Context
+	cancel         func()
+}
+
+// StartRecordingToSink starts sending events received from the specified eventBroadcaster to the given sink.
+// The return value can be ignored or used to stop recording, if desired.
+// TODO: make me an object with parameterizable queue length and retry interval
+func (e *eventBroadcasterImpl) StartRecordingToSink(sink EventSink) watch.Interface {
+	eventCorrelator := NewEventCorrelatorWithOptions(e.options)
+	return e.StartEventWatcher(
+		func(event *v1.Event) {
+			e.recordToSink(sink, event, eventCorrelator)
+		})
+}
+
+func (e *eventBroadcasterImpl) Shutdown() {
+	e.Broadcaster.Shutdown()
+	e.cancel()
+}
+
+func (e *eventBroadcasterImpl) recordToSink(sink EventSink, event *v1.Event, eventCorrelator *EventCorrelator) {
+	// Make a copy before modification, because there could be multiple listeners.
+	// Events are safe to copy like this.
+	eventCopy := *event
+	event = &eventCopy
+	result, err := eventCorrelator.EventCorrelate(event)
+	if err != nil {
+		utilruntime.HandleError(err)
+	}
+	if result.Skip {
+		return
+	}
+	tries := 0
+	for {
+		if recordEvent(e.cancelationCtx, sink, result.Event, result.Patch, result.Event.Count > 1, eventCorrelator) {
+			break
+		}
+		tries++
+		if tries >= maxTriesPerEvent {
+			klog.FromContext(e.cancelationCtx).Error(nil, "Unable to write event (retry limit exceeded!)", "event", event)
+			break
+		}
+
+		// Randomize the first sleep so that various clients won't all be
+		// synced up if the master goes down.
+		delay := e.sleepDuration
+		if tries == 1 {
+			delay = time.Duration(float64(delay) * rand.Float64())
+		}
+		select {
+		case <-e.cancelationCtx.Done():
+			klog.FromContext(e.cancelationCtx).Error(nil, "Unable to write event (broadcaster is shut down)", "event", event)
+			return
+		case <-time.After(delay):
+		}
+	}
+}
+
+// recordEvent attempts to write event to a sink. It returns true if the event
+// was successfully recorded or discarded, false if it should be retried.
+// If updateExistingEvent is false, it creates a new event, otherwise it updates
+// existing event.
+func recordEvent(ctx context.Context, sink EventSink, event *v1.Event, patch []byte, updateExistingEvent bool, eventCorrelator *EventCorrelator) bool {
+	var newEvent *v1.Event
+	var err error
+	if updateExistingEvent {
+		newEvent, err = sink.Patch(event, patch)
+	}
+	// Update can fail because the event may have been removed and it no longer exists.
+	if !updateExistingEvent || util.IsKeyNotFoundError(err) {
+		// Making sure that ResourceVersion is empty on creation
+		event.ResourceVersion = ""
+		newEvent, err = sink.Create(event)
+	}
+	if err == nil {
+		// we need to update our event correlator with the server returned state to handle name/resourceversion
+		eventCorrelator.UpdateState(newEvent)
+		return true
+	}
+
+	// If we can't contact the server, then hold everything while we keep trying.
+	// Otherwise, something about the event is malformed and we should abandon it.
+	switch err.(type) {
+	case *restclient.RequestConstructionError:
+		// We will construct the request the same next time, so don't keep trying.
+		klog.FromContext(ctx).Error(err, "Unable to construct event (will not retry!)", "event", event)
+		return true
+	case *errors.StatusError:
+		if errors.IsAlreadyExists(err) || errors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
+			klog.FromContext(ctx).V(5).Info("Server rejected event (will not retry!)", "event", event, "err", err)
+		} else {
+			klog.FromContext(ctx).Error(err, "Server rejected event (will not retry!)", "event", event)
+		}
+		return true
+	case *errors.UnexpectedObjectError:
+		// We don't expect this; it implies the server's response didn't match a
+		// known pattern. Go ahead and retry.
+	default:
+		// This case includes actual http transport errors. Go ahead and retry.
+	}
+	klog.FromContext(ctx).Error(err, "Unable to write event (may retry after sleeping)", "event", event)
+	return false
+}
+
+// StartLogging starts sending events received from this EventBroadcaster to the given logging function.
+// The return value can be ignored or used to stop recording, if desired.
+func (e *eventBroadcasterImpl) StartLogging(logf func(format string, args ...interface{})) watch.Interface {
+	return e.StartEventWatcher(
+		func(e *v1.Event) {
+			logf("Event(%#v): type: '%v' reason: '%v' %v", e.InvolvedObject, e.Type, e.Reason, e.Message)
+		})
+}
+
+// StartStructuredLogging starts sending events received from this EventBroadcaster to a structured logger.
+// The logger is retrieved from a context if the broadcaster was constructed with a context, otherwise
+// the global default is used.
+// The return value can be ignored or used to stop recording, if desired.
+func (e *eventBroadcasterImpl) StartStructuredLogging(verbosity klog.Level) watch.Interface {
+	loggerV := klog.FromContext(e.cancelationCtx).V(int(verbosity))
+	return e.StartEventWatcher(
+		func(e *v1.Event) {
+			loggerV.Info("Event occurred", "object", klog.KRef(e.InvolvedObject.Namespace, e.InvolvedObject.Name), "fieldPath", e.InvolvedObject.FieldPath, "kind", e.InvolvedObject.Kind, "apiVersion", e.InvolvedObject.APIVersion, "type", e.Type, "reason", e.Reason, "message", e.Message)
+		})
+}
+
+// StartEventWatcher starts sending events received from this EventBroadcaster to the given event handler function.
+// The return value can be ignored or used to stop recording, if desired.
+func (e *eventBroadcasterImpl) StartEventWatcher(eventHandler func(*v1.Event)) watch.Interface {
+	watcher, err := e.Watch()
+	if err != nil {
+		// This function traditionally returns no error even though it can fail.
+		// Instead, it logs the error and returns an empty watch. The empty
+		// watch ensures that callers don't crash when calling Stop.
+		klog.FromContext(e.cancelationCtx).Error(err, "Unable start event watcher (will not retry!)")
+		return watch.NewEmptyWatch()
+	}
+	go func() {
+		defer utilruntime.HandleCrash()
+		for {
+			select {
+			case <-e.cancelationCtx.Done():
+				watcher.Stop()
+				return
+			case watchEvent, ok := <-watcher.ResultChan():
+				if !ok {
+					return
+				}
+				event, ok := watchEvent.Object.(*v1.Event)
+				if !ok {
+					// This is all local, so there's no reason this should
+					// ever happen.
+					continue
+				}
+				eventHandler(event)
+			}
+		}
+	}()
+	return watcher
+}
+
+// NewRecorder returns an EventRecorder that records events with the given event source.
+func (e *eventBroadcasterImpl) NewRecorder(scheme *runtime.Scheme, source v1.EventSource) EventRecorderLogger {
+	return &recorderImplLogger{recorderImpl: &recorderImpl{scheme, source, e.Broadcaster, clock.RealClock{}}, logger: klog.Background()}
+}
+
+type recorderImpl struct {
+	scheme *runtime.Scheme
+	source v1.EventSource
+	*watch.Broadcaster
+	clock clock.PassiveClock
+}
+
+var _ EventRecorder = &recorderImpl{}
+
+func (recorder *recorderImpl) generateEvent(logger klog.Logger, object runtime.Object, annotations map[string]string, eventtype, reason, message string) {
+	ref, err := ref.GetReference(recorder.scheme, object)
+	if err != nil {
+		logger.Error(err, "Could not construct reference, will not report event", "object", object, "eventType", eventtype, "reason", reason, "message", message)
+		return
+	}
+
+	if !util.ValidateEventType(eventtype) {
+		logger.Error(nil, "Unsupported event type", "eventType", eventtype)
+		return
+	}
+
+	event := recorder.makeEvent(ref, annotations, eventtype, reason, message)
+	event.Source = recorder.source
+
+	event.ReportingInstance = recorder.source.Host
+	event.ReportingController = recorder.source.Component
+
+	// NOTE: events should be a non-blocking operation, but we also need to not
+	// put this in a goroutine, otherwise we'll race to write to a closed channel
+	// when we go to shut down this broadcaster.  Just drop events if we get overloaded,
+	// and log an error if that happens (we've configured the broadcaster to drop
+	// outgoing events anyway).
+	sent, err := recorder.ActionOrDrop(watch.Added, event)
+	if err != nil {
+		logger.Error(err, "Unable to record event (will not retry!)")
+		return
+	}
+	if !sent {
+		logger.Error(nil, "Unable to record event: too many queued events, dropped event", "event", event)
+	}
+}
+
+func (recorder *recorderImpl) Event(object runtime.Object, eventtype, reason, message string) {
+	recorder.generateEvent(klog.Background(), object, nil, eventtype, reason, message)
+}
+
+func (recorder *recorderImpl) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	recorder.Event(object, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (recorder *recorderImpl) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	recorder.generateEvent(klog.Background(), object, annotations, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (recorder *recorderImpl) makeEvent(ref *v1.ObjectReference, annotations map[string]string, eventtype, reason, message string) *v1.Event {
+	t := metav1.Time{Time: recorder.clock.Now()}
+	namespace := ref.Namespace
+	if namespace == "" {
+		namespace = metav1.NamespaceDefault
+	}
+	return &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        util.GenerateEventName(ref.Name, t.UnixNano()),
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		InvolvedObject: *ref,
+		Reason:         reason,
+		Message:        message,
+		FirstTimestamp: t,
+		LastTimestamp:  t,
+		Count:          1,
+		Type:           eventtype,
+	}
+}
+
+type recorderImplLogger struct {
+	*recorderImpl
+	logger klog.Logger
+}
+
+var _ EventRecorderLogger = &recorderImplLogger{}
+
+func (recorder recorderImplLogger) Event(object runtime.Object, eventtype, reason, message string) {
+	recorder.recorderImpl.generateEvent(recorder.logger, object, nil, eventtype, reason, message)
+}
+
+func (recorder recorderImplLogger) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	recorder.Event(object, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (recorder recorderImplLogger) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	recorder.generateEvent(recorder.logger, object, annotations, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (recorder recorderImplLogger) WithLogger(logger klog.Logger) EventRecorderLogger {
+	return recorderImplLogger{recorderImpl: recorder.recorderImpl, logger: logger}
+}

--- a/vendor/k8s.io/client-go/tools/record/events_cache.go
+++ b/vendor/k8s.io/client-go/tools/record/events_cache.go
@@ -1,0 +1,521 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package record
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/clock"
+	"k8s.io/utils/lru"
+)
+
+const (
+	maxLruCacheEntries = 4096
+
+	// if we see the same event that varies only by message
+	// more than 10 times in a 10 minute period, aggregate the event
+	defaultAggregateMaxEvents         = 10
+	defaultAggregateIntervalInSeconds = 600
+
+	// by default, allow a source to send 25 events about an object
+	// but control the refill rate to 1 new event every 5 minutes
+	// this helps control the long-tail of events for things that are always
+	// unhealthy
+	defaultSpamBurst = 25
+	defaultSpamQPS   = 1. / 300.
+)
+
+// getEventKey builds unique event key based on source, involvedObject, reason, message
+func getEventKey(event *v1.Event) string {
+	return strings.Join([]string{
+		event.Source.Component,
+		event.Source.Host,
+		event.InvolvedObject.Kind,
+		event.InvolvedObject.Namespace,
+		event.InvolvedObject.Name,
+		event.InvolvedObject.FieldPath,
+		string(event.InvolvedObject.UID),
+		event.InvolvedObject.APIVersion,
+		event.Type,
+		event.Reason,
+		event.Message,
+	},
+		"")
+}
+
+// getSpamKey builds unique event key based on source, involvedObject
+func getSpamKey(event *v1.Event) string {
+	return strings.Join([]string{
+		event.Source.Component,
+		event.Source.Host,
+		event.InvolvedObject.Kind,
+		event.InvolvedObject.Namespace,
+		event.InvolvedObject.Name,
+		string(event.InvolvedObject.UID),
+		event.InvolvedObject.APIVersion,
+		event.Type,
+	},
+		"")
+}
+
+// EventSpamKeyFunc is a function that returns unique key based on provided event
+type EventSpamKeyFunc func(event *v1.Event) string
+
+// EventFilterFunc is a function that returns true if the event should be skipped
+type EventFilterFunc func(event *v1.Event) bool
+
+// EventSourceObjectSpamFilter is responsible for throttling
+// the amount of events a source and object can produce.
+type EventSourceObjectSpamFilter struct {
+	// the cache that manages last synced state
+	cache *lru.Cache
+
+	// burst is the amount of events we allow per source + object
+	burst int
+
+	// qps is the refill rate of the token bucket in queries per second
+	qps float32
+
+	// clock is used to allow for testing over a time interval
+	clock clock.PassiveClock
+
+	// spamKeyFunc is a func used to create a key based on an event, which is later used to filter spam events.
+	spamKeyFunc EventSpamKeyFunc
+}
+
+// NewEventSourceObjectSpamFilter allows burst events from a source about an object with the specified qps refill.
+func NewEventSourceObjectSpamFilter(lruCacheSize, burst int, qps float32, clock clock.PassiveClock, spamKeyFunc EventSpamKeyFunc) *EventSourceObjectSpamFilter {
+	return &EventSourceObjectSpamFilter{
+		cache:       lru.New(lruCacheSize),
+		burst:       burst,
+		qps:         qps,
+		clock:       clock,
+		spamKeyFunc: spamKeyFunc,
+	}
+}
+
+// spamRecord holds data used to perform spam filtering decisions.
+type spamRecord struct {
+	// rateLimiter controls the rate of events about this object
+	rateLimiter flowcontrol.PassiveRateLimiter
+}
+
+// Filter controls that a given source+object are not exceeding the allowed rate.
+func (f *EventSourceObjectSpamFilter) Filter(event *v1.Event) bool {
+	var record spamRecord
+
+	// controls our cached information about this event
+	eventKey := f.spamKeyFunc(event)
+
+	// do we have a record of similar events in our cache?
+	value, found := f.cache.Get(eventKey)
+	if found {
+		record = value.(spamRecord)
+	}
+
+	// verify we have a rate limiter for this record
+	if record.rateLimiter == nil {
+		record.rateLimiter = flowcontrol.NewTokenBucketPassiveRateLimiterWithClock(f.qps, f.burst, f.clock)
+	}
+
+	// ensure we have available rate
+	filter := !record.rateLimiter.TryAccept()
+
+	// update the cache
+	f.cache.Add(eventKey, record)
+
+	return filter
+}
+
+// EventAggregatorKeyFunc is responsible for grouping events for aggregation
+// It returns a tuple of the following:
+// aggregateKey - key the identifies the aggregate group to bucket this event
+// localKey - key that makes this event in the local group
+type EventAggregatorKeyFunc func(event *v1.Event) (aggregateKey string, localKey string)
+
+// EventAggregatorByReasonFunc aggregates events by exact match on event.Source, event.InvolvedObject, event.Type,
+// event.Reason, event.ReportingController and event.ReportingInstance
+func EventAggregatorByReasonFunc(event *v1.Event) (string, string) {
+	return strings.Join([]string{
+		event.Source.Component,
+		event.Source.Host,
+		event.InvolvedObject.Kind,
+		event.InvolvedObject.Namespace,
+		event.InvolvedObject.Name,
+		string(event.InvolvedObject.UID),
+		event.InvolvedObject.APIVersion,
+		event.Type,
+		event.Reason,
+		event.ReportingController,
+		event.ReportingInstance,
+	},
+		""), event.Message
+}
+
+// EventAggregatorMessageFunc is responsible for producing an aggregation message
+type EventAggregatorMessageFunc func(event *v1.Event) string
+
+// EventAggregatorByReasonMessageFunc returns an aggregate message by prefixing the incoming message
+func EventAggregatorByReasonMessageFunc(event *v1.Event) string {
+	return "(combined from similar events): " + event.Message
+}
+
+// EventAggregator identifies similar events and aggregates them into a single event
+type EventAggregator struct {
+	sync.RWMutex
+
+	// The cache that manages aggregation state
+	cache *lru.Cache
+
+	// The function that groups events for aggregation
+	keyFunc EventAggregatorKeyFunc
+
+	// The function that generates a message for an aggregate event
+	messageFunc EventAggregatorMessageFunc
+
+	// The maximum number of events in the specified interval before aggregation occurs
+	maxEvents uint
+
+	// The amount of time in seconds that must transpire since the last occurrence of a similar event before it's considered new
+	maxIntervalInSeconds uint
+
+	// clock is used to allow for testing over a time interval
+	clock clock.PassiveClock
+}
+
+// NewEventAggregator returns a new instance of an EventAggregator
+func NewEventAggregator(lruCacheSize int, keyFunc EventAggregatorKeyFunc, messageFunc EventAggregatorMessageFunc,
+	maxEvents int, maxIntervalInSeconds int, clock clock.PassiveClock) *EventAggregator {
+	return &EventAggregator{
+		cache:                lru.New(lruCacheSize),
+		keyFunc:              keyFunc,
+		messageFunc:          messageFunc,
+		maxEvents:            uint(maxEvents),
+		maxIntervalInSeconds: uint(maxIntervalInSeconds),
+		clock:                clock,
+	}
+}
+
+// aggregateRecord holds data used to perform aggregation decisions
+type aggregateRecord struct {
+	// we track the number of unique local keys we have seen in the aggregate set to know when to actually aggregate
+	// if the size of this set exceeds the max, we know we need to aggregate
+	localKeys sets.Set[string]
+	// The last time at which the aggregate was recorded
+	lastTimestamp metav1.Time
+}
+
+// EventAggregate checks if a similar event has been seen according to the
+// aggregation configuration (max events, max interval, etc) and returns:
+//
+//   - The (potentially modified) event that should be created
+//   - The cache key for the event, for correlation purposes. This will be set to
+//     the full key for normal events, and to the result of
+//     EventAggregatorMessageFunc for aggregate events.
+func (e *EventAggregator) EventAggregate(newEvent *v1.Event) (*v1.Event, string) {
+	now := metav1.NewTime(e.clock.Now())
+	var record aggregateRecord
+	// eventKey is the full cache key for this event
+	eventKey := getEventKey(newEvent)
+	// aggregateKey is for the aggregate event, if one is needed.
+	aggregateKey, localKey := e.keyFunc(newEvent)
+
+	// Do we have a record of similar events in our cache?
+	e.Lock()
+	defer e.Unlock()
+	value, found := e.cache.Get(aggregateKey)
+	if found {
+		record = value.(aggregateRecord)
+	}
+
+	// Is the previous record too old? If so, make a fresh one. Note: if we didn't
+	// find a similar record, its lastTimestamp will be the zero value, so we
+	// create a new one in that case.
+	maxInterval := time.Duration(e.maxIntervalInSeconds) * time.Second
+	interval := now.Time.Sub(record.lastTimestamp.Time)
+	if interval > maxInterval {
+		record = aggregateRecord{localKeys: sets.New[string]()}
+	}
+
+	// Write the new event into the aggregation record and put it on the cache
+	record.localKeys.Insert(localKey)
+	record.lastTimestamp = now
+	e.cache.Add(aggregateKey, record)
+
+	// If we are not yet over the threshold for unique events, don't correlate them
+	if uint(record.localKeys.Len()) < e.maxEvents {
+		return newEvent, eventKey
+	}
+
+	// do not grow our local key set any larger than max
+	record.localKeys.PopAny()
+
+	// create a new aggregate event, and return the aggregateKey as the cache key
+	// (so that it can be overwritten.)
+	eventCopy := &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%v.%x", newEvent.InvolvedObject.Name, now.UnixNano()),
+			Namespace: newEvent.Namespace,
+		},
+		Count:          1,
+		FirstTimestamp: now,
+		InvolvedObject: newEvent.InvolvedObject,
+		LastTimestamp:  now,
+		Message:        e.messageFunc(newEvent),
+		Type:           newEvent.Type,
+		Reason:         newEvent.Reason,
+		Source:         newEvent.Source,
+	}
+	return eventCopy, aggregateKey
+}
+
+// eventLog records data about when an event was observed
+type eventLog struct {
+	// The number of times the event has occurred since first occurrence.
+	count uint
+
+	// The time at which the event was first recorded.
+	firstTimestamp metav1.Time
+
+	// The unique name of the first occurrence of this event
+	name string
+
+	// Resource version returned from previous interaction with server
+	resourceVersion string
+}
+
+// eventLogger logs occurrences of an event
+type eventLogger struct {
+	sync.RWMutex
+	cache *lru.Cache
+	clock clock.PassiveClock
+}
+
+// newEventLogger observes events and counts their frequencies
+func newEventLogger(lruCacheEntries int, clock clock.PassiveClock) *eventLogger {
+	return &eventLogger{cache: lru.New(lruCacheEntries), clock: clock}
+}
+
+// eventObserve records an event, or updates an existing one if key is a cache hit
+func (e *eventLogger) eventObserve(newEvent *v1.Event, key string) (*v1.Event, []byte, error) {
+	var (
+		patch []byte
+		err   error
+	)
+	eventCopy := *newEvent
+	event := &eventCopy
+
+	e.Lock()
+	defer e.Unlock()
+
+	// Check if there is an existing event we should update
+	lastObservation := e.lastEventObservationFromCache(key)
+
+	// If we found a result, prepare a patch
+	if lastObservation.count > 0 {
+		// update the event based on the last observation so patch will work as desired
+		event.Name = lastObservation.name
+		event.ResourceVersion = lastObservation.resourceVersion
+		event.FirstTimestamp = lastObservation.firstTimestamp
+		event.Count = int32(lastObservation.count) + 1
+
+		eventCopy2 := *event
+		eventCopy2.Count = 0
+		eventCopy2.LastTimestamp = metav1.NewTime(time.Unix(0, 0))
+		eventCopy2.Message = ""
+
+		newData, _ := json.Marshal(event)
+		oldData, _ := json.Marshal(eventCopy2)
+		patch, err = strategicpatch.CreateTwoWayMergePatch(oldData, newData, event)
+	}
+
+	// record our new observation
+	e.cache.Add(
+		key,
+		eventLog{
+			count:           uint(event.Count),
+			firstTimestamp:  event.FirstTimestamp,
+			name:            event.Name,
+			resourceVersion: event.ResourceVersion,
+		},
+	)
+	return event, patch, err
+}
+
+// updateState updates its internal tracking information based on latest server state
+func (e *eventLogger) updateState(event *v1.Event) {
+	key := getEventKey(event)
+	e.Lock()
+	defer e.Unlock()
+	// record our new observation
+	e.cache.Add(
+		key,
+		eventLog{
+			count:           uint(event.Count),
+			firstTimestamp:  event.FirstTimestamp,
+			name:            event.Name,
+			resourceVersion: event.ResourceVersion,
+		},
+	)
+}
+
+// lastEventObservationFromCache returns the event from the cache, reads must be protected via external lock
+func (e *eventLogger) lastEventObservationFromCache(key string) eventLog {
+	value, ok := e.cache.Get(key)
+	if ok {
+		observationValue, ok := value.(eventLog)
+		if ok {
+			return observationValue
+		}
+	}
+	return eventLog{}
+}
+
+// EventCorrelator processes all incoming events and performs analysis to avoid overwhelming the system.  It can filter all
+// incoming events to see if the event should be filtered from further processing.  It can aggregate similar events that occur
+// frequently to protect the system from spamming events that are difficult for users to distinguish.  It performs de-duplication
+// to ensure events that are observed multiple times are compacted into a single event with increasing counts.
+type EventCorrelator struct {
+	// the function to filter the event
+	filterFunc EventFilterFunc
+	// the object that performs event aggregation
+	aggregator *EventAggregator
+	// the object that observes events as they come through
+	logger *eventLogger
+}
+
+// EventCorrelateResult is the result of a Correlate
+type EventCorrelateResult struct {
+	// the event after correlation
+	Event *v1.Event
+	// if provided, perform a strategic patch when updating the record on the server
+	Patch []byte
+	// if true, do no further processing of the event
+	Skip bool
+}
+
+// NewEventCorrelator returns an EventCorrelator configured with default values.
+//
+// The EventCorrelator is responsible for event filtering, aggregating, and counting
+// prior to interacting with the API server to record the event.
+//
+// The default behavior is as follows:
+//   - Aggregation is performed if a similar event is recorded 10 times
+//     in a 10 minute rolling interval.  A similar event is an event that varies only by
+//     the Event.Message field.  Rather than recording the precise event, aggregation
+//     will create a new event whose message reports that it has combined events with
+//     the same reason.
+//   - Events are incrementally counted if the exact same event is encountered multiple
+//     times.
+//   - A source may burst 25 events about an object, but has a refill rate budget
+//     per object of 1 event every 5 minutes to control long-tail of spam.
+func NewEventCorrelator(clock clock.PassiveClock) *EventCorrelator {
+	cacheSize := maxLruCacheEntries
+	spamFilter := NewEventSourceObjectSpamFilter(cacheSize, defaultSpamBurst, defaultSpamQPS, clock, getSpamKey)
+	return &EventCorrelator{
+		filterFunc: spamFilter.Filter,
+		aggregator: NewEventAggregator(
+			cacheSize,
+			EventAggregatorByReasonFunc,
+			EventAggregatorByReasonMessageFunc,
+			defaultAggregateMaxEvents,
+			defaultAggregateIntervalInSeconds,
+			clock),
+
+		logger: newEventLogger(cacheSize, clock),
+	}
+}
+
+func NewEventCorrelatorWithOptions(options CorrelatorOptions) *EventCorrelator {
+	optionsWithDefaults := populateDefaults(options)
+	spamFilter := NewEventSourceObjectSpamFilter(
+		optionsWithDefaults.LRUCacheSize,
+		optionsWithDefaults.BurstSize,
+		optionsWithDefaults.QPS,
+		optionsWithDefaults.Clock,
+		optionsWithDefaults.SpamKeyFunc)
+	return &EventCorrelator{
+		filterFunc: spamFilter.Filter,
+		aggregator: NewEventAggregator(
+			optionsWithDefaults.LRUCacheSize,
+			optionsWithDefaults.KeyFunc,
+			optionsWithDefaults.MessageFunc,
+			optionsWithDefaults.MaxEvents,
+			optionsWithDefaults.MaxIntervalInSeconds,
+			optionsWithDefaults.Clock),
+		logger: newEventLogger(optionsWithDefaults.LRUCacheSize, optionsWithDefaults.Clock),
+	}
+}
+
+// populateDefaults populates the zero value options with defaults
+func populateDefaults(options CorrelatorOptions) CorrelatorOptions {
+	if options.LRUCacheSize == 0 {
+		options.LRUCacheSize = maxLruCacheEntries
+	}
+	if options.BurstSize == 0 {
+		options.BurstSize = defaultSpamBurst
+	}
+	if options.QPS == 0 {
+		options.QPS = defaultSpamQPS
+	}
+	if options.KeyFunc == nil {
+		options.KeyFunc = EventAggregatorByReasonFunc
+	}
+	if options.MessageFunc == nil {
+		options.MessageFunc = EventAggregatorByReasonMessageFunc
+	}
+	if options.MaxEvents == 0 {
+		options.MaxEvents = defaultAggregateMaxEvents
+	}
+	if options.MaxIntervalInSeconds == 0 {
+		options.MaxIntervalInSeconds = defaultAggregateIntervalInSeconds
+	}
+	if options.Clock == nil {
+		options.Clock = clock.RealClock{}
+	}
+	if options.SpamKeyFunc == nil {
+		options.SpamKeyFunc = getSpamKey
+	}
+	return options
+}
+
+// EventCorrelate filters, aggregates, counts, and de-duplicates all incoming events
+func (c *EventCorrelator) EventCorrelate(newEvent *v1.Event) (*EventCorrelateResult, error) {
+	if newEvent == nil {
+		return nil, fmt.Errorf("event is nil")
+	}
+	aggregateEvent, ckey := c.aggregator.EventAggregate(newEvent)
+	observedEvent, patch, err := c.logger.eventObserve(aggregateEvent, ckey)
+	if c.filterFunc(observedEvent) {
+		return &EventCorrelateResult{Skip: true}, nil
+	}
+	return &EventCorrelateResult{Event: observedEvent, Patch: patch}, err
+}
+
+// UpdateState based on the latest observed state from server
+func (c *EventCorrelator) UpdateState(event *v1.Event) {
+	c.logger.updateState(event)
+}

--- a/vendor/k8s.io/client-go/tools/record/fake.go
+++ b/vendor/k8s.io/client-go/tools/record/fake.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package record
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+)
+
+// FakeRecorder is used as a fake during tests. It is thread safe. It is usable
+// when created manually and not by NewFakeRecorder, however all events may be
+// thrown away in this case.
+type FakeRecorder struct {
+	Events chan string
+
+	IncludeObject bool
+}
+
+var _ EventRecorderLogger = &FakeRecorder{}
+
+func objectString(object runtime.Object, includeObject bool) string {
+	if !includeObject {
+		return ""
+	}
+	return fmt.Sprintf(" involvedObject{kind=%s,apiVersion=%s}",
+		object.GetObjectKind().GroupVersionKind().Kind,
+		object.GetObjectKind().GroupVersionKind().GroupVersion(),
+	)
+}
+
+func annotationsString(annotations map[string]string) string {
+	if len(annotations) == 0 {
+		return ""
+	} else {
+		return " " + fmt.Sprint(annotations)
+	}
+}
+
+func (f *FakeRecorder) writeEvent(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	if f.Events != nil {
+		f.Events <- fmt.Sprintf(eventtype+" "+reason+" "+messageFmt, args...) +
+			objectString(object, f.IncludeObject) + annotationsString(annotations)
+	}
+}
+
+func (f *FakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	f.writeEvent(object, nil, eventtype, reason, "%s", message)
+}
+
+func (f *FakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.writeEvent(object, nil, eventtype, reason, messageFmt, args...)
+}
+
+func (f *FakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.writeEvent(object, annotations, eventtype, reason, messageFmt, args...)
+}
+
+func (f *FakeRecorder) WithLogger(logger klog.Logger) EventRecorderLogger {
+	return f
+}
+
+// NewFakeRecorder creates new fake event recorder with event channel with
+// buffer of given size.
+func NewFakeRecorder(bufferSize int) *FakeRecorder {
+	return &FakeRecorder{
+		Events: make(chan string, bufferSize),
+	}
+}

--- a/vendor/k8s.io/client-go/tools/record/util/util.go
+++ b/vendor/k8s.io/client-go/tools/record/util/util.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+)
+
+// ValidateEventType checks that eventtype is an expected type of event
+func ValidateEventType(eventtype string) bool {
+	switch eventtype {
+	case v1.EventTypeNormal, v1.EventTypeWarning:
+		return true
+	}
+	return false
+}
+
+// IsKeyNotFoundError is utility function that checks if an error is not found error
+func IsKeyNotFoundError(err error) bool {
+	statusErr, _ := err.(*errors.StatusError)
+
+	return statusErr != nil && statusErr.Status().Code == http.StatusNotFound
+}
+
+// GenerateEventName generates a valid Event name from the referenced name and the passed UNIX timestamp.
+// The referenced Object name may not be a valid name for Events and cause the Event to fail
+// to be created, so we need to generate a new one in that case.
+// Ref: https://issues.k8s.io/127594
+func GenerateEventName(refName string, unixNano int64) string {
+	name := fmt.Sprintf("%s.%x", refName, unixNano)
+	if errs := apimachineryvalidation.NameIsDNSSubdomain(name, false); len(errs) > 0 {
+		// Using an uuid guarantees uniqueness and correctness
+		name = uuid.New().String()
+	}
+	return name
+}

--- a/vendor/k8s.io/utils/internal/third_party/forked/golang/golang-lru/lru.go
+++ b/vendor/k8s.io/utils/internal/third_party/forked/golang/golang-lru/lru.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2013 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package lru implements an LRU cache.
+package golang_lru
+
+import "container/list"
+
+// Cache is an LRU cache. It is not safe for concurrent access.
+type Cache struct {
+	// MaxEntries is the maximum number of cache entries before
+	// an item is evicted. Zero means no limit.
+	MaxEntries int
+
+	// OnEvicted optionally specifies a callback function to be
+	// executed when an entry is purged from the cache.
+	OnEvicted func(key Key, value interface{})
+
+	ll    *list.List
+	cache map[interface{}]*list.Element
+}
+
+// A Key may be any value that is comparable. See http://golang.org/ref/spec#Comparison_operators
+type Key interface{}
+
+type entry struct {
+	key   Key
+	value interface{}
+}
+
+// New creates a new Cache.
+// If maxEntries is zero, the cache has no limit and it's assumed
+// that eviction is done by the caller.
+func New(maxEntries int) *Cache {
+	return &Cache{
+		MaxEntries: maxEntries,
+		ll:         list.New(),
+		cache:      make(map[interface{}]*list.Element),
+	}
+}
+
+// Add adds a value to the cache.
+func (c *Cache) Add(key Key, value interface{}) {
+	if c.cache == nil {
+		c.cache = make(map[interface{}]*list.Element)
+		c.ll = list.New()
+	}
+	if ee, ok := c.cache[key]; ok {
+		c.ll.MoveToFront(ee)
+		ee.Value.(*entry).value = value
+		return
+	}
+	ele := c.ll.PushFront(&entry{key, value})
+	c.cache[key] = ele
+	if c.MaxEntries != 0 && c.ll.Len() > c.MaxEntries {
+		c.RemoveOldest()
+	}
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key Key) (value interface{}, ok bool) {
+	if c.cache == nil {
+		return
+	}
+	if ele, hit := c.cache[key]; hit {
+		c.ll.MoveToFront(ele)
+		return ele.Value.(*entry).value, true
+	}
+	return
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key Key) {
+	if c.cache == nil {
+		return
+	}
+	if ele, hit := c.cache[key]; hit {
+		c.removeElement(ele)
+	}
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() {
+	if c.cache == nil {
+		return
+	}
+	ele := c.ll.Back()
+	if ele != nil {
+		c.removeElement(ele)
+	}
+}
+
+func (c *Cache) removeElement(e *list.Element) {
+	c.ll.Remove(e)
+	kv := e.Value.(*entry)
+	delete(c.cache, kv.key)
+	if c.OnEvicted != nil {
+		c.OnEvicted(kv.key, kv.value)
+	}
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	if c.cache == nil {
+		return 0
+	}
+	return c.ll.Len()
+}
+
+// Clear purges all stored items from the cache.
+func (c *Cache) Clear() {
+	if c.OnEvicted != nil {
+		for _, e := range c.cache {
+			kv := e.Value.(*entry)
+			c.OnEvicted(kv.key, kv.value)
+		}
+	}
+	c.ll = nil
+	c.cache = nil
+}

--- a/vendor/k8s.io/utils/lru/lru.go
+++ b/vendor/k8s.io/utils/lru/lru.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package lru
+
+import (
+	"fmt"
+	"sync"
+
+	groupcache "k8s.io/utils/internal/third_party/forked/golang/golang-lru"
+)
+
+type Key = groupcache.Key
+type EvictionFunc = func(key Key, value interface{})
+
+// Cache is a thread-safe fixed size LRU cache.
+type Cache struct {
+	cache *groupcache.Cache
+	lock  sync.RWMutex
+}
+
+// New creates an LRU of the given size.
+func New(size int) *Cache {
+	return &Cache{
+		cache: groupcache.New(size),
+	}
+}
+
+// NewWithEvictionFunc creates an LRU of the given size with the given eviction func.
+func NewWithEvictionFunc(size int, f EvictionFunc) *Cache {
+	c := New(size)
+	c.cache.OnEvicted = f
+	return c
+}
+
+// SetEvictionFunc updates the eviction func
+func (c *Cache) SetEvictionFunc(f EvictionFunc) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.cache.OnEvicted != nil {
+		return fmt.Errorf("lru cache eviction function is already set")
+	}
+	c.cache.OnEvicted = f
+	return nil
+}
+
+// Add adds a value to the cache.
+func (c *Cache) Add(key Key, value interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.Add(key, value)
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key Key) (value interface{}, ok bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cache.Get(key)
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key Key) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.Remove(key)
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.RemoveOldest()
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.cache.Len()
+}
+
+// Clear purges all stored items from the cache.
+func (c *Cache) Clear() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.Clear()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -180,6 +180,8 @@ github.com/pkg/errors
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.24.1
 ## explicit; go 1.25.0
+github.com/prometheus/client_golang/api
+github.com/prometheus/client_golang/api/prometheus/v1
 github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil
 github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil/header
 github.com/prometheus/client_golang/prometheus
@@ -1058,8 +1060,11 @@ k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/tools/clientcmd/api
 k8s.io/client-go/tools/clientcmd/api/latest
 k8s.io/client-go/tools/clientcmd/api/v1
+k8s.io/client-go/tools/internal/events
 k8s.io/client-go/tools/metrics
 k8s.io/client-go/tools/pager
+k8s.io/client-go/tools/record
+k8s.io/client-go/tools/record/util
 k8s.io/client-go/tools/reference
 k8s.io/client-go/transport
 k8s.io/client-go/util/apply
@@ -1104,7 +1109,9 @@ k8s.io/kube-openapi/pkg/validation/spec
 k8s.io/utils/buffer
 k8s.io/utils/clock
 k8s.io/utils/dump
+k8s.io/utils/internal/third_party/forked/golang/golang-lru
 k8s.io/utils/internal/third_party/forked/golang/net
+k8s.io/utils/lru
 k8s.io/utils/net
 k8s.io/utils/ptr
 k8s.io/utils/trace


### PR DESCRIPTION
## Summary

Gate StatefulSet zone progression on cell-level PromQL health checks so a bad zone soak can pause the rollout before the next zone starts, instead of relying on pod readiness alone.

* New namespaced `RolloutHealthCheck` CRD and `grafana.com/rollout-health-check` annotation
* Checks use design-doc `errorPolicy` / `failurePolicy` / `noDataPolicy` (retries and consecutive pass/fail across reconciles)
* Operator evaluates candidate vs baseline queries against Prometheus before starting subsequent zones (first zone remains ungated)
* `${targetMatchers}` includes namespace, zone (`name` label), and pod matchers
* Validating admission webhook for `RolloutHealthCheck` (same pattern as ZPDB)
* Failed / no-data / unreachable checks pause by default (`Warn` / `Disabled` supported); misconfigured bindings proceed with events + metrics
* Kubernetes events and Prometheus metrics for blocked and misconfigured rollouts

### Context

Implements Proposal 1b from the health-check driven progressive deployment design: health evaluation lives in rollout-operator rather than a separate per-cell Deployment. Integration coverage against a mocked Prometheus is left as follow-up.

Fixes https://github.com/grafana/rollout-operator/issues/178

Made with [Cursor](https://cursor.com)