### PR TITLE
Add Lease leader election

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [CHANGE] Prefer `grafana.com/min-time-between-zones-downscale` as a StatefulSet annotation instead of a label. The label remains supported as a fallback and logs a deprecation warning when used. #463
 * [BUGFIX] Allow a StatefulSet rollout to recover when pods from a previous failed update are stuck in an unrecoverable state (e.g. `CrashLoopBackOff` or `ImagePullBackOff`): outdated stuck pods are deleted even when the `rollout-max-unavailable` budget is exhausted, since deleting an already-unavailable pod doesn't reduce availability. A subsequent Spec update can then replace them without a manual delete. #466
+* [FEATURE] Added Kubernetes Lease leader election so only one rollout-operator instance runs controllers and admission webhooks.
 * [ENHANCEMENT] Updated dependencies, including: #470
   * `github.com/prometheus/client_golang` from `v1.23.2` to `v1.24.1`
   * `github.com/prometheus/common` from `v0.70.0` to `v0.70.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main / unreleased
 
+* [FEATURE] Added Kubernetes Lease leader election so only one rollout-operator instance runs controllers and admission webhooks.
 * [CHANGE] ZPDB cross-zone eviction delays use the Pod Ready condition's `lastTransitionTime` instead of the `grafana.com/ready-time` annotation, eliminating annotation PATCH requests and measuring the delay from Kubernetes readiness transitions. The `-zpdb.pod-ready-annotation-patch-timeout` flag is deprecated, has no effect, and logs a warning when supplied. #498
 * [ENHANCEMENT] Update Go to `1.27` #494
 * [ENHANCEMENT] Updated dependencies, including: #491

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Offers a `ValidatingAdmissionWebhook` to validate `ZoneAwarePodDisruptionBudget`
 
 ### RBAC
 
-When running the `rollout-operator` as a pod, it needs a Role with at least the following privileges:
+When running the `rollout-operator` as a pod, it uses a Kubernetes Lease to ensure only one instance is active. It needs a Role with at least the following privileges:
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -215,6 +215,14 @@ rules:
   resources:
   - statefulsets/status
   verbs:
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
   - update
 - apiGroups:
   - rollout-operator.grafana.com

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/google/uuid"
 	"github.com/grafana/dskit/clusterutil"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/tracing"
@@ -25,12 +26,16 @@ import (
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Required to get the GCP auth provider working.
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/grafana/rollout-operator/pkg/admission"
@@ -62,6 +67,11 @@ type config struct {
 	podClientTimeout     time.Duration
 	reconcileInterval    time.Duration
 	clusterValidationCfg clusterutil.ClusterValidationProtocolConfigForHTTP
+
+	leaderElectionLeaseName     string
+	leaderElectionLeaseDuration time.Duration
+	leaderElectionRenewDeadline time.Duration
+	leaderElectionRetryPeriod   time.Duration
 
 	serverTLSEnabled        bool
 	serverTLSPort           int
@@ -97,6 +107,11 @@ func (cfg *config) register(fs *flag.FlagSet) {
 	fs.StringVar(&cfg.kubeNamespace, "kubernetes.namespace", "", "The Kubernetes namespace for which this operator is running.")
 	fs.DurationVar(&cfg.reconcileInterval, "reconcile.interval", 5*time.Second, "The minimum interval of reconciliation.")
 	cfg.clusterValidationCfg.RegisterFlagsWithPrefix("server.cluster-validation.http.", fs)
+
+	fs.StringVar(&cfg.leaderElectionLeaseName, "leader-election.lease-name", "rollout-operator", "Name of the Lease used to ensure only one rollout-operator is active in the namespace.")
+	fs.DurationVar(&cfg.leaderElectionLeaseDuration, "leader-election.lease-duration", 15*time.Second, "Duration that non-leaders wait before attempting to acquire an unrenewed leader election Lease.")
+	fs.DurationVar(&cfg.leaderElectionRenewDeadline, "leader-election.renew-deadline", 10*time.Second, "Duration that the leader retries refreshing its Lease before giving up leadership.")
+	fs.DurationVar(&cfg.leaderElectionRetryPeriod, "leader-election.retry-period", 2*time.Second, "Interval between attempts to acquire or renew the leader election Lease.")
 
 	fs.BoolVar(&cfg.serverTLSEnabled, "server-tls.enabled", false, "Enable TLS server for webhook connections.")
 	fs.IntVar(&cfg.serverTLSPort, "server-tls.port", 8443, "Port to use for exposing TLS server for webhook connections (if enabled).")
@@ -135,6 +150,25 @@ func (cfg config) validate() error {
 	}
 	if cfg.kubeClientQPS > 0 && cfg.kubeClientBurst < 1 {
 		return errors.New("-kubernetes.client-burst must be at least 1 when -kubernetes.client-qps is greater than 0, since each request consumes one token")
+	}
+	if cfg.leaderElectionLeaseName == "" {
+		return errors.New("-leader-election.lease-name cannot be an empty string")
+	}
+	if cfg.leaderElectionLeaseDuration < time.Second {
+		return errors.New("-leader-election.lease-duration must be at least one second")
+	}
+	if cfg.leaderElectionRenewDeadline <= 0 {
+		return errors.New("-leader-election.renew-deadline must be positive")
+	}
+	if cfg.leaderElectionRetryPeriod <= 0 {
+		return errors.New("-leader-election.retry-period must be positive")
+	}
+	serializedLeaseDuration := cfg.leaderElectionLeaseDuration.Truncate(time.Second)
+	if serializedLeaseDuration <= cfg.leaderElectionRenewDeadline {
+		return errors.New("-leader-election.lease-duration, truncated to whole seconds by Kubernetes, must be greater than -leader-election.renew-deadline")
+	}
+	if cfg.leaderElectionRenewDeadline <= time.Duration(leaderelection.JitterFactor*float64(cfg.leaderElectionRetryPeriod)) {
+		return errors.New("-leader-election.renew-deadline must be greater than -leader-election.retry-period multiplied by the client-go jitter factor")
 	}
 	if cfg.serverTLSRequestTimeout <= 0 {
 		return errors.New("-server-tls.request-timeout must be positive")
@@ -258,6 +292,43 @@ func main() {
 		fatal(fmt.Errorf("failed to init dynamicClient: %w", err))
 	}
 
+	hostname, err := os.Hostname()
+	if err != nil {
+		fatal(fmt.Errorf("failed to determine leader election identity: %w", err))
+	}
+	identity := fmt.Sprintf("%s_%s", hostname, uuid.NewString())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		waitForSignalOrRestart(logger, restart)
+		cancel()
+	}()
+
+	err = runWithLeaderElection(ctx, coreKubeClient, cfg, identity, logger, ready, func(leaderCtx context.Context) {
+		runOperator(leaderCtx, cfg, kubeConfig, podHTTPClient, logger, coreKubeClient, dynamicClient, restMapper, scaleClient, restart, reg, metrics, zpdbMetrics, ready)
+	})
+	if err != nil {
+		fatal(err)
+	}
+}
+
+func runOperator(
+	ctx context.Context,
+	cfg config,
+	kubeConfig *rest.Config,
+	podHTTPClient *instrumentation.PodHTTPClient,
+	logger log.Logger,
+	coreKubeClient *kubernetes.Clientset,
+	dynamicClient dynamic.Interface,
+	restMapper meta.RESTMapper,
+	scaleClient scale.ScalesGetter,
+	restart chan string,
+	reg *prometheus.Registry,
+	metrics *metrics,
+	zpdbMetrics *zpdb.Metrics,
+	ready *atomic.Bool,
+) {
 	// watches for validating webhooks being added - this is only started if the TLS server is started
 	webhookObserver := tlscert.NewWebhookObserver(coreKubeClient, cfg.kubeNamespace, logger)
 
@@ -295,9 +366,10 @@ func main() {
 		fatal(fmt.Errorf("failed to init controller: %w", err))
 	}
 
-	// Listen to sigterm, as well as for restart (like for certificate renewal).
+	// Stop all leader-only work before another pod can take over.
 	go func() {
-		waitForSignalOrRestart(logger, restart)
+		<-ctx.Done()
+		ready.Store(false)
 		c.Stop()
 		evictionController.Stop()
 		webhookObserver.Stop()
@@ -312,6 +384,66 @@ func main() {
 
 	// Run and block until stopped.
 	c.Run()
+	if ctx.Err() == nil {
+		fatal(errors.New("rollout controller stopped unexpectedly"))
+	}
+}
+
+func runWithLeaderElection(
+	ctx context.Context,
+	client kubernetes.Interface,
+	cfg config,
+	identity string,
+	logger log.Logger,
+	ready *atomic.Bool,
+	run func(context.Context),
+) error {
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      cfg.leaderElectionLeaseName,
+			Namespace: cfg.kubeNamespace,
+		},
+		Client: client.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: identity,
+		},
+	}
+
+	elector, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:          lock,
+		LeaseDuration: cfg.leaderElectionLeaseDuration,
+		RenewDeadline: cfg.leaderElectionRenewDeadline,
+		RetryPeriod:   cfg.leaderElectionRetryPeriod,
+		// OnStartedLeading runs asynchronously, so waiting for expiration prevents a replacement
+		// from taking over before all leader-only controllers and webhooks have stopped.
+		ReleaseOnCancel: false,
+		Name:            "rollout-operator",
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(leaderCtx context.Context) {
+				level.Info(logger).Log("msg", "acquired leader election lease", "lease", cfg.leaderElectionLeaseName, "identity", identity)
+				run(leaderCtx)
+			},
+			OnStoppedLeading: func() {
+				// Followers must not receive webhook traffic because admission state is process-local.
+				ready.Store(false)
+			},
+			OnNewLeader: func(newIdentity string) {
+				if newIdentity != identity {
+					level.Info(logger).Log("msg", "new leader elected", "lease", cfg.leaderElectionLeaseName, "identity", newIdentity)
+				}
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to configure leader election: %w", err)
+	}
+
+	elector.Run(ctx)
+	ready.Store(false)
+	if ctx.Err() != nil {
+		return nil
+	}
+	return errors.New("leader election lease lost")
 }
 
 func waitForSignalOrRestart(logger log.Logger, restart chan string) {

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/google/uuid"
 	"github.com/grafana/dskit/clusterutil"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/tracing"
@@ -25,12 +26,16 @@ import (
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Required to get the GCP auth provider working.
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/grafana/rollout-operator/pkg/admission"
@@ -64,6 +69,11 @@ type config struct {
 	podClientTimeout     time.Duration
 	reconcileInterval    time.Duration
 	clusterValidationCfg clusterutil.ClusterValidationProtocolConfigForHTTP
+
+	leaderElectionLeaseName     string
+	leaderElectionLeaseDuration time.Duration
+	leaderElectionRenewDeadline time.Duration
+	leaderElectionRetryPeriod   time.Duration
 
 	serverTLSEnabled        bool
 	serverTLSPort           int
@@ -99,6 +109,11 @@ func (cfg *config) register(fs *flag.FlagSet) {
 	fs.StringVar(&cfg.kubeNamespace, "kubernetes.namespace", "", "The Kubernetes namespace for which this operator is running.")
 	fs.DurationVar(&cfg.reconcileInterval, "reconcile.interval", 5*time.Second, "The minimum interval of reconciliation.")
 	cfg.clusterValidationCfg.RegisterFlagsWithPrefix("server.cluster-validation.http.", fs)
+
+	fs.StringVar(&cfg.leaderElectionLeaseName, "leader-election.lease-name", "rollout-operator", "Name of the Lease used to ensure only one rollout-operator is active in the namespace.")
+	fs.DurationVar(&cfg.leaderElectionLeaseDuration, "leader-election.lease-duration", 15*time.Second, "Duration that non-leaders wait before attempting to acquire an unrenewed leader election Lease.")
+	fs.DurationVar(&cfg.leaderElectionRenewDeadline, "leader-election.renew-deadline", 10*time.Second, "Duration that the leader retries refreshing its Lease before giving up leadership.")
+	fs.DurationVar(&cfg.leaderElectionRetryPeriod, "leader-election.retry-period", 2*time.Second, "Interval between attempts to acquire or renew the leader election Lease.")
 
 	fs.BoolVar(&cfg.serverTLSEnabled, "server-tls.enabled", false, "Enable TLS server for webhook connections.")
 	fs.IntVar(&cfg.serverTLSPort, "server-tls.port", 8443, "Port to use for exposing TLS server for webhook connections (if enabled).")
@@ -144,6 +159,25 @@ func (cfg config) validate() error {
 	}
 	if cfg.kubeClientQPS > 0 && cfg.kubeClientBurst < 1 {
 		return errors.New("-kubernetes.client-burst must be at least 1 when -kubernetes.client-qps is greater than 0, since each request consumes one token")
+	}
+	if cfg.leaderElectionLeaseName == "" {
+		return errors.New("-leader-election.lease-name cannot be an empty string")
+	}
+	if cfg.leaderElectionLeaseDuration < time.Second {
+		return errors.New("-leader-election.lease-duration must be at least one second")
+	}
+	if cfg.leaderElectionRenewDeadline <= 0 {
+		return errors.New("-leader-election.renew-deadline must be positive")
+	}
+	if cfg.leaderElectionRetryPeriod <= 0 {
+		return errors.New("-leader-election.retry-period must be positive")
+	}
+	serializedLeaseDuration := cfg.leaderElectionLeaseDuration.Truncate(time.Second)
+	if serializedLeaseDuration <= cfg.leaderElectionRenewDeadline {
+		return errors.New("-leader-election.lease-duration, truncated to whole seconds by Kubernetes, must be greater than -leader-election.renew-deadline")
+	}
+	if cfg.leaderElectionRenewDeadline <= time.Duration(leaderelection.JitterFactor*float64(cfg.leaderElectionRetryPeriod)) {
+		return errors.New("-leader-election.renew-deadline must be greater than -leader-election.retry-period multiplied by the client-go jitter factor")
 	}
 	if cfg.serverTLSRequestTimeout <= 0 {
 		return errors.New("-server-tls.request-timeout must be positive")
@@ -279,6 +313,43 @@ func main() {
 		fatal(fmt.Errorf("failed to init dynamicClient: %w", err))
 	}
 
+	hostname, err := os.Hostname()
+	if err != nil {
+		fatal(fmt.Errorf("failed to determine leader election identity: %w", err))
+	}
+	identity := fmt.Sprintf("%s_%s", hostname, uuid.NewString())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		waitForSignalOrRestart(logger, restart)
+		cancel()
+	}()
+
+	err = runWithLeaderElection(ctx, coreKubeClient, cfg, identity, logger, ready, func(leaderCtx context.Context) {
+		runOperator(leaderCtx, cfg, wireComponentConfig, podHTTPClient, logger, coreKubeClient, dynamicClient, restMapper, scaleClient, restart, reg, metrics, zpdbMetrics, ready)
+	})
+	if err != nil {
+		fatal(err)
+	}
+}
+
+func runOperator(
+	ctx context.Context,
+	cfg config,
+	wireComponentConfig func(string) *rest.Config,
+	podHTTPClient *instrumentation.PodHTTPClient,
+	logger log.Logger,
+	coreKubeClient *kubernetes.Clientset,
+	dynamicClient dynamic.Interface,
+	restMapper meta.RESTMapper,
+	scaleClient scale.ScalesGetter,
+	restart chan string,
+	reg *prometheus.Registry,
+	metrics *metrics,
+	zpdbMetrics *zpdb.Metrics,
+	ready *atomic.Bool,
+) {
 	// watches for validating webhooks being added - this is only started if the TLS server is started
 	webhookObserver := tlscert.NewWebhookObserver(coreKubeClient, cfg.kubeNamespace, logger)
 
@@ -319,9 +390,10 @@ func main() {
 		fatal(fmt.Errorf("failed to init controller: %w", err))
 	}
 
-	// Listen to sigterm, as well as for restart (like for certificate renewal).
+	// Stop all leader-only work before another pod can take over.
 	go func() {
-		waitForSignalOrRestart(logger, restart)
+		<-ctx.Done()
+		ready.Store(false)
 		c.Stop()
 		evictionController.Stop()
 		webhookObserver.Stop()
@@ -336,6 +408,66 @@ func main() {
 
 	// Run and block until stopped.
 	c.Run()
+	if ctx.Err() == nil {
+		fatal(errors.New("rollout controller stopped unexpectedly"))
+	}
+}
+
+func runWithLeaderElection(
+	ctx context.Context,
+	client kubernetes.Interface,
+	cfg config,
+	identity string,
+	logger log.Logger,
+	ready *atomic.Bool,
+	run func(context.Context),
+) error {
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      cfg.leaderElectionLeaseName,
+			Namespace: cfg.kubeNamespace,
+		},
+		Client: client.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: identity,
+		},
+	}
+
+	elector, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:          lock,
+		LeaseDuration: cfg.leaderElectionLeaseDuration,
+		RenewDeadline: cfg.leaderElectionRenewDeadline,
+		RetryPeriod:   cfg.leaderElectionRetryPeriod,
+		// OnStartedLeading runs asynchronously, so waiting for expiration prevents a replacement
+		// from taking over before all leader-only controllers and webhooks have stopped.
+		ReleaseOnCancel: false,
+		Name:            "rollout-operator",
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(leaderCtx context.Context) {
+				level.Info(logger).Log("msg", "acquired leader election lease", "lease", cfg.leaderElectionLeaseName, "identity", identity)
+				run(leaderCtx)
+			},
+			OnStoppedLeading: func() {
+				// Followers must not receive webhook traffic because admission state is process-local.
+				ready.Store(false)
+			},
+			OnNewLeader: func(newIdentity string) {
+				if newIdentity != identity {
+					level.Info(logger).Log("msg", "new leader elected", "lease", cfg.leaderElectionLeaseName, "identity", newIdentity)
+				}
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to configure leader election: %w", err)
+	}
+
+	elector.Run(ctx)
+	ready.Store(false)
+	if ctx.Err() != nil {
+		return nil
+	}
+	return errors.New("leader election lease lost")
 }
 
 func waitForSignalOrRestart(logger log.Logger, restart chan string) {

--- a/cmd/rollout-operator/main_test.go
+++ b/cmd/rollout-operator/main_test.go
@@ -1,12 +1,89 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestConfigValidateLeaderElection(t *testing.T) {
+	tests := map[string]func(*config){
+		"empty lease name": func(cfg *config) {
+			cfg.leaderElectionLeaseName = ""
+		},
+		"subsecond lease duration": func(cfg *config) {
+			cfg.leaderElectionLeaseDuration = 500 * time.Millisecond
+			cfg.leaderElectionRenewDeadline = 400 * time.Millisecond
+			cfg.leaderElectionRetryPeriod = 100 * time.Millisecond
+		},
+		"lease duration not greater than renew deadline": func(cfg *config) {
+			cfg.leaderElectionLeaseDuration = cfg.leaderElectionRenewDeadline
+		},
+		"serialized lease duration not greater than renew deadline": func(cfg *config) {
+			cfg.leaderElectionLeaseDuration = 1500 * time.Millisecond
+			cfg.leaderElectionRenewDeadline = 1400 * time.Millisecond
+			cfg.leaderElectionRetryPeriod = 100 * time.Millisecond
+		},
+		"renew deadline does not allow for retry jitter": func(cfg *config) {
+			cfg.leaderElectionRenewDeadline = 110 * time.Millisecond
+			cfg.leaderElectionRetryPeriod = 100 * time.Millisecond
+		},
+		"non-positive retry period": func(cfg *config) {
+			cfg.leaderElectionRetryPeriod = 0
+		},
+	}
+
+	for name, modify := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := newValidConfig(t)
+			modify(&cfg)
+			require.Error(t, cfg.validate())
+		})
+	}
+}
+
+func TestRunWithLeaderElectionAcquiresLease(t *testing.T) {
+	cfg := newValidConfig(t)
+	cfg.leaderElectionLeaseDuration = 2 * time.Second
+	cfg.leaderElectionRenewDeadline = time.Second
+	cfg.leaderElectionRetryPeriod = 100 * time.Millisecond
+
+	client := fake.NewSimpleClientset()
+	ready := atomic.NewBool(false)
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	result := make(chan error, 1)
+
+	go func() {
+		result <- runWithLeaderElection(ctx, client, cfg, "test-pod", log.NewNopLogger(), ready, func(leaderCtx context.Context) {
+			ready.Store(true)
+			close(started)
+			<-leaderCtx.Done()
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting to acquire leader election lease")
+	}
+
+	lease, err := client.CoordinationV1().Leases(cfg.kubeNamespace).Get(t.Context(), cfg.leaderElectionLeaseName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, lease.Spec.HolderIdentity)
+	require.Equal(t, "test-pod", *lease.Spec.HolderIdentity)
+
+	cancel()
+	require.NoError(t, <-result)
+	require.False(t, ready.Load())
+}
 
 // newValidConfig returns a config populated with the flag defaults and the minimum required fields set,
 // so that cfg.validate() passes. Individual tests override only the field under test.

--- a/cmd/rollout-operator/main_test.go
+++ b/cmd/rollout-operator/main_test.go
@@ -2,13 +2,89 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestConfigValidateLeaderElection(t *testing.T) {
+	tests := map[string]func(*config){
+		"empty lease name": func(cfg *config) {
+			cfg.leaderElectionLeaseName = ""
+		},
+		"subsecond lease duration": func(cfg *config) {
+			cfg.leaderElectionLeaseDuration = 500 * time.Millisecond
+			cfg.leaderElectionRenewDeadline = 400 * time.Millisecond
+			cfg.leaderElectionRetryPeriod = 100 * time.Millisecond
+		},
+		"lease duration not greater than renew deadline": func(cfg *config) {
+			cfg.leaderElectionLeaseDuration = cfg.leaderElectionRenewDeadline
+		},
+		"serialized lease duration not greater than renew deadline": func(cfg *config) {
+			cfg.leaderElectionLeaseDuration = 1500 * time.Millisecond
+			cfg.leaderElectionRenewDeadline = 1400 * time.Millisecond
+			cfg.leaderElectionRetryPeriod = 100 * time.Millisecond
+		},
+		"renew deadline does not allow for retry jitter": func(cfg *config) {
+			cfg.leaderElectionRenewDeadline = 110 * time.Millisecond
+			cfg.leaderElectionRetryPeriod = 100 * time.Millisecond
+		},
+		"non-positive retry period": func(cfg *config) {
+			cfg.leaderElectionRetryPeriod = 0
+		},
+	}
+
+	for name, modify := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := newValidConfig(t)
+			modify(&cfg)
+			require.Error(t, cfg.validate())
+		})
+	}
+}
+
+func TestRunWithLeaderElectionAcquiresLease(t *testing.T) {
+	cfg := newValidConfig(t)
+	cfg.leaderElectionLeaseDuration = 2 * time.Second
+	cfg.leaderElectionRenewDeadline = time.Second
+	cfg.leaderElectionRetryPeriod = 100 * time.Millisecond
+
+	client := fake.NewSimpleClientset()
+	ready := atomic.NewBool(false)
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	result := make(chan error, 1)
+
+	go func() {
+		result <- runWithLeaderElection(ctx, client, cfg, "test-pod", log.NewNopLogger(), ready, func(leaderCtx context.Context) {
+			ready.Store(true)
+			close(started)
+			<-leaderCtx.Done()
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting to acquire leader election lease")
+	}
+
+	lease, err := client.CoordinationV1().Leases(cfg.kubeNamespace).Get(t.Context(), cfg.leaderElectionLeaseName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, lease.Spec.HolderIdentity)
+	require.Equal(t, "test-pod", *lease.Spec.HolderIdentity)
+
+	cancel()
+	require.NoError(t, <-result)
+	require.False(t, ready.Load())
+}
 
 // newValidConfig returns a config populated with the flag defaults and the minimum required fields set,
 // so that cfg.validate() passes. Individual tests override only the field under test.

--- a/development/rollout-operator-role.yaml
+++ b/development/rollout-operator-role.yaml
@@ -29,6 +29,14 @@ rules:
     verbs:
       - update
   - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
       - rollout-operator.grafana.com
     resources:
       - zoneawarepoddisruptionbudgets

--- a/operations/policies/policies_role.rego
+++ b/operations/policies/policies_role.rego
@@ -23,6 +23,11 @@ expected_rules = [
     "resources": ["configmaps"],
     "verbs": ["get", "update", "create"],
   },
+  {
+    "apiGroups": ["coordination.k8s.io"],
+    "resources": ["leases"],
+    "verbs": ["get", "create", "update"],
+  },
 ]
 
 extra_zpdb_rule = {

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -199,6 +199,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -198,6 +198,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -44,6 +44,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -43,6 +43,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -199,6 +199,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -198,6 +198,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -123,6 +123,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - replicatemplates/scale

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -122,6 +122,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - replicatemplates/scale

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -199,6 +199,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - replicatemplates/scale

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -198,6 +198,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - replicatemplates/scale

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -123,6 +123,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -122,6 +122,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -123,6 +123,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -122,6 +122,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -123,6 +123,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -122,6 +122,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -123,6 +123,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -122,6 +122,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -123,6 +123,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -122,6 +122,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -123,6 +123,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -122,6 +122,14 @@ rules:
   - update
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets

--- a/operations/rollout-operator/rollout-operator.libsonnet
+++ b/operations/rollout-operator/rollout-operator.libsonnet
@@ -134,6 +134,9 @@
         policyRule.withApiGroups('') +
         policyRule.withResources(['configmaps']) +
         policyRule.withVerbs(['get', 'update', 'create']),
+        policyRule.withApiGroups('coordination.k8s.io') +
+        policyRule.withResources(['leases']) +
+        policyRule.withVerbs(['get', 'create', 'update']),
       ] +
       (
         if $._config.rollout_operator_replica_template_access_enabled then [

--- a/operations/rollout-operator/rollout-operator.libsonnet
+++ b/operations/rollout-operator/rollout-operator.libsonnet
@@ -133,6 +133,9 @@
         policyRule.withApiGroups('') +
         policyRule.withResources(['configmaps']) +
         policyRule.withVerbs(['get', 'update', 'create']),
+        policyRule.withApiGroups('coordination.k8s.io') +
+        policyRule.withResources(['leases']) +
+        policyRule.withVerbs(['get', 'create', 'update']),
       ] +
       (
         if $._config.rollout_operator_replica_template_access_enabled then [

--- a/vendor/k8s.io/client-go/tools/leaderelection/OWNERS
+++ b/vendor/k8s.io/client-go/tools/leaderelection/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - mikedanese
+  - jefftree
+reviewers:
+  - wojtek-t
+  - deads2k
+  - mikedanese
+  - ingvagabund
+  - jefftree
+emeritus_approvers:
+  - timothysc

--- a/vendor/k8s.io/client-go/tools/leaderelection/healthzadaptor.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/healthzadaptor.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+// HealthzAdaptor associates the /healthz endpoint with the LeaderElection object.
+// It helps deal with the /healthz endpoint being set up prior to the LeaderElection.
+// This contains the code needed to act as an adaptor between the leader
+// election code the health check code. It allows us to provide health
+// status about the leader election. Most specifically about if the leader
+// has failed to renew without exiting the process. In that case we should
+// report not healthy and rely on the kubelet to take down the process.
+type HealthzAdaptor struct {
+	pointerLock sync.Mutex
+	le          *LeaderElector
+	timeout     time.Duration
+}
+
+// Name returns the name of the health check we are implementing.
+func (l *HealthzAdaptor) Name() string {
+	return "leaderElection"
+}
+
+// Check is called by the healthz endpoint handler.
+// It fails (returns an error) if we own the lease but had not been able to renew it.
+func (l *HealthzAdaptor) Check(req *http.Request) error {
+	l.pointerLock.Lock()
+	defer l.pointerLock.Unlock()
+	if l.le == nil {
+		return nil
+	}
+	return l.le.Check(l.timeout)
+}
+
+// SetLeaderElection ties a leader election object to a HealthzAdaptor
+func (l *HealthzAdaptor) SetLeaderElection(le *LeaderElector) {
+	l.pointerLock.Lock()
+	defer l.pointerLock.Unlock()
+	l.le = le
+}
+
+// NewLeaderHealthzAdaptor creates a basic healthz adaptor to monitor a leader election.
+// timeout determines the time beyond the lease expiry to be allowed for timeout.
+// checks within the timeout period after the lease expires will still return healthy.
+func NewLeaderHealthzAdaptor(timeout time.Duration) *HealthzAdaptor {
+	result := &HealthzAdaptor{
+		timeout: timeout,
+	}
+	return result
+}

--- a/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -1,0 +1,561 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package leaderelection implements leader election of a set of endpoints.
+// It uses an annotation in the endpoints object to store the record of the
+// election state. This implementation does not guarantee that only one
+// client is acting as a leader (a.k.a. fencing).
+//
+// A client only acts on timestamps captured locally to infer the state of the
+// leader election. The client does not consider timestamps in the leader
+// election record to be accurate because these timestamps may not have been
+// produced by a local clock. The implemention does not depend on their
+// accuracy and only uses their change to indicate that another client has
+// renewed the leader lease. Thus the implementation is tolerant to arbitrary
+// clock skew, but is not tolerant to arbitrary clock skew rate.
+//
+// However the level of tolerance to skew rate can be configured by setting
+// RenewDeadline and LeaseDuration appropriately. The tolerance expressed as a
+// maximum tolerated ratio of time passed on the fastest node to time passed on
+// the slowest node can be approximately achieved with a configuration that sets
+// the same ratio of LeaseDuration to RenewDeadline. For example if a user wanted
+// to tolerate some nodes progressing forward in time twice as fast as other nodes,
+// the user could set LeaseDuration to 60 seconds and RenewDeadline to 30 seconds.
+//
+// While not required, some method of clock synchronization between nodes in the
+// cluster is highly recommended. It's important to keep in mind when configuring
+// this client that the tolerance to skew rate varies inversely to master
+// availability.
+//
+// Larger clusters often have a more lenient SLA for API latency. This should be
+// taken into account when configuring the client. The rate of leader transitions
+// should be monitored and RetryPeriod and LeaseDuration should be increased
+// until the rate is stable and acceptably low. It's important to keep in mind
+// when configuring this client that the tolerance to API latency varies inversely
+// to master availability.
+//
+// DISCLAIMER: this is an alpha API. This library will likely change significantly
+// or even be removed entirely in subsequent releases. Depend on this API at
+// your own risk.
+package leaderelection
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+const (
+	JitterFactor = 1.2
+)
+
+// NewLeaderElector creates a LeaderElector from a LeaderElectionConfig
+func NewLeaderElector(lec LeaderElectionConfig) (*LeaderElector, error) {
+	if lec.LeaseDuration <= lec.RenewDeadline {
+		return nil, fmt.Errorf("leaseDuration must be greater than renewDeadline")
+	}
+	if lec.RenewDeadline <= time.Duration(JitterFactor*float64(lec.RetryPeriod)) {
+		return nil, fmt.Errorf("renewDeadline must be greater than retryPeriod*JitterFactor")
+	}
+	if lec.LeaseDuration < 1 {
+		return nil, fmt.Errorf("leaseDuration must be greater than zero")
+	}
+	if lec.RenewDeadline < 1 {
+		return nil, fmt.Errorf("renewDeadline must be greater than zero")
+	}
+	if lec.RetryPeriod < 1 {
+		return nil, fmt.Errorf("retryPeriod must be greater than zero")
+	}
+	if lec.Callbacks.OnStartedLeading == nil {
+		return nil, fmt.Errorf("OnStartedLeading callback must not be nil")
+	}
+	if lec.Callbacks.OnStoppedLeading == nil {
+		return nil, fmt.Errorf("OnStoppedLeading callback must not be nil")
+	}
+
+	if lec.Lock == nil {
+		return nil, fmt.Errorf("Lock must not be nil.")
+	}
+	id := lec.Lock.Identity()
+	if id == "" {
+		return nil, fmt.Errorf("Lock identity is empty")
+	}
+
+	le := LeaderElector{
+		config:  lec,
+		clock:   clock.RealClock{},
+		metrics: globalMetricsFactory.newLeaderMetrics(),
+	}
+	le.metrics.leaderOff(le.config.Name)
+	return &le, nil
+}
+
+type LeaderElectionConfig struct {
+	// Lock is the resource that will be used for locking
+	Lock rl.Interface
+
+	// LeaseDuration is the duration that non-leader candidates will
+	// wait to force acquire leadership. This is measured against time of
+	// last observed ack.
+	//
+	// A client needs to wait a full LeaseDuration without observing a change to
+	// the record before it can attempt to take over. When all clients are
+	// shutdown and a new set of clients are started with different names against
+	// the same leader record, they must wait the full LeaseDuration before
+	// attempting to acquire the lease. Thus LeaseDuration should be as short as
+	// possible (within your tolerance for clock skew rate) to avoid a possible
+	// long waits in the scenario.
+	//
+	// Core clients default this value to 15 seconds.
+	LeaseDuration time.Duration
+	// RenewDeadline is the duration that the acting master will retry
+	// refreshing leadership before giving up.
+	//
+	// Core clients default this value to 10 seconds.
+	RenewDeadline time.Duration
+	// RetryPeriod is the duration the LeaderElector clients should wait
+	// between tries of actions.
+	//
+	// Core clients default this value to 2 seconds.
+	RetryPeriod time.Duration
+
+	// Callbacks are callbacks that are triggered during certain lifecycle
+	// events of the LeaderElector
+	Callbacks LeaderCallbacks
+
+	// WatchDog is the associated health checker
+	// WatchDog may be null if it's not needed/configured.
+	WatchDog *HealthzAdaptor
+
+	// ReleaseOnCancel should be set true if the lock should be released
+	// when the run context is cancelled. If you set this to true, you must
+	// ensure all code guarded by this lease has successfully completed
+	// prior to cancelling the context, or you may have two processes
+	// simultaneously acting on the critical path.
+	ReleaseOnCancel bool
+
+	// Name is the name of the resource lock for debugging
+	Name string
+
+	// Coordinated will use the Coordinated Leader Election feature
+	// WARNING: Coordinated leader election is ALPHA.
+	Coordinated bool
+}
+
+// LeaderCallbacks are callbacks that are triggered during certain
+// lifecycle events of the LeaderElector. These are invoked asynchronously.
+//
+// possible future callbacks:
+//   - OnChallenge()
+type LeaderCallbacks struct {
+	// OnStartedLeading is called when a LeaderElector client starts leading
+	OnStartedLeading func(context.Context)
+	// OnStoppedLeading is called when a LeaderElector client stops leading.
+	// This callback is always called when the LeaderElector exits, even if it did not start leading.
+	// Users should not assume that OnStoppedLeading is only called after OnStartedLeading.
+	// see: https://github.com/kubernetes/kubernetes/pull/127675#discussion_r1780059887
+	OnStoppedLeading func()
+	// OnNewLeader is called when the client observes a leader that is
+	// not the previously observed leader. This includes the first observed
+	// leader when the client starts.
+	OnNewLeader func(identity string)
+}
+
+// LeaderElector is a leader election client.
+type LeaderElector struct {
+	config LeaderElectionConfig
+	// internal bookkeeping
+	observedRecord    rl.LeaderElectionRecord
+	observedRawRecord []byte
+	observedTime      time.Time
+	// used to implement OnNewLeader(), may lag slightly from the
+	// value observedRecord.HolderIdentity if the transition has
+	// not yet been reported.
+	reportedLeader string
+
+	// clock is wrapper around time to allow for less flaky testing
+	clock clock.Clock
+
+	// used to lock the observedRecord and the observedTime
+	observedRecordLock sync.RWMutex
+
+	metrics leaderMetricsAdapter
+}
+
+// Run starts the leader election loop. Run will not return
+// before leader election loop is stopped by ctx or it has
+// stopped holding the leader lease
+func (le *LeaderElector) Run(ctx context.Context) {
+	defer runtime.HandleCrashWithContext(ctx)
+	defer le.config.Callbacks.OnStoppedLeading()
+
+	if !le.acquire(ctx) {
+		return // ctx signalled done
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go le.config.Callbacks.OnStartedLeading(ctx)
+	le.renew(ctx)
+}
+
+// RunOrDie starts a client with the provided config or panics if the config
+// fails to validate. RunOrDie blocks until leader election loop is
+// stopped by ctx or it has stopped holding the leader lease
+func RunOrDie(ctx context.Context, lec LeaderElectionConfig) {
+	le, err := NewLeaderElector(lec)
+	if err != nil {
+		panic(err)
+	}
+	if lec.WatchDog != nil {
+		lec.WatchDog.SetLeaderElection(le)
+	}
+	le.Run(ctx)
+}
+
+// GetLeader returns the identity of the last observed leader or returns the empty string if
+// no leader has yet been observed.
+// This function is for informational purposes. (e.g. monitoring, logs, etc.)
+func (le *LeaderElector) GetLeader() string {
+	return le.getObservedRecord().HolderIdentity
+}
+
+// IsLeader returns true if the last observed leader was this client else returns false.
+func (le *LeaderElector) IsLeader() bool {
+	return le.getObservedRecord().HolderIdentity == le.config.Lock.Identity()
+}
+
+// acquire loops calling tryAcquireOrRenew and returns true immediately when tryAcquireOrRenew succeeds.
+// Returns false if ctx signals done.
+func (le *LeaderElector) acquire(ctx context.Context) bool {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	succeeded := false
+	desc := le.config.Lock.Describe()
+	logger := klog.FromContext(ctx)
+	logger.Info("Attempting to acquire leader lease...", "lock", desc)
+	wait.JitterUntilWithContext(ctx, func(ctx context.Context) {
+		if !le.config.Coordinated {
+			succeeded = le.tryAcquireOrRenew(ctx)
+		} else {
+			succeeded = le.tryCoordinatedRenew(ctx)
+		}
+		le.maybeReportTransition()
+		if !succeeded {
+			logger.V(4).Info("Failed to acquire lease", "lock", desc)
+			return
+		}
+		le.config.Lock.RecordEvent("became leader")
+		le.metrics.leaderOn(le.config.Name)
+		logger.Info("Successfully acquired lease", "lock", desc)
+		cancel()
+	}, le.config.RetryPeriod, JitterFactor, true)
+	return succeeded
+}
+
+// renew loops calling tryAcquireOrRenew and returns immediately when tryAcquireOrRenew fails or ctx signals done.
+func (le *LeaderElector) renew(ctx context.Context) {
+	defer le.config.Lock.RecordEvent("stopped leading")
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	logger := klog.FromContext(ctx)
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
+		err := wait.PollUntilContextTimeout(ctx, le.config.RetryPeriod, le.config.RenewDeadline, true, func(ctx context.Context) (done bool, err error) {
+			// PollUntilContextTimeout invokes condition even when the context is canceled when immediate=true.
+			// Short-circuit this to prevent unnecessary processing and error log messages.
+			if err := ctx.Err(); err != nil {
+				return false, err
+			}
+			if !le.config.Coordinated {
+				return le.tryAcquireOrRenew(ctx), nil
+			} else {
+				return le.tryCoordinatedRenew(ctx), nil
+			}
+		})
+		le.maybeReportTransition()
+		desc := le.config.Lock.Describe()
+		if err == nil {
+			logger.V(5).Info("Successfully renewed lease", "lock", desc)
+			return
+		}
+		le.metrics.leaderOff(le.config.Name)
+		logger.Info("Failed to renew lease", "lock", desc, "err", err)
+		cancel()
+	}, le.config.RetryPeriod)
+
+	// if we hold the lease, give it up
+	if le.config.ReleaseOnCancel {
+		le.release(logger)
+	}
+}
+
+// release attempts to release the leader lease if we have acquired it.
+func (le *LeaderElector) release(logger klog.Logger) bool {
+	ctx := context.Background()
+	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, le.config.RenewDeadline)
+	defer timeoutCancel()
+	// update the resourceVersion of lease
+	oldLeaderElectionRecord, _, err := le.config.Lock.Get(timeoutCtx)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			logger.Error(err, "error retrieving resource lock", "lock", le.config.Lock.Describe())
+			return false
+		}
+		logger.Info("lease lock not found", "lock", le.config.Lock.Describe())
+		return false
+	}
+
+	if !le.IsLeader() {
+		return true
+	}
+	now := metav1.NewTime(le.clock.Now())
+	leaderElectionRecord := rl.LeaderElectionRecord{
+		LeaderTransitions:    oldLeaderElectionRecord.LeaderTransitions,
+		LeaseDurationSeconds: 1,
+		RenewTime:            now,
+		AcquireTime:          now,
+	}
+	if err := le.config.Lock.Update(timeoutCtx, leaderElectionRecord); err != nil {
+		logger.Error(err, "Failed to release lease", "lock", le.config.Lock.Describe())
+		return false
+	}
+
+	le.setObservedRecord(&leaderElectionRecord)
+	return true
+}
+
+// tryCoordinatedRenew checks if it acquired a lease and tries to renew the
+// lease if it has already been acquired. Returns true on success else returns
+// false.
+func (le *LeaderElector) tryCoordinatedRenew(ctx context.Context) bool {
+	logger := klog.FromContext(ctx)
+	now := metav1.NewTime(le.clock.Now())
+	leaderElectionRecord := rl.LeaderElectionRecord{
+		HolderIdentity:       le.config.Lock.Identity(),
+		LeaseDurationSeconds: int(le.config.LeaseDuration / time.Second),
+		RenewTime:            now,
+		AcquireTime:          now,
+	}
+
+	// 1. obtain the electionRecord
+	oldLeaderElectionRecord, oldLeaderElectionRawRecord, err := le.config.Lock.Get(ctx)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			logger.Error(err, "Error retrieving lease lock", "lock", le.config.Lock.Describe())
+			return false
+		}
+		logger.Info("Lease lock not found", "lock", le.config.Lock.Describe(), "err", err)
+		return false
+	}
+
+	// 2. Record obtained, check the Identity & Time
+	if !bytes.Equal(le.observedRawRecord, oldLeaderElectionRawRecord) {
+		le.setObservedRecord(oldLeaderElectionRecord)
+
+		le.observedRawRecord = oldLeaderElectionRawRecord
+	}
+
+	le.observedRecordLock.RLock()
+	obsTime := le.observedTime
+	le.observedRecordLock.RUnlock()
+
+	hasExpired := obsTime.Add(time.Second * time.Duration(oldLeaderElectionRecord.LeaseDurationSeconds)).Before(now.Time)
+	if hasExpired {
+		logger.Info("Lease has expired", "lock", le.config.Lock.Describe())
+		return false
+	}
+
+	if !le.IsLeader() {
+		logger.V(6).Info("Lease is held and has not yet expired", "lock", le.config.Lock.Describe(), "holder", oldLeaderElectionRecord.HolderIdentity)
+		return false
+	}
+
+	// 2b. If the lease has been marked as "end of term", don't renew it
+	if le.IsLeader() && oldLeaderElectionRecord.PreferredHolder != "" {
+		logger.V(4).Info("Lease is marked as 'end of term'", "lock", le.config.Lock.Describe())
+		// TODO: Instead of letting lease expire, the holder may deleted it directly
+		// This will not be compatible with all controllers, so it needs to be opt-in behavior.
+		// We must ensure all code guarded by this lease has successfully completed
+		// prior to releasing or there may be two processes
+		// simultaneously acting on the critical path.
+		// Usually once this returns false, the process is terminated..
+		// xref: OnStoppedLeading
+		return false
+	}
+
+	// 3. We're going to try to update. The leaderElectionRecord is set to it's default
+	// here. Let's correct it before updating.
+	if le.IsLeader() {
+		leaderElectionRecord.AcquireTime = oldLeaderElectionRecord.AcquireTime
+		leaderElectionRecord.LeaderTransitions = oldLeaderElectionRecord.LeaderTransitions
+		leaderElectionRecord.Strategy = oldLeaderElectionRecord.Strategy
+		le.metrics.slowpathExercised(le.config.Name)
+	} else {
+		leaderElectionRecord.LeaderTransitions = oldLeaderElectionRecord.LeaderTransitions + 1
+	}
+
+	// update the lock itself
+	if err = le.config.Lock.Update(ctx, leaderElectionRecord); err != nil {
+		logger.Error(err, "Failed to update lock", "lock", le.config.Lock.Describe())
+		return false
+	}
+
+	le.setObservedRecord(&leaderElectionRecord)
+	return true
+}
+
+// tryAcquireOrRenew tries to acquire a leader lease if it is not already acquired,
+// else it tries to renew the lease if it has already been acquired. Returns true
+// on success else returns false.
+func (le *LeaderElector) tryAcquireOrRenew(ctx context.Context) bool {
+	logger := klog.FromContext(ctx)
+	now := metav1.NewTime(le.clock.Now())
+	leaderElectionRecord := rl.LeaderElectionRecord{
+		HolderIdentity:       le.config.Lock.Identity(),
+		LeaseDurationSeconds: int(le.config.LeaseDuration / time.Second),
+		RenewTime:            now,
+		AcquireTime:          now,
+	}
+
+	// 1. fast path for the leader to update optimistically assuming that the record observed
+	// last time is the current version.
+	if le.IsLeader() && le.isLeaseValid(now.Time) {
+		oldObservedRecord := le.getObservedRecord()
+		leaderElectionRecord.AcquireTime = oldObservedRecord.AcquireTime
+		leaderElectionRecord.LeaderTransitions = oldObservedRecord.LeaderTransitions
+
+		err := le.config.Lock.Update(ctx, leaderElectionRecord)
+		if err == nil {
+			le.setObservedRecord(&leaderElectionRecord)
+			return true
+		}
+		logger.V(2).Info("Failed to update lease optimistically, falling back to slow path", "lock", le.config.Lock.Describe(), "err", err)
+	}
+
+	// 2. obtain or create the ElectionRecord
+	oldLeaderElectionRecord, oldLeaderElectionRawRecord, err := le.config.Lock.Get(ctx)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			logger.Error(err, "Error retrieving lease lock", "lock", le.config.Lock.Describe())
+			return false
+		}
+		if err = le.config.Lock.Create(ctx, leaderElectionRecord); err != nil {
+			logger.Error(err, "Error initially creating lease lock", "lock", le.config.Lock.Describe())
+			return false
+		}
+
+		le.setObservedRecord(&leaderElectionRecord)
+
+		return true
+	}
+
+	// 3. Record obtained, check the Identity & Time
+	if !bytes.Equal(le.observedRawRecord, oldLeaderElectionRawRecord) {
+		le.setObservedRecord(oldLeaderElectionRecord)
+
+		le.observedRawRecord = oldLeaderElectionRawRecord
+	}
+	if len(oldLeaderElectionRecord.HolderIdentity) > 0 && le.isLeaseValid(now.Time) && !le.IsLeader() {
+		logger.V(4).Info("Lease is held by and has not yet expired", "lock", le.config.Lock.Describe(), "holder", oldLeaderElectionRecord.HolderIdentity)
+		return false
+	}
+
+	// 4. We're going to try to update. The leaderElectionRecord is set to it's default
+	// here. Let's correct it before updating.
+	if le.IsLeader() {
+		leaderElectionRecord.AcquireTime = oldLeaderElectionRecord.AcquireTime
+		leaderElectionRecord.LeaderTransitions = oldLeaderElectionRecord.LeaderTransitions
+		le.metrics.slowpathExercised(le.config.Name)
+	} else {
+		leaderElectionRecord.LeaderTransitions = oldLeaderElectionRecord.LeaderTransitions + 1
+	}
+
+	// update the lock itself
+	if err = le.config.Lock.Update(ctx, leaderElectionRecord); err != nil {
+		logger.Error(err, "Failed to update lease", "lock", le.config.Lock.Describe())
+		return false
+	}
+
+	le.setObservedRecord(&leaderElectionRecord)
+	return true
+}
+
+func (le *LeaderElector) maybeReportTransition() {
+	if le.observedRecord.HolderIdentity == le.reportedLeader {
+		return
+	}
+	le.reportedLeader = le.observedRecord.HolderIdentity
+	if le.config.Callbacks.OnNewLeader != nil {
+		go le.config.Callbacks.OnNewLeader(le.reportedLeader)
+	}
+}
+
+// Check will determine if the current lease is expired by more than timeout.
+func (le *LeaderElector) Check(maxTolerableExpiredLease time.Duration) error {
+	if !le.IsLeader() {
+		// Currently not concerned with the case that we are hot standby
+		return nil
+	}
+	// If we are more than timeout seconds after the lease duration that is past the timeout
+	// on the lease renew. Time to start reporting ourselves as unhealthy. We should have
+	// died but conditions like deadlock can prevent this. (See #70819)
+	le.observedRecordLock.RLock()
+	lastObservation := le.observedTime
+	leaseDuration := le.config.LeaseDuration
+	le.observedRecordLock.RUnlock()
+
+	if le.clock.Since(lastObservation) > leaseDuration+maxTolerableExpiredLease {
+		return fmt.Errorf("failed election to renew leadership on lease %s", le.config.Name)
+	}
+
+	return nil
+}
+
+func (le *LeaderElector) isLeaseValid(now time.Time) bool {
+	// Lock to safely read both the time and the record
+	le.observedRecordLock.RLock()
+	defer le.observedRecordLock.RUnlock()
+
+	return le.observedTime.Add(time.Second * time.Duration(le.observedRecord.LeaseDurationSeconds)).After(now)
+}
+
+// setObservedRecord will set a new observedRecord and update observedTime to the current time.
+// Protect critical sections with lock.
+func (le *LeaderElector) setObservedRecord(observedRecord *rl.LeaderElectionRecord) {
+	le.observedRecordLock.Lock()
+	defer le.observedRecordLock.Unlock()
+
+	le.observedRecord = *observedRecord
+	le.observedTime = le.clock.Now()
+}
+
+// getObservedRecord returns observersRecord.
+// Protect critical sections with lock.
+func (le *LeaderElector) getObservedRecord() rl.LeaderElectionRecord {
+	le.observedRecordLock.RLock()
+	defer le.observedRecordLock.RUnlock()
+
+	return le.observedRecord
+}

--- a/vendor/k8s.io/client-go/tools/leaderelection/leasecandidate.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/leasecandidate.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/coordination/v1"
+	v1beta1 "k8s.io/api/coordination/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	coordinationv1beta1client "k8s.io/client-go/kubernetes/typed/coordination/v1beta1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+
+	coordinationv1beta1listers "k8s.io/client-go/listers/coordination/v1beta1"
+)
+
+const requeueInterval = 5 * time.Minute
+
+type CacheSyncWaiter interface {
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+}
+
+type LeaseCandidate struct {
+	leaseClient            coordinationv1beta1client.LeaseCandidateInterface
+	leaseCandidateInformer cache.SharedIndexInformer
+	leaseCandidateLister   coordinationv1beta1listers.LeaseCandidateLister
+	informerFactory        informers.SharedInformerFactory
+	hasSynced              cache.InformerSynced
+
+	// At most there will be one item in this Queue (since we only watch one item)
+	queue workqueue.TypedRateLimitingInterface[int]
+
+	name      string
+	namespace string
+
+	// controller lease
+	leaseName string
+
+	clock clock.Clock
+
+	binaryVersion, emulationVersion string
+	strategy                        v1.CoordinatedLeaseStrategy
+}
+
+// NewCandidate creates new LeaseCandidate controller that creates a
+// LeaseCandidate object if it does not exist and watches changes
+// to the corresponding object and renews if PingTime is set.
+// WARNING: This is an ALPHA feature. Ensure that the CoordinatedLeaderElection
+// feature gate is on.
+func NewCandidate(clientset kubernetes.Interface,
+	candidateNamespace string,
+	candidateName string,
+	targetLease string,
+	binaryVersion, emulationVersion string,
+	strategy v1.CoordinatedLeaseStrategy,
+) (*LeaseCandidate, CacheSyncWaiter, error) {
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", candidateName).String()
+	// A separate informer factory is required because this must start before informerFactories
+	// are started for leader elected components
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(
+		clientset, 5*time.Minute,
+		informers.WithNamespace(candidateNamespace),
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.FieldSelector = fieldSelector
+		}),
+	)
+	leaseCandidateInformer := informerFactory.Coordination().V1beta1().LeaseCandidates().Informer()
+	leaseCandidateLister := informerFactory.Coordination().V1beta1().LeaseCandidates().Lister()
+
+	lc := &LeaseCandidate{
+		leaseClient:            clientset.CoordinationV1beta1().LeaseCandidates(candidateNamespace),
+		leaseCandidateInformer: leaseCandidateInformer,
+		leaseCandidateLister:   leaseCandidateLister,
+		informerFactory:        informerFactory,
+		name:                   candidateName,
+		namespace:              candidateNamespace,
+		leaseName:              targetLease,
+		clock:                  clock.RealClock{},
+		binaryVersion:          binaryVersion,
+		emulationVersion:       emulationVersion,
+		strategy:               strategy,
+	}
+	lc.queue = workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[int](), workqueue.TypedRateLimitingQueueConfig[int]{Name: "leasecandidate"})
+
+	h, err := leaseCandidateInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			if leasecandidate, ok := newObj.(*v1beta1.LeaseCandidate); ok {
+				if leasecandidate.Spec.PingTime != nil && leasecandidate.Spec.PingTime.After(leasecandidate.Spec.RenewTime.Time) {
+					lc.enqueueLease()
+				}
+			}
+		},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	lc.hasSynced = h.HasSynced
+
+	return lc, informerFactory, nil
+}
+
+func (c *LeaseCandidate) Run(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	logger = klog.LoggerWithName(logger, "leasecandidate")
+	ctx = klog.NewContext(ctx, logger)
+
+	var wg sync.WaitGroup
+	defer func() {
+		c.queue.ShutDown()
+		wg.Wait()
+	}()
+
+	c.informerFactory.Start(ctx.Done())
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.hasSynced) {
+		return
+	}
+
+	c.enqueueLease()
+	wg.Go(func() {
+		c.runWorker(ctx)
+	})
+	<-ctx.Done()
+}
+
+func (c *LeaseCandidate) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *LeaseCandidate) processNextWorkItem(ctx context.Context) bool {
+	key, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.ensureLease(ctx)
+	if err == nil {
+		c.queue.AddAfter(key, requeueInterval)
+		return true
+	}
+
+	utilruntime.HandleErrorWithContext(ctx, err, "Ensuring lease failed")
+	c.queue.AddRateLimited(key)
+
+	return true
+}
+
+func (c *LeaseCandidate) enqueueLease() {
+	c.queue.Add(0)
+}
+
+// ensureLease creates the lease if it does not exist and renew it if it exists. Returns the lease and
+// a bool (true if this call created the lease), or any error that occurs.
+func (c *LeaseCandidate) ensureLease(ctx context.Context) error {
+	logger := klog.FromContext(ctx)
+	lease, err := c.leaseCandidateLister.LeaseCandidates(c.namespace).Get(c.name)
+	if apierrors.IsNotFound(err) {
+		logger.V(2).Info("Creating lease candidate")
+		// lease does not exist, create it.
+		leaseToCreate := c.newLeaseCandidate()
+		if _, err := c.leaseClient.Create(ctx, leaseToCreate, metav1.CreateOptions{}); err != nil {
+			return err
+		}
+		logger.V(2).Info("Created lease candidate")
+		return nil
+	} else if err != nil {
+		return err
+	}
+	logger.V(2).Info("Lease candidate exists. Renewing.")
+	clone := lease.DeepCopy()
+	clone.Spec.RenewTime = &metav1.MicroTime{Time: c.clock.Now()}
+	_, err = c.leaseClient.Update(ctx, clone, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *LeaseCandidate) newLeaseCandidate() *v1beta1.LeaseCandidate {
+	lc := &v1beta1.LeaseCandidate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.name,
+			Namespace: c.namespace,
+		},
+		Spec: v1beta1.LeaseCandidateSpec{
+			LeaseName:        c.leaseName,
+			BinaryVersion:    c.binaryVersion,
+			EmulationVersion: c.emulationVersion,
+			Strategy:         c.strategy,
+		},
+	}
+	lc.Spec.RenewTime = &metav1.MicroTime{Time: c.clock.Now()}
+	return lc
+}

--- a/vendor/k8s.io/client-go/tools/leaderelection/metrics.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/metrics.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"sync"
+)
+
+// This file provides abstractions for setting the provider (e.g., prometheus)
+// of metrics.
+
+type leaderMetricsAdapter interface {
+	leaderOn(name string)
+	leaderOff(name string)
+	slowpathExercised(name string)
+}
+
+// LeaderMetric instruments metrics used in leader election.
+type LeaderMetric interface {
+	On(name string)
+	Off(name string)
+	SlowpathExercised(name string)
+}
+
+type noopMetric struct{}
+
+func (noopMetric) On(name string)                {}
+func (noopMetric) Off(name string)               {}
+func (noopMetric) SlowpathExercised(name string) {}
+
+// defaultLeaderMetrics expects the caller to lock before setting any metrics.
+type defaultLeaderMetrics struct {
+	// leader's value indicates if the current process is the owner of name lease
+	leader LeaderMetric
+}
+
+func (m *defaultLeaderMetrics) leaderOn(name string) {
+	if m == nil {
+		return
+	}
+	m.leader.On(name)
+}
+
+func (m *defaultLeaderMetrics) leaderOff(name string) {
+	if m == nil {
+		return
+	}
+	m.leader.Off(name)
+}
+
+func (m *defaultLeaderMetrics) slowpathExercised(name string) {
+	if m == nil {
+		return
+	}
+	m.leader.SlowpathExercised(name)
+}
+
+type noMetrics struct{}
+
+func (noMetrics) leaderOn(name string)          {}
+func (noMetrics) leaderOff(name string)         {}
+func (noMetrics) slowpathExercised(name string) {}
+
+// MetricsProvider generates various metrics used by the leader election.
+type MetricsProvider interface {
+	NewLeaderMetric() LeaderMetric
+}
+
+type noopMetricsProvider struct{}
+
+func (noopMetricsProvider) NewLeaderMetric() LeaderMetric {
+	return noopMetric{}
+}
+
+var globalMetricsFactory = leaderMetricsFactory{
+	metricsProvider: noopMetricsProvider{},
+}
+
+type leaderMetricsFactory struct {
+	metricsProvider MetricsProvider
+
+	onlyOnce sync.Once
+}
+
+func (f *leaderMetricsFactory) setProvider(mp MetricsProvider) {
+	f.onlyOnce.Do(func() {
+		f.metricsProvider = mp
+	})
+}
+
+func (f *leaderMetricsFactory) newLeaderMetrics() leaderMetricsAdapter {
+	mp := f.metricsProvider
+	if mp == (noopMetricsProvider{}) {
+		return noMetrics{}
+	}
+	return &defaultLeaderMetrics{
+		leader: mp.NewLeaderMetric(),
+	}
+}
+
+// SetProvider sets the metrics provider for all subsequently created work
+// queues. Only the first call has an effect.
+func SetProvider(metricsProvider MetricsProvider) {
+	globalMetricsFactory.setProvider(metricsProvider)
+}

--- a/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	restclient "k8s.io/client-go/rest"
+)
+
+const (
+	LeaderElectionRecordAnnotationKey = "control-plane.alpha.kubernetes.io/leader"
+	endpointsResourceLock             = "endpoints"
+	configMapsResourceLock            = "configmaps"
+	LeasesResourceLock                = "leases"
+	endpointsLeasesResourceLock       = "endpointsleases"
+	configMapsLeasesResourceLock      = "configmapsleases"
+)
+
+// LeaderElectionRecord is the record that is stored in the leader election annotation.
+// This information should be used for observational purposes only and could be replaced
+// with a random string (e.g. UUID) with only slight modification of this code.
+// TODO(mikedanese): this should potentially be versioned
+type LeaderElectionRecord struct {
+	// HolderIdentity is the ID that owns the lease. If empty, no one owns this lease and
+	// all callers may acquire. Versions of this library prior to Kubernetes 1.14 will not
+	// attempt to acquire leases with empty identities and will wait for the full lease
+	// interval to expire before attempting to reacquire. This value is set to empty when
+	// a client voluntarily steps down.
+	HolderIdentity       string                      `json:"holderIdentity"`
+	LeaseDurationSeconds int                         `json:"leaseDurationSeconds"`
+	AcquireTime          metav1.Time                 `json:"acquireTime"`
+	RenewTime            metav1.Time                 `json:"renewTime"`
+	LeaderTransitions    int                         `json:"leaderTransitions"`
+	Strategy             v1.CoordinatedLeaseStrategy `json:"strategy"`
+	PreferredHolder      string                      `json:"preferredHolder"`
+}
+
+// EventRecorder records a change in the ResourceLock.
+type EventRecorder interface {
+	Eventf(obj runtime.Object, eventType, reason, message string, args ...interface{})
+}
+
+// ResourceLockConfig common data that exists across different
+// resource locks
+type ResourceLockConfig struct {
+	// Identity is the unique string identifying a lease holder across
+	// all participants in an election.
+	Identity string
+	// EventRecorder is optional.
+	EventRecorder EventRecorder
+}
+
+// Interface offers a common interface for locking on arbitrary
+// resources used in leader election.  The Interface is used
+// to hide the details on specific implementations in order to allow
+// them to change over time.  This interface is strictly for use
+// by the leaderelection code.
+type Interface interface {
+	// Get returns the LeaderElectionRecord
+	Get(ctx context.Context) (*LeaderElectionRecord, []byte, error)
+
+	// Create attempts to create a LeaderElectionRecord
+	Create(ctx context.Context, ler LeaderElectionRecord) error
+
+	// Update will update and existing LeaderElectionRecord
+	Update(ctx context.Context, ler LeaderElectionRecord) error
+
+	// RecordEvent is used to record events
+	RecordEvent(string)
+
+	// Identity will return the locks Identity
+	Identity() string
+
+	// Describe is used to convert details on current resource lock
+	// into a string
+	Describe() string
+}
+
+// new will create a lock of a given type according to the input parameters
+func new(lockType string, ns string, name string, coreClient corev1.CoreV1Interface, coordinationClient coordinationv1.CoordinationV1Interface, rlc ResourceLockConfig, labels map[string]string) (Interface, error) {
+	leaseLock := &LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+		Client:     coordinationClient,
+		LockConfig: rlc,
+		Labels:     labels,
+	}
+	switch lockType {
+	case endpointsResourceLock:
+		return nil, fmt.Errorf("endpoints lock is removed, migrate to %s", LeasesResourceLock)
+	case configMapsResourceLock:
+		return nil, fmt.Errorf("configmaps lock is removed, migrate to %s", LeasesResourceLock)
+	case LeasesResourceLock:
+		return leaseLock, nil
+	case endpointsLeasesResourceLock:
+		return nil, fmt.Errorf("endpointsleases lock is removed, migrate to %s", LeasesResourceLock)
+	case configMapsLeasesResourceLock:
+		return nil, fmt.Errorf("configmapsleases lock is removed, migrated to %s", LeasesResourceLock)
+	default:
+		return nil, fmt.Errorf("Invalid lock-type %s", lockType)
+	}
+}
+
+// New will create a lock of a given type according to the input parameters
+func New(lockType string, ns string, name string, coreClient corev1.CoreV1Interface, coordinationClient coordinationv1.CoordinationV1Interface, rlc ResourceLockConfig) (Interface, error) {
+	return new(lockType, ns, name, coreClient, coordinationClient, rlc, nil)
+}
+
+// NewWithLabels will create a lock of a given type according to the input parameters
+// When the holder of the lock changes, that holder will apply their labels
+func NewWithLabels(lockType string, ns string, name string, coreClient corev1.CoreV1Interface, coordinationClient coordinationv1.CoordinationV1Interface, rlc ResourceLockConfig, labels map[string]string) (Interface, error) {
+	return new(lockType, ns, name, coreClient, coordinationClient, rlc, labels)
+}
+
+// NewFromKubeconfig will create a lock of a given type according to the input parameters.
+// Timeout set for a client used to contact to Kubernetes should be lower than
+// RenewDeadline to keep a single hung request from forcing a leader loss.
+// Setting it to max(time.Second, RenewDeadline/2) as a reasonable heuristic.
+func NewFromKubeconfig(lockType string, ns string, name string, rlc ResourceLockConfig, kubeconfig *restclient.Config, renewDeadline time.Duration) (Interface, error) {
+	// shallow copy, do not modify the kubeconfig
+	config := *kubeconfig
+	timeout := renewDeadline / 2
+	if timeout < time.Second {
+		timeout = time.Second
+	}
+	config.Timeout = timeout
+	leaderElectionClient := clientset.NewForConfigOrDie(restclient.AddUserAgent(&config, "leader-election"))
+	return New(lockType, ns, name, leaderElectionClient.CoreV1(), leaderElectionClient.CoordinationV1(), rlc)
+}

--- a/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coordinationv1client "k8s.io/client-go/kubernetes/typed/coordination/v1"
+)
+
+type LeaseLock struct {
+	// LeaseMeta should contain a Name and a Namespace of a
+	// LeaseMeta object that the LeaderElector will attempt to lead.
+	LeaseMeta  metav1.ObjectMeta
+	Client     coordinationv1client.LeasesGetter
+	LockConfig ResourceLockConfig
+	lease      *coordinationv1.Lease
+	Labels     map[string]string
+}
+
+// Get returns the election record from a Lease spec
+func (ll *LeaseLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte, error) {
+	lease, err := ll.Client.Leases(ll.LeaseMeta.Namespace).Get(ctx, ll.LeaseMeta.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	ll.lease = lease
+	record := LeaseSpecToLeaderElectionRecord(&ll.lease.Spec)
+	recordByte, err := json.Marshal(*record)
+	if err != nil {
+		return nil, nil, err
+	}
+	return record, recordByte, nil
+}
+
+// Create attempts to create a Lease
+func (ll *LeaseLock) Create(ctx context.Context, ler LeaderElectionRecord) error {
+	var err error
+	lease := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ll.LeaseMeta.Name,
+			Namespace: ll.LeaseMeta.Namespace,
+			Labels:    ll.Labels,
+		},
+		Spec: LeaderElectionRecordToLeaseSpec(&ler),
+	}
+
+	ll.lease, err = ll.Client.Leases(ll.LeaseMeta.Namespace).Create(ctx, lease, metav1.CreateOptions{})
+	return err
+}
+
+// Update will update an existing Lease spec.
+func (ll *LeaseLock) Update(ctx context.Context, ler LeaderElectionRecord) error {
+	if ll.lease == nil {
+		return errors.New("lease not initialized, call get or create first")
+	}
+	ll.lease.Spec = LeaderElectionRecordToLeaseSpec(&ler)
+
+	if ll.Labels != nil {
+		if ll.lease.Labels == nil {
+			ll.lease.Labels = map[string]string{}
+		}
+		// Only overwrite the labels that are specifically set
+		for k, v := range ll.Labels {
+			ll.lease.Labels[k] = v
+		}
+	}
+
+	lease, err := ll.Client.Leases(ll.LeaseMeta.Namespace).Update(ctx, ll.lease, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	ll.lease = lease
+	return nil
+}
+
+// RecordEvent in leader election while adding meta-data
+func (ll *LeaseLock) RecordEvent(s string) {
+	if ll.LockConfig.EventRecorder == nil {
+		return
+	}
+	events := fmt.Sprintf("%v %v", ll.LockConfig.Identity, s)
+	subject := &coordinationv1.Lease{ObjectMeta: ll.lease.ObjectMeta}
+	// Populate the type meta, so we don't have to get it from the schema
+	subject.Kind = "Lease"
+	subject.APIVersion = coordinationv1.SchemeGroupVersion.String()
+	ll.LockConfig.EventRecorder.Eventf(subject, corev1.EventTypeNormal, "LeaderElection", "%s", events)
+}
+
+// Describe is used to convert details on current resource lock
+// into a string
+func (ll *LeaseLock) Describe() string {
+	return fmt.Sprintf("%v/%v", ll.LeaseMeta.Namespace, ll.LeaseMeta.Name)
+}
+
+// Identity returns the Identity of the lock
+func (ll *LeaseLock) Identity() string {
+	return ll.LockConfig.Identity
+}
+
+func LeaseSpecToLeaderElectionRecord(spec *coordinationv1.LeaseSpec) *LeaderElectionRecord {
+	var r LeaderElectionRecord
+	if spec.HolderIdentity != nil {
+		r.HolderIdentity = *spec.HolderIdentity
+	}
+	if spec.LeaseDurationSeconds != nil {
+		r.LeaseDurationSeconds = int(*spec.LeaseDurationSeconds)
+	}
+	if spec.LeaseTransitions != nil {
+		r.LeaderTransitions = int(*spec.LeaseTransitions)
+	}
+	if spec.AcquireTime != nil {
+		r.AcquireTime = metav1.Time{Time: spec.AcquireTime.Time}
+	}
+	if spec.RenewTime != nil {
+		r.RenewTime = metav1.Time{Time: spec.RenewTime.Time}
+	}
+	if spec.PreferredHolder != nil {
+		r.PreferredHolder = *spec.PreferredHolder
+	}
+	if spec.Strategy != nil {
+		r.Strategy = *spec.Strategy
+	}
+	return &r
+
+}
+
+func LeaderElectionRecordToLeaseSpec(ler *LeaderElectionRecord) coordinationv1.LeaseSpec {
+	leaseDurationSeconds := int32(ler.LeaseDurationSeconds)
+	leaseTransitions := int32(ler.LeaderTransitions)
+	spec := coordinationv1.LeaseSpec{
+		HolderIdentity:       &ler.HolderIdentity,
+		LeaseDurationSeconds: &leaseDurationSeconds,
+		AcquireTime:          &metav1.MicroTime{Time: ler.AcquireTime.Time},
+		RenewTime:            &metav1.MicroTime{Time: ler.RenewTime.Time},
+		LeaseTransitions:     &leaseTransitions,
+	}
+	if ler.PreferredHolder != "" {
+		spec.PreferredHolder = &ler.PreferredHolder
+	}
+	if ler.Strategy != "" {
+		spec.Strategy = &ler.Strategy
+	}
+	return spec
+}

--- a/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/multilock.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/resourcelock/multilock.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+const (
+	UnknownLeader = "leaderelection.k8s.io/unknown"
+)
+
+// MultiLock is used for lock's migration
+type MultiLock struct {
+	Primary   Interface
+	Secondary Interface
+}
+
+// Get returns the older election record of the lock
+func (ml *MultiLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte, error) {
+	primary, primaryRaw, err := ml.Primary.Get(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secondary, secondaryRaw, err := ml.Secondary.Get(ctx)
+	if err != nil {
+		// Lock is held by old client
+		if apierrors.IsNotFound(err) && primary.HolderIdentity != ml.Identity() {
+			return primary, primaryRaw, nil
+		}
+		return nil, nil, err
+	}
+
+	if primary.HolderIdentity != secondary.HolderIdentity {
+		primary.HolderIdentity = UnknownLeader
+		primaryRaw, err = json.Marshal(primary)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return primary, ConcatRawRecord(primaryRaw, secondaryRaw), nil
+}
+
+// Create attempts to create both primary lock and secondary lock
+func (ml *MultiLock) Create(ctx context.Context, ler LeaderElectionRecord) error {
+	err := ml.Primary.Create(ctx, ler)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return ml.Secondary.Create(ctx, ler)
+}
+
+// Update will update and existing annotation on both two resources.
+func (ml *MultiLock) Update(ctx context.Context, ler LeaderElectionRecord) error {
+	err := ml.Primary.Update(ctx, ler)
+	if err != nil {
+		return err
+	}
+	_, _, err = ml.Secondary.Get(ctx)
+	if err != nil && apierrors.IsNotFound(err) {
+		return ml.Secondary.Create(ctx, ler)
+	}
+	return ml.Secondary.Update(ctx, ler)
+}
+
+// RecordEvent in leader election while adding meta-data
+func (ml *MultiLock) RecordEvent(s string) {
+	ml.Primary.RecordEvent(s)
+	ml.Secondary.RecordEvent(s)
+}
+
+// Describe is used to convert details on current resource lock
+// into a string
+func (ml *MultiLock) Describe() string {
+	return ml.Primary.Describe()
+}
+
+// Identity returns the Identity of the lock
+func (ml *MultiLock) Identity() string {
+	return ml.Primary.Identity()
+}
+
+func ConcatRawRecord(primaryRaw, secondaryRaw []byte) []byte {
+	return bytes.Join([][]byte{primaryRaw, secondaryRaw}, []byte(","))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1045,6 +1045,8 @@ k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/tools/clientcmd/api
 k8s.io/client-go/tools/clientcmd/api/latest
 k8s.io/client-go/tools/clientcmd/api/v1
+k8s.io/client-go/tools/leaderelection
+k8s.io/client-go/tools/leaderelection/resourcelock
 k8s.io/client-go/tools/metrics
 k8s.io/client-go/tools/pager
 k8s.io/client-go/tools/reference

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1058,6 +1058,8 @@ k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/tools/clientcmd/api
 k8s.io/client-go/tools/clientcmd/api/latest
 k8s.io/client-go/tools/clientcmd/api/v1
+k8s.io/client-go/tools/leaderelection
+k8s.io/client-go/tools/leaderelection/resourcelock
 k8s.io/client-go/tools/metrics
 k8s.io/client-go/tools/pager
 k8s.io/client-go/tools/reference


### PR DESCRIPTION
## Summary

Add Kubernetes Lease leader election so duplicate rollout-operator pods cannot run controllers or admission webhooks concurrently.

- Keep followers unready so the Service only routes webhook requests to the leader
- Exit after losing leadership and wait for Lease expiration before handoff to avoid overlapping leader-only work
- Add Lease RBAC and validate configurable election timings

Fixes: https://github.com/grafana/mimir-squad/issues/2519

Made with [Cursor](https://cursor.com)