### PR TITLE
Add datetime tag for main Docker images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -308,7 +308,11 @@ jobs:
           if [[ "$REF_TYPE" == "tag" ]]; then
             echo "tag=$REF_NAME" >> "$GITHUB_OUTPUT"
           else
+            # Keep main-<sha> for continuity, and add a sortable datetime tag
+            # based on commit time (stable across workflow re-runs).
+            DATETIME="$(TZ=UTC git show -s --format=%cd --date=format-local:%Y%m%d%H%M%S "$SHA")"
             echo "tag=main-$SHA" >> "$GITHUB_OUTPUT"
+            echo "additional_tag=main-${DATETIME}-${SHA}" >> "$GITHUB_OUTPUT"
           fi
         env:
           REF_TYPE: ${{ github.ref_type }}
@@ -324,6 +328,7 @@ jobs:
         env:
           REF_TYPE: ${{ github.ref_type }}
           IMAGE_TAG: ${{ steps.image_tag.outputs.tag }}
+          ADDITIONAL_IMAGE_TAG: ${{ steps.image_tag.outputs.additional_tag }}
           # Push to the GAR mirror repo; gar-image-mirror copies these to
           # docker.io/grafana. The Publish release step below intentionally does
           # not set IMAGE_PREFIX, so the release notes keep the public grafana/ name.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -312,7 +312,7 @@ jobs:
             # based on commit time (stable across workflow re-runs).
             DATETIME="$(TZ=UTC git show -s --format=%cd --date=format-local:%Y%m%d%H%M%S "$SHA")"
             SHORT_SHA="${SHA:0:7}"
-            echo "tag=main-$SHORT_SHA" >> "$GITHUB_OUTPUT"
+            echo "tag=main-$SHA" >> "$GITHUB_OUTPUT"
             echo "additional_tag=main-${DATETIME}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
           fi
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -311,8 +311,9 @@ jobs:
             # Keep main-<sha> for continuity, and add a sortable datetime tag
             # based on commit time (stable across workflow re-runs).
             DATETIME="$(TZ=UTC git show -s --format=%cd --date=format-local:%Y%m%d%H%M%S "$SHA")"
-            echo "tag=main-$SHA" >> "$GITHUB_OUTPUT"
-            echo "additional_tag=main-${DATETIME}-${SHA}" >> "$GITHUB_OUTPUT"
+            SHORT_SHA="${SHA:0:7}"
+            echo "tag=main-$SHORT_SHA" >> "$GITHUB_OUTPUT"
+            echo "additional_tag=main-${DATETIME}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
           fi
         env:
           REF_TYPE: ${{ github.ref_type }}

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ GIT_REVISION := $(shell git rev-parse --short HEAD)
 
 IMAGE_PREFIX ?= grafana
 IMAGE_TAG ?= $(subst /,-,$(GIT_BRANCH))-$(GIT_REVISION)
+# Optional second tag applied on publish (e.g. main-<datetime>-<sha> from CI).
+ADDITIONAL_IMAGE_TAG ?=
+ADDITIONAL_IMAGE_TAG_FLAG = $(if $(ADDITIONAL_IMAGE_TAG),-t $(IMAGE_PREFIX)/rollout-operator:$(ADDITIONAL_IMAGE_TAG),)
+ADDITIONAL_BORINGCRYPTO_IMAGE_TAG_FLAG = $(if $(ADDITIONAL_IMAGE_TAG),-t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(ADDITIONAL_IMAGE_TAG),)
 
 # Support gsed on OSX (installed via brew), falling back to sed. On Linux
 # systems gsed won't be installed, so will use sed as expected.
@@ -64,11 +68,11 @@ publish-images: publish-standard-image publish-boringcrypto-image ## Build and p
 
 .PHONY: publish-standard-image
 publish-standard-image: clean ## Build and publish only the standard rollout-operator image
-	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) .
+	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) -t $(IMAGE_PREFIX)/rollout-operator:$(IMAGE_TAG) $(ADDITIONAL_IMAGE_TAG_FLAG) .
 
 .PHONY: publish-boringcrypto-image
 publish-boringcrypto-image: clean ## Build and publish only the boring-crypto rollout-operator image
-	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) -f Dockerfile.boringcrypto .
+	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) $(ADDITIONAL_BORINGCRYPTO_IMAGE_TAG_FLAG) -f Dockerfile.boringcrypto .
 
 .PHONY: release-notes 
 release-notes: ## Generate the release notes for a GitHub release


### PR DESCRIPTION
## Summary

Main-branch image publishes currently only get `main-<sha>`, which is hard to order by build age. Keep that tag and also push a commit-time datetime tag.

- Still publish `main-<sha>`
- Also publish `main-<UTC YYYYMMDDHHMMSS>-<sha>` (seconds precision, no milliseconds)
- Datetime comes from the commit timestamp so workflow re-runs stay stable

Made with [Cursor](https://cursor.com)