### PR TITLE
Add CRD compatibility CI check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,6 +170,26 @@ jobs:
           version: v2.12.2
           args: --timeout=5m
 
+  crd-compatibility:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: '1.26'
+          check-latest: true
+          cache: false
+      - name: Install crdify
+        run: go install sigs.k8s.io/crdify@v0.6.0
+      - name: Check CRD compatibility
+        run: make check-crd-compatibility
+        env:
+          CRD_BASE_REF: ${{ github.event.pull_request.base.sha }}
+
   lint-jsonnet:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,10 @@ check-jsonnet-manifests: format-jsonnet
 check-crd-compatibility: ## Check CRDs for backward-incompatible schema changes.
 	@test -n "$(CRD_BASE_REF)" || (echo "CRD_BASE_REF is required" >&2 && false)
 	@for crd in $(CRD_PATHS); do \
+		if ! git cat-file -e "$(CRD_BASE_REF):$$crd" 2>/dev/null; then \
+			echo "Skipping new CRD $$crd"; \
+			continue; \
+		fi; \
 		echo "Checking $$crd against $(CRD_BASE_REF)"; \
 		$(CRDIFY) "git://$(CRD_BASE_REF)?path=$$crd" "file://$$crd" || exit 1; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,13 @@ DOC_SOURCES_PATH := docs
 
 REGO_POLICIES_PATH=operations/policies
 
+# CRDs checked for backward-incompatible schema changes.
+CRD_PATHS := \
+	operations/rollout-operator/crds/replica-templates.yaml \
+	operations/rollout-operator/crds/zone-aware-pod-disruption-budget.yaml
+CRD_BASE_REF ?= $(shell git merge-base HEAD origin/main)
+CRDIFY ?= crdify
+
 # path to jsonnetfmt
 JSONNET_FMT := jsonnetfmt
 
@@ -124,6 +131,14 @@ check-jsonnet-manifests: ## Check the rollout-operator manifests.
 check-jsonnet-manifests: format-jsonnet
 	@echo "Checking diff:"
 	@./tools/find-diff-or-untracked.sh $(JSONNET_MANIFESTS_PATHS) || (echo "Please format jsonnet by running 'make format-jsonnet'" && false)
+
+.PHONY: check-crd-compatibility
+check-crd-compatibility: ## Check CRDs for backward-incompatible schema changes.
+	@test -n "$(CRD_BASE_REF)" || (echo "CRD_BASE_REF is required" >&2 && false)
+	@for crd in $(CRD_PATHS); do \
+		echo "Checking $$crd against $(CRD_BASE_REF)"; \
+		$(CRDIFY) "git://$(CRD_BASE_REF)?path=$$crd" "file://$$crd" || exit 1; \
+	done
 
 .PHONY: format-jsonnet
 format-jsonnet: ## Format the rollout-operator manifests.

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,7 @@ DOC_SOURCES_PATH := docs
 
 REGO_POLICIES_PATH=operations/policies
 
-# CRDs checked for backward-incompatible schema changes.
-CRD_PATHS := \
-	operations/rollout-operator/crds/replica-templates.yaml \
-	operations/rollout-operator/crds/zone-aware-pod-disruption-budget.yaml
+CRD_PATHS := $(wildcard operations/rollout-operator/crds/*.yaml)
 CRD_BASE_REF ?= $(shell git merge-base HEAD origin/main)
 CRDIFY ?= crdify
 

--- a/operations/rollout-operator/crds/zone-aware-pod-disruption-budget.yaml
+++ b/operations/rollout-operator/crds/zone-aware-pod-disruption-budget.yaml
@@ -43,6 +43,9 @@ spec:
                   type: integer
                   minimum: 1
                   description: The regular expression capture group number that contains the partition name. This field is only required when the podNamePartitionRegex field is set and has more then one grouping. The default value is 1 and 1-based indexing is used.
+                crossZoneEvictionDelay:
+                  type: string
+                  description: An optional duration that defines the minimum time that must elapse after a pod returns to a ready state before another pod for the same partition can be evicted. The value must be a valid Go duration string (e.g. "20m", "1h"). This field is only applicable when podNamePartitionRegex is set.
       subresources:
         status: {}
   scope: Namespaced

--- a/operations/rollout-operator/crds/zone-aware-pod-disruption-budget.yaml
+++ b/operations/rollout-operator/crds/zone-aware-pod-disruption-budget.yaml
@@ -43,9 +43,6 @@ spec:
                   type: integer
                   minimum: 1
                   description: The regular expression capture group number that contains the partition name. This field is only required when the podNamePartitionRegex field is set and has more then one grouping. The default value is 1 and 1-based indexing is used.
-                crossZoneEvictionDelay:
-                  type: string
-                  description: An optional duration that defines the minimum time that must elapse after a pod returns to a ready state before another pod for the same partition can be evicted. The value must be a valid Go duration string (e.g. "20m", "1h"). This field is only applicable when podNamePartitionRegex is set.
       subresources:
         status: {}
   scope: Namespaced


### PR DESCRIPTION
## Summary

Add a CRD compatibility check so PRs cannot accidentally introduce backward-incompatible schema changes.

- Compare both operator CRDs against the exact PR base commit using `crdify` v0.6.0
- Expose a local Make target with a configurable base ref

Made with [Cursor](https://cursor.com)