### PR TITLE
Allow startup before CRDs are installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main / unreleased
 
+* [ENHANCEMENT] Allow startup without the ReplicaTemplate or ZoneAwarePodDisruptionBudget CRDs and recover automatically when they are installed later. ZPDB enforcement is inactive while its CRD is absent; startup still waits for cache synchronization when it is present. Expose readiness metrics for both resources. #476
 * [CHANGE] ZPDB cross-zone eviction delays use the Pod Ready condition's `lastTransitionTime` instead of the `grafana.com/ready-time` annotation, eliminating annotation PATCH requests and measuring the delay from Kubernetes readiness transitions. The `-zpdb.pod-ready-annotation-patch-timeout` flag is deprecated, has no effect, and logs a warning when supplied. #498
 * [ENHANCEMENT] Update Go to `1.27` #494
 * [ENHANCEMENT] Updated dependencies, including: #491

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Required to get the GCP auth provider working.
@@ -46,6 +47,21 @@ const defaultServerSelfSignedCertExpiration = model.Duration(365 * 24 * time.Hou
 var (
 	defaultClusterValidationExcludePaths = []string{"admission/no-downscale", "admission/prepare-downscale"}
 )
+
+type replicaTemplateResourceMapper struct {
+	delegate scale.PreferredResourceMapper
+}
+
+func (m replicaTemplateResourceMapper) ResourceFor(resource schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	if resource.Group == "rollout-operator.grafana.com" && resource.Resource == "replicatemplates" {
+		return schema.GroupVersionResource{
+			Group:    resource.Group,
+			Version:  "v1",
+			Resource: resource.Resource,
+		}, nil
+	}
+	return m.delegate.ResourceFor(resource)
+}
 
 type config struct {
 	logFormat string
@@ -248,7 +264,7 @@ func main() {
 	// we don't use cached discovery because DiscoveryScaleKindResolver does its own caching,
 	// so we want to re-fetch every time when we actually ask for it
 	scaleKindResolver := scale.NewDiscoveryScaleKindResolver(coreKubeClient.Discovery())
-	scaleClient, err := scale.NewForConfig(kubeConfig, restMapper, dynamic.LegacyAPIPathResolverFunc, scaleKindResolver)
+	scaleClient, err := scale.NewForConfig(kubeConfig, replicaTemplateResourceMapper{delegate: restMapper}, dynamic.LegacyAPIPathResolverFunc, scaleKindResolver)
 	if err != nil {
 		fatal(fmt.Errorf("failed to init scaleClient: %w", err))
 	}
@@ -290,7 +306,7 @@ func main() {
 	}
 
 	// Init the controller
-	c := controller.NewRolloutController(coreKubeClient, restMapper, scaleClient, dynamicClient, cfg.kubeClusterDomain, cfg.kubeNamespace, podHTTPClient, cfg.reconcileInterval, reg, logger, evictionController)
+	c := controller.NewRolloutController(coreKubeClient, coreKubeClient.Discovery(), restMapper, scaleClient, dynamicClient, cfg.kubeClusterDomain, cfg.kubeNamespace, podHTTPClient, cfg.reconcileInterval, reg, logger, evictionController)
 	if err := c.Init(); err != nil {
 		fatal(fmt.Errorf("failed to init controller: %w", err))
 	}

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Required to get the GCP auth provider working.
@@ -48,6 +49,21 @@ const deprecatedZPDBPodReadyAnnotationPatchTimeoutFlag = "zpdb.pod-ready-annotat
 var (
 	defaultClusterValidationExcludePaths = []string{"admission/no-downscale", "admission/prepare-downscale"}
 )
+
+type replicaTemplateResourceMapper struct {
+	delegate scale.PreferredResourceMapper
+}
+
+func (m replicaTemplateResourceMapper) ResourceFor(resource schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	if resource.Group == "rollout-operator.grafana.com" && resource.Resource == "replicatemplates" {
+		return schema.GroupVersionResource{
+			Group:    resource.Group,
+			Version:  "v1",
+			Resource: resource.Resource,
+		}, nil
+	}
+	return m.delegate.ResourceFor(resource)
+}
 
 type config struct {
 	logFormat string
@@ -269,7 +285,7 @@ func main() {
 	// we don't use cached discovery because DiscoveryScaleKindResolver does its own caching,
 	// so we want to re-fetch every time when we actually ask for it
 	scaleKindResolver := scale.NewDiscoveryScaleKindResolver(coreKubeClient.Discovery())
-	scaleClient, err := scale.NewForConfig(coreConfig, restMapper, dynamic.LegacyAPIPathResolverFunc, scaleKindResolver)
+	scaleClient, err := scale.NewForConfig(coreConfig, replicaTemplateResourceMapper{delegate: restMapper}, dynamic.LegacyAPIPathResolverFunc, scaleKindResolver)
 	if err != nil {
 		fatal(fmt.Errorf("failed to init scaleClient: %w", err))
 	}
@@ -314,7 +330,7 @@ func main() {
 	}
 
 	// Init the controller
-	c := controller.NewRolloutController(coreKubeClient, restMapper, scaleClient, dynamicClient, cfg.kubeClusterDomain, cfg.kubeNamespace, podsFactory, podHTTPClient, cfg.reconcileInterval, reg, logger, evictionController)
+	c := controller.NewRolloutController(coreKubeClient, coreKubeClient.Discovery(), restMapper, scaleClient, dynamicClient, cfg.kubeClusterDomain, cfg.kubeNamespace, podsFactory, podHTTPClient, cfg.reconcileInterval, reg, logger, evictionController)
 	if err := c.Init(); err != nil {
 		fatal(fmt.Errorf("failed to init controller: %w", err))
 	}

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"regexp"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/grafana/rollout-operator/pkg/config"
 	"github.com/grafana/rollout-operator/pkg/util"
 )
 
@@ -119,6 +121,56 @@ func TestRolloutRecoversFromFailedUpdate(t *testing.T) {
 	requireEventuallyPod(t, api, ctx, "mock-zone-a-0", expectReady(), expectVersion("3"))
 	requireEventuallyPod(t, api, ctx, "mock-zone-b-0", expectReady(), expectVersion("3"))
 	requireEventuallyPod(t, api, ctx, "mock-zone-c-0", expectReady(), expectVersion("3"))
+}
+
+func TestRolloutOperatorStartsWithoutCRDs(t *testing.T) {
+	ctx := context.Background()
+
+	cluster := createKindCluster(t, "rollout-operator:latest")
+	api := cluster.API()
+	path := initManifestFiles(t, "webhooks-not-enabled")
+
+	createRolloutOperatorWithoutCRDs(t, ctx, api, cluster.ExtAPI(), path, false)
+	rolloutOperatorPod := eventuallyGetFirstPod(ctx, t, api, "name=rollout-operator")
+	requireEventuallyPod(t, api, ctx, rolloutOperatorPod, expectPodPhase(corev1.PodRunning), expectReady())
+
+	metricsMatch := func(pattern *regexp.Regexp) func() bool {
+		return func() bool {
+			metrics, err := api.CoreV1().RESTClient().Get().
+				Namespace(corev1.NamespaceDefault).
+				Resource("pods").
+				Name(rolloutOperatorPod + ":8001").
+				SubResource("proxy").
+				Suffix("metrics").
+				DoRaw(ctx)
+			if err != nil {
+				t.Logf("failed to query rollout-operator metrics: %s", err)
+				return false
+			}
+			return pattern.Match(metrics)
+		}
+	}
+
+	sts := mockServiceStatefulSet("missing-replica-template", "1", true, 0)
+	sts.Annotations = map[string]string{
+		config.RolloutMirrorReplicasFromResourceNameAnnotationKey:       "missing",
+		config.RolloutMirrorReplicasFromResourceKindAnnotationKey:       "ReplicaTemplate",
+		config.RolloutMirrorReplicasFromResourceAPIVersionAnnotationKey: "rollout-operator.grafana.com/v1",
+	}
+	requireCreateStatefulSet(ctx, t, api, sts)
+
+	failedReconcile := regexp.MustCompile(`(?m)^rollout_operator_group_reconciles_failed_total\{rollout_group="mock"\} [1-9][0-9]*(?:\.[0-9]+)?$`)
+	require.Eventually(t, metricsMatch(failedReconcile), time.Minute, time.Second, "missing CRDs did not cause a failed reconcile metric")
+
+	createZoneAwarePodDistruptionBudgetCustomResourceDefinition(t, cluster.ExtAPI())
+	require.Eventually(t, func() bool {
+		_, err := cluster.DynK().Resource(zoneAwarePodDisruptionBudgetSchema()).Namespace(corev1.NamespaceDefault).
+			Create(ctx, zoneAwarePodDisruptionBudget(corev1.NamespaceDefault, "late-zpdb", "mock", 1), metav1.CreateOptions{})
+		return err == nil
+	}, time.Minute, time.Second, "failed to create ZPDB after installing its CRD")
+
+	observedZPDB := regexp.MustCompile(`(?m)^rollout_operator_zpdb_configurations_observed_total\{result="updated"\} [1-9][0-9]*(?:\.[0-9]+)?$`)
+	require.Eventually(t, metricsMatch(observedZPDB), time.Minute, time.Second, "operator did not observe ZPDB created after startup")
 }
 
 // TestRolloutHappyCaseWithZpdb performs pod updates via the rolling update controller and uses the zpdb to determine if the pod delete is safe or not

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -128,11 +128,20 @@ func TestRolloutOperatorStartsWithoutCRDs(t *testing.T) {
 
 	cluster := createKindCluster(t, "rollout-operator:latest")
 	api := cluster.API()
-	path := initManifestFiles(t, "webhooks-not-enabled")
+	path := initManifestFiles(t, "missing-crds")
 
-	createRolloutOperatorWithoutCRDs(t, ctx, api, cluster.ExtAPI(), path, false)
+	createRolloutOperatorWithoutCRDs(t, ctx, api, cluster.ExtAPI(), path, true)
 	rolloutOperatorPod := eventuallyGetFirstPod(ctx, t, api, "name=rollout-operator")
 	requireEventuallyPod(t, api, ctx, rolloutOperatorPod, expectPodPhase(corev1.PodRunning), expectReady())
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		logs, err := api.CoreV1().Pods(corev1.NamespaceDefault).GetLogs(rolloutOperatorPod, &corev1.PodLogOptions{}).DoRaw(ctx)
+		if err == nil {
+			t.Logf("rollout-operator logs:\n%s", logs)
+		}
+	})
 
 	metricsMatch := func(pattern *regexp.Regexp) func() bool {
 		return func() bool {
@@ -151,6 +160,11 @@ func TestRolloutOperatorStartsWithoutCRDs(t *testing.T) {
 		}
 	}
 
+	replicaTemplateNotReady := regexp.MustCompile(`(?m)^rollout_operator_replica_template_observer_ready 0$`)
+	zpdbNotReady := regexp.MustCompile(`(?m)^rollout_operator_zpdb_config_observer_ready 0$`)
+	require.Eventually(t, metricsMatch(replicaTemplateNotReady), time.Minute, time.Second, "missing ReplicaTemplate CRD was not reported")
+	require.Eventually(t, metricsMatch(zpdbNotReady), time.Minute, time.Second, "missing ZPDB CRD was not reported")
+
 	sts := mockServiceStatefulSet("missing-replica-template", "1", true, 0)
 	sts.Annotations = map[string]string{
 		config.RolloutMirrorReplicasFromResourceNameAnnotationKey:       "missing",
@@ -162,6 +176,19 @@ func TestRolloutOperatorStartsWithoutCRDs(t *testing.T) {
 	failedReconcile := regexp.MustCompile(`(?m)^rollout_operator_group_reconciles_failed_total\{rollout_group="mock"\} [1-9][0-9]*(?:\.[0-9]+)?$`)
 	require.Eventually(t, metricsMatch(failedReconcile), time.Minute, time.Second, "missing CRDs did not cause a failed reconcile metric")
 
+	// Future CRDs should cover both startup without the CRD and recovery when it is installed later.
+	createReplicaTemplateCustomResourceDefinition(t, cluster.ExtAPI())
+	require.Eventually(t, func() bool {
+		_, err := cluster.DynK().Resource(replicaTemplateSchema()).Namespace(corev1.NamespaceDefault).
+			Create(ctx, replicaTemplate(corev1.NamespaceDefault, "missing", 0), metav1.CreateOptions{})
+		return err == nil
+	}, time.Minute, time.Second, "failed to create ReplicaTemplate after installing its CRD")
+
+	successfulReconcile := regexp.MustCompile(`(?m)^rollout_operator_last_successful_group_reconcile_timestamp_seconds\{rollout_group="mock"\} [1-9][0-9.e+]*$`)
+	replicaTemplateReady := regexp.MustCompile(`(?m)^rollout_operator_replica_template_observer_ready 1$`)
+	require.Eventually(t, metricsMatch(replicaTemplateReady), time.Minute, time.Second, "ReplicaTemplate observer did not become ready")
+	require.Eventually(t, metricsMatch(successfulReconcile), time.Minute, time.Second, "operator did not recover after installing the ReplicaTemplate CRD")
+
 	createZoneAwarePodDistruptionBudgetCustomResourceDefinition(t, cluster.ExtAPI())
 	require.Eventually(t, func() bool {
 		_, err := cluster.DynK().Resource(zoneAwarePodDisruptionBudgetSchema()).Namespace(corev1.NamespaceDefault).
@@ -171,6 +198,8 @@ func TestRolloutOperatorStartsWithoutCRDs(t *testing.T) {
 
 	observedZPDB := regexp.MustCompile(`(?m)^rollout_operator_zpdb_configurations_observed_total\{result="updated"\} [1-9][0-9]*(?:\.[0-9]+)?$`)
 	require.Eventually(t, metricsMatch(observedZPDB), time.Minute, time.Second, "operator did not observe ZPDB created after startup")
+	zpdbReady := regexp.MustCompile(`(?m)^rollout_operator_zpdb_config_observer_ready 1$`)
+	require.Eventually(t, metricsMatch(zpdbReady), time.Minute, time.Second, "ZPDB observer did not become ready")
 }
 
 // TestRolloutHappyCaseWithZpdb performs pod updates via the rolling update controller and uses the zpdb to determine if the pod delete is safe or not

--- a/integration/jsonnet-integration/missing-crds.jsonnet
+++ b/integration/jsonnet-integration/missing-crds.jsonnet
@@ -1,0 +1,11 @@
+local rollout_operator = import 'rollout-operator/rollout-operator.libsonnet';
+
+rollout_operator {
+  _config+:: {
+    namespace: 'default',
+    rollout_operator_webhooks_enabled: true,
+    rollout_operator_replica_template_access_enabled: true,
+    zpdb_custom_resource_definition_enabled: false,
+    replica_template_custom_resource_definition_enabled: false,
+  },
+}

--- a/integration/manifests_mock_service_test.go
+++ b/integration/manifests_mock_service_test.go
@@ -187,6 +187,28 @@ func zoneAwarePodDisruptionBudget(namespace, name, rolloutGroup string, maxUnava
 	return zpdb
 }
 
+func replicaTemplateSchema() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "rollout-operator.grafana.com",
+		Version:  "v1",
+		Resource: "replicatemplates",
+	}
+}
+
+func replicaTemplate(namespace, name string, replicas int64) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "rollout-operator.grafana.com/v1",
+		"kind":       "ReplicaTemplate",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": map[string]interface{}{
+			"replicas": replicas,
+		},
+	}}
+}
+
 // serviceNameToNodePort maps service names to their assigned NodePorts
 func serviceNameToNodePort(name string) (int32, error) {
 	switch name {

--- a/integration/manifests_rollout_operator_test.go
+++ b/integration/manifests_rollout_operator_test.go
@@ -60,7 +60,15 @@ func initManifestFiles(t *testing.T, test string) string {
 }
 
 func createRolloutOperator(t *testing.T, ctx context.Context, api *kubernetes.Clientset, extApi *apiextensionsclient.Clientset, directory string, webhook bool, extraEnv ...corev1.EnvVar) {
-	createRolloutOperatorDependencies(t, ctx, api, extApi, directory, webhook)
+	createRolloutOperatorWithCRDs(t, ctx, api, extApi, directory, webhook, true, extraEnv...)
+}
+
+func createRolloutOperatorWithoutCRDs(t *testing.T, ctx context.Context, api *kubernetes.Clientset, extApi *apiextensionsclient.Clientset, directory string, webhook bool, extraEnv ...corev1.EnvVar) {
+	createRolloutOperatorWithCRDs(t, ctx, api, extApi, directory, webhook, false, extraEnv...)
+}
+
+func createRolloutOperatorWithCRDs(t *testing.T, ctx context.Context, api *kubernetes.Clientset, extApi *apiextensionsclient.Clientset, directory string, webhook, installCRDs bool, extraEnv ...corev1.EnvVar) {
+	createRolloutOperatorDependencies(t, ctx, api, extApi, directory, webhook, installCRDs)
 
 	deployment := loadFromDisk[appsv1.Deployment](t, directory+yamlDeployment, &appsv1.Deployment{})
 	deployment.Spec.Template.Spec.Containers[0].Image = "rollout-operator:latest"
@@ -71,7 +79,7 @@ func createRolloutOperator(t *testing.T, ctx context.Context, api *kubernetes.Cl
 	require.NoError(t, err)
 }
 
-func createRolloutOperatorDependencies(t *testing.T, ctx context.Context, api *kubernetes.Clientset, extApi *apiextensionsclient.Clientset, directory string, webhook bool) {
+func createRolloutOperatorDependencies(t *testing.T, ctx context.Context, api *kubernetes.Clientset, extApi *apiextensionsclient.Clientset, directory string, webhook, installCRDs bool) {
 
 	serviceAccount := loadFromDisk[corev1.ServiceAccount](t, directory+yamlServiceAccount, &corev1.ServiceAccount{})
 	_, err := api.CoreV1().ServiceAccounts(corev1.NamespaceDefault).Create(ctx, serviceAccount, metav1.CreateOptions{})
@@ -85,10 +93,14 @@ func createRolloutOperatorDependencies(t *testing.T, ctx context.Context, api *k
 	_, err = api.RbacV1().RoleBindings(corev1.NamespaceDefault).Create(ctx, roleBinding, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	_ = createZoneAwarePodDistruptionBudgetCustomResourceDefinition(t, extApi)
+	if installCRDs {
+		_ = createZoneAwarePodDistruptionBudgetCustomResourceDefinition(t, extApi)
+	}
 
 	if webhook {
-		_ = createReplicaTemplateCustomResourceDefinition(t, extApi)
+		if installCRDs {
+			_ = createReplicaTemplateCustomResourceDefinition(t, extApi)
+		}
 
 		operatorRole := loadFromDisk[rbacv1.Role](t, directory+yamlRoleSecret, &rbacv1.Role{})
 		_, err = api.RbacV1().Roles(corev1.NamespaceDefault).Create(ctx, operatorRole, metav1.CreateOptions{})

--- a/integration/tls_cert_test.go
+++ b/integration/tls_cert_test.go
@@ -123,7 +123,7 @@ func TestSelfSignedCertificate_RenewsAfterExpiration(t *testing.T) {
 	webhookName := createValidatingWebhookConfiguration(t, api, ctx, path+yamlWebhookNoDownscale).Name
 
 	t.Log("Create rollout-operator with a short-lived self-signed certificate.")
-	createRolloutOperatorDependencies(t, ctx, api, cluster.ExtAPI(), path, true)
+	createRolloutOperatorDependencies(t, ctx, api, cluster.ExtAPI(), path, true, true)
 	createRolloutOperatorDeployment(t, ctx, api, path, func(deployment *appsv1.Deployment) {
 		deployment.Spec.Template.Spec.Containers[0].Args = setSelfSignedCertExpiration(
 			deployment.Spec.Template.Spec.Containers[0].Args,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -296,9 +296,10 @@ func (c *RolloutController) reconcileStatefulSetsGroup(ctx context.Context, grou
 	durationTimer := prometheus.NewTimer(c.groupReconcileDuration.WithLabelValues(groupName))
 	failed := c.groupReconcileFailed.WithLabelValues(groupName)
 	lastSuccess := c.groupReconcileLastSuccess.WithLabelValues(groupName)
+	scalingFailed := false
 	defer func() {
 		durationTimer.ObserveDuration()
-		if returnErr != nil {
+		if returnErr != nil || scalingFailed {
 			failed.Inc()
 		} else {
 			lastSuccess.SetToCurrentTime()
@@ -313,6 +314,7 @@ func (c *RolloutController) reconcileStatefulSetsGroup(ctx context.Context, grou
 	// up-to-date.
 	updated, err := c.adjustStatefulSetsGroupReplicas(ctx, groupName, sets)
 	if err != nil {
+		scalingFailed = true
 		level.Warn(c.logger).Log("msg", "unable to adjust desired replicas of StatefulSet", "group", groupName, "err", err)
 	}
 	if err == nil && updated {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,8 +19,10 @@ import (
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -43,6 +45,17 @@ const (
 
 var tracer = otel.Tracer("pkg/controller")
 
+var replicaTemplateGroupKind = schema.GroupKind{
+	Group: "rollout-operator.grafana.com",
+	Kind:  "ReplicaTemplate",
+}
+
+var replicaTemplateGVR = schema.GroupVersionResource{
+	Group:    replicaTemplateGroupKind.Group,
+	Version:  "v1",
+	Resource: "replicatemplates",
+}
+
 type ZPDBEvictionController interface {
 	MarkPodAsDeleted(ctx context.Context, namespace string, podName string, source string, override zpdb.MaxUnavailableZeroOverride) error
 	HasPartitionAwarePdb(pod *corev1.Pod) (bool, error)
@@ -50,6 +63,7 @@ type ZPDBEvictionController interface {
 
 type RolloutController struct {
 	kubeClient           kubernetes.Interface
+	discoveryClient      discovery.DiscoveryInterface
 	clusterDomain        string
 	namespace            string
 	reconcileInterval    time.Duration
@@ -78,13 +92,15 @@ type RolloutController struct {
 	groupReconcileFailed      *prometheus.CounterVec
 	groupReconcileDuration    *prometheus.HistogramVec
 	groupReconcileLastSuccess *prometheus.GaugeVec
+	replicaTemplateReady      prometheus.Gauge
+	replicaTemplateAvailable  atomic.Bool
 
 	// Keep track of discovered rollout groups. We use this information to delete metrics
 	// related to rollout groups that have been decommissioned.
 	discoveredGroups map[string]struct{}
 }
 
-func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTMapper, scaleClient scale.ScalesGetter, dynamic dynamic.Interface, clusterDomain string, namespace string, podHTTPClient *instrumentation.PodHTTPClient, reconcileInterval time.Duration, reg prometheus.Registerer, logger log.Logger, zpdbController ZPDBEvictionController) *RolloutController {
+func NewRolloutController(kubeClient kubernetes.Interface, discoveryClient discovery.DiscoveryInterface, restMapper meta.RESTMapper, scaleClient scale.ScalesGetter, dynamic dynamic.Interface, clusterDomain string, namespace string, podHTTPClient *instrumentation.PodHTTPClient, reconcileInterval time.Duration, reg prometheus.Registerer, logger log.Logger, zpdbController ZPDBEvictionController) *RolloutController {
 	namespaceOpt := informers.WithNamespace(namespace)
 
 	// Initialise the StatefulSet informer to restrict the returned StatefulSets to only the ones
@@ -101,6 +117,7 @@ func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTM
 
 	c := &RolloutController{
 		kubeClient:           kubeClient,
+		discoveryClient:      discoveryClient,
 		clusterDomain:        clusterDomain,
 		namespace:            namespace,
 		reconcileInterval:    reconcileInterval,
@@ -135,7 +152,12 @@ func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTM
 			Name: "rollout_operator_last_successful_group_reconcile_timestamp_seconds",
 			Help: "Timestamp of the last successful reconcile for a specific rollout group.",
 		}, []string{"rollout_group"}),
+		replicaTemplateReady: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "rollout_operator_replica_template_observer_ready",
+			Help: "Whether the ReplicaTemplate resource is discoverable by the rollout controller.",
+		}),
 	}
+	c.replicaTemplateReady.Set(0)
 
 	return c
 }
@@ -167,6 +189,9 @@ func (c *RolloutController) Init() error {
 	// Start informers.
 	go c.statefulSetsFactory.Start(c.stopCh)
 	go c.podsFactory.Start(c.stopCh)
+	if c.discoveryClient != nil {
+		go c.observeReplicaTemplate()
+	}
 
 	// Wait until all informer caches have been synced.
 	level.Info(c.logger).Log("msg", "informer caches are syncing")
@@ -176,6 +201,45 @@ func (c *RolloutController) Init() error {
 	level.Info(c.logger).Log("msg", "informer caches have synced")
 
 	return nil
+}
+
+func (c *RolloutController) observeReplicaTemplate() {
+	update := func() {
+		resourceAvailable := false
+		scaleAvailable := false
+		resources, err := c.discoveryClient.ServerResourcesForGroupVersion(replicaTemplateGVR.GroupVersion().String())
+		if err == nil {
+			for _, resource := range resources.APIResources {
+				switch resource.Name {
+				case replicaTemplateGVR.Resource:
+					resourceAvailable = true
+				case replicaTemplateGVR.Resource + "/scale":
+					scaleAvailable = true
+				}
+			}
+		}
+		available := resourceAvailable && scaleAvailable
+		if available {
+			c.replicaTemplateReady.Set(1)
+		} else {
+			c.replicaTemplateReady.Set(0)
+		}
+		if !c.replicaTemplateAvailable.Swap(available) && available {
+			c.enqueueReconcile()
+		}
+	}
+
+	update()
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		case <-ticker.C:
+			update()
+		}
+	}
 }
 
 func (c *RolloutController) onAdded(obj interface{}) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,8 +19,10 @@ import (
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -43,6 +45,17 @@ const (
 
 var tracer = otel.Tracer("pkg/controller")
 
+var replicaTemplateGroupKind = schema.GroupKind{
+	Group: "rollout-operator.grafana.com",
+	Kind:  "ReplicaTemplate",
+}
+
+var replicaTemplateGVR = schema.GroupVersionResource{
+	Group:    replicaTemplateGroupKind.Group,
+	Version:  "v1",
+	Resource: "replicatemplates",
+}
+
 type ZPDBEvictionController interface {
 	MarkPodAsDeleted(ctx context.Context, namespace string, podName string, source string, override zpdb.MaxUnavailableZeroOverride) error
 	HasPartitionAwarePdb(pod *corev1.Pod) (bool, error)
@@ -50,6 +63,7 @@ type ZPDBEvictionController interface {
 
 type RolloutController struct {
 	kubeClient           kubernetes.Interface
+	discoveryClient      discovery.DiscoveryInterface
 	clusterDomain        string
 	namespace            string
 	reconcileInterval    time.Duration
@@ -78,6 +92,8 @@ type RolloutController struct {
 	groupReconcileFailed      *prometheus.CounterVec
 	groupReconcileDuration    *prometheus.HistogramVec
 	groupReconcileLastSuccess *prometheus.GaugeVec
+	replicaTemplateReady      prometheus.Gauge
+	replicaTemplateAvailable  atomic.Bool
 
 	// Keep track of discovered rollout groups. We use this information to delete metrics
 	// related to rollout groups that have been decommissioned.
@@ -92,7 +108,7 @@ func NewPodInformerFactory(kubeClient kubernetes.Interface, namespace string) in
 	return informers.NewSharedInformerFactoryWithOptions(kubeClient, informerSyncInterval, informers.WithNamespace(namespace))
 }
 
-func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTMapper, scaleClient scale.ScalesGetter, dynamic dynamic.Interface, clusterDomain string, namespace string, podsFactory informers.SharedInformerFactory, podHTTPClient *instrumentation.PodHTTPClient, reconcileInterval time.Duration, reg prometheus.Registerer, logger log.Logger, zpdbController ZPDBEvictionController) *RolloutController {
+func NewRolloutController(kubeClient kubernetes.Interface, discoveryClient discovery.DiscoveryInterface, restMapper meta.RESTMapper, scaleClient scale.ScalesGetter, dynamic dynamic.Interface, clusterDomain string, namespace string, podsFactory informers.SharedInformerFactory, podHTTPClient *instrumentation.PodHTTPClient, reconcileInterval time.Duration, reg prometheus.Registerer, logger log.Logger, zpdbController ZPDBEvictionController) *RolloutController {
 	namespaceOpt := informers.WithNamespace(namespace)
 
 	// Initialise the StatefulSet informer to restrict the returned StatefulSets to only the ones
@@ -108,6 +124,7 @@ func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTM
 
 	c := &RolloutController{
 		kubeClient:           kubeClient,
+		discoveryClient:      discoveryClient,
 		clusterDomain:        clusterDomain,
 		namespace:            namespace,
 		reconcileInterval:    reconcileInterval,
@@ -142,7 +159,12 @@ func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTM
 			Name: "rollout_operator_last_successful_group_reconcile_timestamp_seconds",
 			Help: "Timestamp of the last successful reconcile for a specific rollout group.",
 		}, []string{"rollout_group"}),
+		replicaTemplateReady: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "rollout_operator_replica_template_observer_ready",
+			Help: "Whether the ReplicaTemplate resource is discoverable by the rollout controller.",
+		}),
 	}
+	c.replicaTemplateReady.Set(0)
 
 	return c
 }
@@ -176,6 +198,9 @@ func (c *RolloutController) Init() error {
 	// and the other call is a no-op.
 	go c.statefulSetsFactory.Start(c.stopCh)
 	go c.podsFactory.Start(c.stopCh)
+	if c.discoveryClient != nil {
+		go c.observeReplicaTemplate()
+	}
 
 	// Wait until all informer caches have been synced.
 	level.Info(c.logger).Log("msg", "informer caches are syncing")
@@ -185,6 +210,45 @@ func (c *RolloutController) Init() error {
 	level.Info(c.logger).Log("msg", "informer caches have synced")
 
 	return nil
+}
+
+func (c *RolloutController) observeReplicaTemplate() {
+	update := func() {
+		resourceAvailable := false
+		scaleAvailable := false
+		resources, err := c.discoveryClient.ServerResourcesForGroupVersion(replicaTemplateGVR.GroupVersion().String())
+		if err == nil {
+			for _, resource := range resources.APIResources {
+				switch resource.Name {
+				case replicaTemplateGVR.Resource:
+					resourceAvailable = true
+				case replicaTemplateGVR.Resource + "/scale":
+					scaleAvailable = true
+				}
+			}
+		}
+		available := resourceAvailable && scaleAvailable
+		if available {
+			c.replicaTemplateReady.Set(1)
+		} else {
+			c.replicaTemplateReady.Set(0)
+		}
+		if !c.replicaTemplateAvailable.Swap(available) && available {
+			c.enqueueReconcile()
+		}
+	}
+
+	update()
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		case <-ticker.C:
+			update()
+		}
+	}
 }
 
 func (c *RolloutController) onAdded(obj interface{}) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -305,9 +305,10 @@ func (c *RolloutController) reconcileStatefulSetsGroup(ctx context.Context, grou
 	durationTimer := prometheus.NewTimer(c.groupReconcileDuration.WithLabelValues(groupName))
 	failed := c.groupReconcileFailed.WithLabelValues(groupName)
 	lastSuccess := c.groupReconcileLastSuccess.WithLabelValues(groupName)
+	scalingFailed := false
 	defer func() {
 		durationTimer.ObserveDuration()
-		if returnErr != nil {
+		if returnErr != nil || scalingFailed {
 			failed.Inc()
 		} else {
 			lastSuccess.SetToCurrentTime()
@@ -322,6 +323,7 @@ func (c *RolloutController) reconcileStatefulSetsGroup(ctx context.Context, grou
 	// up-to-date.
 	updated, err := c.adjustStatefulSetsGroupReplicas(ctx, groupName, sets)
 	if err != nil {
+		scalingFailed = true
 		level.Warn(c.logger).Log("msg", "unable to adjust desired replicas of StatefulSet", "group", groupName, "err", err)
 	}
 	if err == nil && updated {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -62,6 +62,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 		expectedPatchedSets               map[string][]string
 		expectedPatchedResources          map[string][]string
 		expectedErr                       string
+		expectedFailureMetric             bool
 		zpdbErrors                        []error
 		zpdbPartitionMode                 bool
 	}{
@@ -692,7 +693,8 @@ func TestRolloutController_Reconcile(t *testing.T) {
 					"grafana.com/rollout-mirror-replicas-from-resource-api-version": customResourceGVK.GroupVersion().String(),
 				})),
 			},
-			expectedErr: "", // reconciliation continues if scaling fails
+			expectedErr:           "", // reconciliation continues if scaling fails
+			expectedFailureMetric: true,
 		},
 		"should not fail if scaling based on custom resource fails due to scale subresource not being available": {
 			statefulSets: []runtime.Object{
@@ -702,8 +704,9 @@ func TestRolloutController_Reconcile(t *testing.T) {
 					"grafana.com/rollout-mirror-replicas-from-resource-api-version": customResourceGVK.GroupVersion().String(),
 				})),
 			},
-			getScaleErr: fmt.Errorf("cannot get scale subresource"),
-			expectedErr: "", // reconciliation continues if scaling fails
+			getScaleErr:           fmt.Errorf("cannot get scale subresource"),
+			expectedErr:           "", // reconciliation continues if scaling fails
+			expectedFailureMetric: true,
 		},
 		"all statefulsets are considered": {
 			statefulSets: []runtime.Object{
@@ -920,7 +923,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 
 			// Assert on metrics.
 			expectedFailures := 0
-			if testData.expectedErr != "" {
+			if testData.expectedErr != "" || testData.expectedFailureMetric || testData.kubePatchErr != nil || testData.getScaleErr != nil {
 				expectedFailures = 1
 			}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -860,7 +860,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 			// Pass in a slice of errors. Each eviction request takes and removes from the head and uses this as the eviction response. Once exhausted no evictions will return an error.
 			evictionController := &mockEvictionController{nextErrorsIfAny: testData.zpdbErrors, hasPartitionAwarePdb: testData.zpdbPartitionMode}
 
-			c := NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, testClusterDomain, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger(), evictionController)
+			c := NewRolloutController(kubeClient, nil, restMapper, scaleClient, dynamicClient, testClusterDomain, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger(), evictionController)
 			require.NoError(t, c.Init())
 			defer c.Stop()
 
@@ -1366,7 +1366,7 @@ func TestRolloutController_ReconcileStatefulsetWithDownscaleDelay(t *testing.T) 
 
 			// Create the controller and start informers.
 			reg := prometheus.NewPedanticRegistry()
-			c := NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, testClusterDomain, testNamespace, podClientRoundTripper.client(), 5*time.Second, reg, log.NewNopLogger(), &mockEvictionController{})
+			c := NewRolloutController(kubeClient, nil, restMapper, scaleClient, dynamicClient, testClusterDomain, testNamespace, podClientRoundTripper.client(), 5*time.Second, reg, log.NewNopLogger(), &mockEvictionController{})
 			require.NoError(t, c.Init())
 			defer c.Stop()
 
@@ -1468,7 +1468,7 @@ func TestRolloutController_ReconcileShouldDeleteMetricsForDecommissionedRolloutG
 
 	// Create the controller and start informers.
 	reg := prometheus.NewPedanticRegistry()
-	c := NewRolloutController(kubeClient, nil, nil, nil, testClusterDomain, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger(), &mockEvictionController{})
+	c := NewRolloutController(kubeClient, nil, nil, nil, nil, testClusterDomain, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger(), &mockEvictionController{})
 	require.NoError(t, c.Init())
 	defer c.Stop()
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -860,7 +860,7 @@ func TestRolloutController_Reconcile(t *testing.T) {
 			// Pass in a slice of errors. Each eviction request takes and removes from the head and uses this as the eviction response. Once exhausted no evictions will return an error.
 			evictionController := &mockEvictionController{nextErrorsIfAny: testData.zpdbErrors, hasPartitionAwarePdb: testData.zpdbPartitionMode}
 
-			c := NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, testClusterDomain, testNamespace, NewPodInformerFactory(kubeClient, testNamespace), nil, 5*time.Second, reg, log.NewNopLogger(), evictionController)
+			c := NewRolloutController(kubeClient, nil, restMapper, scaleClient, dynamicClient, testClusterDomain, testNamespace, NewPodInformerFactory(kubeClient, testNamespace), nil, 5*time.Second, reg, log.NewNopLogger(), evictionController)
 			require.NoError(t, c.Init())
 			defer c.Stop()
 
@@ -1366,7 +1366,7 @@ func TestRolloutController_ReconcileStatefulsetWithDownscaleDelay(t *testing.T) 
 
 			// Create the controller and start informers.
 			reg := prometheus.NewPedanticRegistry()
-			c := NewRolloutController(kubeClient, restMapper, scaleClient, dynamicClient, testClusterDomain, testNamespace, NewPodInformerFactory(kubeClient, testNamespace), podClientRoundTripper.client(), 5*time.Second, reg, log.NewNopLogger(), &mockEvictionController{})
+			c := NewRolloutController(kubeClient, nil, restMapper, scaleClient, dynamicClient, testClusterDomain, testNamespace, NewPodInformerFactory(kubeClient, testNamespace), podClientRoundTripper.client(), 5*time.Second, reg, log.NewNopLogger(), &mockEvictionController{})
 			require.NoError(t, c.Init())
 			defer c.Stop()
 
@@ -1468,7 +1468,7 @@ func TestRolloutController_ReconcileShouldDeleteMetricsForDecommissionedRolloutG
 
 	// Create the controller and start informers.
 	reg := prometheus.NewPedanticRegistry()
-	c := NewRolloutController(kubeClient, nil, nil, nil, testClusterDomain, testNamespace, NewPodInformerFactory(kubeClient, testNamespace), nil, 5*time.Second, reg, log.NewNopLogger(), &mockEvictionController{})
+	c := NewRolloutController(kubeClient, nil, nil, nil, nil, testClusterDomain, testNamespace, NewPodInformerFactory(kubeClient, testNamespace), nil, 5*time.Second, reg, log.NewNopLogger(), &mockEvictionController{})
 	require.NoError(t, c.Init())
 	defer c.Stop()
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1786,7 +1786,7 @@ func TestRolloutController_UsesTheSuppliedPodInformerFactory(t *testing.T) {
 	kubeClient := fake.NewClientset()
 	podsFactory := NewPodInformerFactory(kubeClient, testNamespace)
 
-	c := NewRolloutController(kubeClient, nil, nil, nil, testClusterDomain, testNamespace, podsFactory, nil, 5*time.Second, prometheus.NewPedanticRegistry(), log.NewNopLogger(), &mockEvictionController{})
+	c := NewRolloutController(kubeClient, nil, nil, nil, nil, testClusterDomain, testNamespace, podsFactory, nil, 5*time.Second, prometheus.NewPedanticRegistry(), log.NewNopLogger(), &mockEvictionController{})
 	require.NoError(t, c.Init())
 	defer c.Stop()
 

--- a/pkg/controller/custom_resource_replicas.go
+++ b/pkg/controller/custom_resource_replicas.go
@@ -117,6 +117,14 @@ func getCustomScaleResourceForStatefulset(ctx context.Context, sts *appsv1.State
 	reference := fmt.Sprintf("%s/%s", kind, name)
 
 	mappings, err := restMapper.RESTMappings(targetGK)
+	if err != nil && targetGK == replicaTemplateGroupKind && targetGV.Version == replicaTemplateGVR.Version {
+		mappings = []*meta.RESTMapping{{
+			Resource:         replicaTemplateGVR,
+			GroupVersionKind: targetGV.WithKind(kind),
+			Scope:            meta.RESTScopeNamespace,
+		}}
+		err = nil
+	}
 	if err != nil {
 		return nil, schema.GroupVersionResource{}, "", fmt.Errorf("unable to find custom resource mapping for reference resource %s: %v", reference, err)
 	}

--- a/pkg/zpdb/config_observer.go
+++ b/pkg/zpdb/config_observer.go
@@ -19,7 +19,9 @@ import (
 
 const (
 	// How frequently informers should resync
-	informerSyncInterval = 5 * time.Minute
+	informerSyncInterval    = 5 * time.Minute
+	initialCacheSyncTimeout = 10 * time.Second
+	readinessCheckInterval  = 30 * time.Second
 )
 
 // An configObserver facilitates listening for ZoneAwarePodDisruptionBudget changes, parsing and storing these into the configCache.
@@ -74,26 +76,75 @@ func (c *configObserver) start() error {
 	if err != nil {
 		return err
 	}
+	if err := c.pdbInformer.SetWatchErrorHandler(func(_ *k8cache.Reflector, err error) {
+		c.metrics.ConfigObserverReady.Set(0)
+		level.Warn(c.logger).Log("msg", "zpdb config observer unavailable", "err", err)
+	}); err != nil {
+		return err
+	}
 
-	_, listErr := c.pdbResource.List(context.Background(), metav1.ListOptions{Limit: 1})
+	ctx, cancel := context.WithTimeout(context.Background(), initialCacheSyncTimeout)
+	_, listErr := c.pdbResource.List(ctx, metav1.ListOptions{Limit: 1})
+	cancel()
 	if listErr != nil && !apierrors.IsNotFound(listErr) {
 		return listErr
 	}
 
 	go c.pdbFactory.Start(c.stopCh)
+	go c.observeReadiness()
+	syncResult := make(chan bool, 1)
+	go func() {
+		syncResult <- c.waitForCacheSync()
+	}()
 
 	if apierrors.IsNotFound(listErr) {
 		level.Warn(c.logger).Log("msg", "zpdb custom resource is unavailable; informer will retry", "err", listErr)
 		return nil
 	}
 
-	level.Info(c.logger).Log("msg", "zpdb config informer caches are syncing")
-	if ok := k8cache.WaitForCacheSync(c.stopCh, c.pdbInformer.HasSynced); !ok {
-		return errors.New("zpdb config informer caches failed to sync")
+	select {
+	case synced := <-syncResult:
+		if !synced {
+			return errors.New("zpdb config informer caches failed to sync")
+		}
+	case <-time.After(initialCacheSyncTimeout):
+		level.Warn(c.logger).Log("msg", "zpdb config informer cache sync timed out; continuing startup")
 	}
-	level.Info(c.logger).Log("msg", "zpdb config informer caches have synced")
 
 	return nil
+}
+
+func (c *configObserver) waitForCacheSync() bool {
+	level.Info(c.logger).Log("msg", "zpdb config informer caches are syncing")
+	if ok := k8cache.WaitForCacheSync(c.stopCh, c.pdbInformer.HasSynced); !ok {
+		return false
+	}
+	c.metrics.ConfigObserverReady.Set(1)
+	level.Info(c.logger).Log("msg", "zpdb config informer caches have synced")
+	return true
+}
+
+func (c *configObserver) observeReadiness() {
+	c.updateReadiness()
+	ticker := time.NewTicker(readinessCheckInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		case <-ticker.C:
+			c.updateReadiness()
+		}
+	}
+}
+
+func (c *configObserver) updateReadiness() {
+	_, err := c.pdbResource.List(context.Background(), metav1.ListOptions{Limit: 1})
+	if err == nil && c.pdbInformer.HasSynced() {
+		c.metrics.ConfigObserverReady.Set(1)
+	} else {
+		c.metrics.ConfigObserverReady.Set(0)
+	}
 }
 
 func (c *configObserver) addOrUpdate(obj *unstructured.Unstructured) {

--- a/pkg/zpdb/config_observer.go
+++ b/pkg/zpdb/config_observer.go
@@ -19,9 +19,9 @@ import (
 
 const (
 	// How frequently informers should resync
-	informerSyncInterval    = 5 * time.Minute
-	initialCacheSyncTimeout = 10 * time.Second
-	readinessCheckInterval  = 30 * time.Second
+	informerSyncInterval        = 5 * time.Minute
+	initialResourceCheckTimeout = 10 * time.Second
+	readinessCheckInterval      = 30 * time.Second
 )
 
 // An configObserver facilitates listening for ZoneAwarePodDisruptionBudget changes, parsing and storing these into the configCache.
@@ -83,7 +83,7 @@ func (c *configObserver) start() error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), initialCacheSyncTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), initialResourceCheckTimeout)
 	_, listErr := c.pdbResource.List(ctx, metav1.ListOptions{Limit: 1})
 	cancel()
 	if listErr != nil && !apierrors.IsNotFound(listErr) {
@@ -92,23 +92,15 @@ func (c *configObserver) start() error {
 
 	go c.pdbFactory.Start(c.stopCh)
 	go c.observeReadiness()
-	syncResult := make(chan bool, 1)
-	go func() {
-		syncResult <- c.waitForCacheSync()
-	}()
 
 	if apierrors.IsNotFound(listErr) {
 		level.Warn(c.logger).Log("msg", "zpdb custom resource is unavailable; informer will retry", "err", listErr)
+		go c.waitForCacheSync()
 		return nil
 	}
 
-	select {
-	case synced := <-syncResult:
-		if !synced {
-			return errors.New("zpdb config informer caches failed to sync")
-		}
-	case <-time.After(initialCacheSyncTimeout):
-		level.Warn(c.logger).Log("msg", "zpdb config informer cache sync timed out; continuing startup")
+	if !c.waitForCacheSync() {
+		return errors.New("zpdb config informer caches failed to sync")
 	}
 
 	return nil

--- a/pkg/zpdb/config_observer.go
+++ b/pkg/zpdb/config_observer.go
@@ -1,12 +1,15 @@
 package zpdb
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -27,6 +30,7 @@ type configObserver struct {
 	metrics     *Metrics
 
 	dynamicClient dynamic.Interface
+	pdbResource   dynamic.ResourceInterface
 	logger        log.Logger
 
 	// Used to signal when the controller should stop.
@@ -52,6 +56,7 @@ func newConfigObserver(dynamic dynamic.Interface, namespace string, logger log.L
 		pdbInformer:   pdbInformer.Informer(),
 		pdbCache:      newConfigCache(),
 		dynamicClient: dynamic,
+		pdbResource:   dynamic.Resource(gvr).Namespace(namespace),
 		metrics:       metrics,
 		logger:        logger,
 		stopCh:        make(chan struct{}),
@@ -70,9 +75,18 @@ func (c *configObserver) start() error {
 		return err
 	}
 
+	_, listErr := c.pdbResource.List(context.Background(), metav1.ListOptions{Limit: 1})
+	if listErr != nil && !apierrors.IsNotFound(listErr) {
+		return listErr
+	}
+
 	go c.pdbFactory.Start(c.stopCh)
 
-	// Wait until all informer caches have been synced.
+	if apierrors.IsNotFound(listErr) {
+		level.Warn(c.logger).Log("msg", "zpdb custom resource is unavailable; informer will retry", "err", listErr)
+		return nil
+	}
+
 	level.Info(c.logger).Log("msg", "zpdb config informer caches are syncing")
 	if ok := k8cache.WaitForCacheSync(c.stopCh, c.pdbInformer.HasSynced); !ok {
 		return errors.New("zpdb config informer caches failed to sync")

--- a/pkg/zpdb/config_observer.go
+++ b/pkg/zpdb/config_observer.go
@@ -87,7 +87,7 @@ func (c *configObserver) start() error {
 	_, listErr := c.pdbResource.List(ctx, metav1.ListOptions{Limit: 1})
 	cancel()
 	if listErr != nil && !apierrors.IsNotFound(listErr) {
-		return listErr
+		level.Warn(c.logger).Log("msg", "zpdb resource check failed; waiting for informer cache sync", "err", listErr)
 	}
 
 	go c.pdbFactory.Start(c.stopCh)

--- a/pkg/zpdb/config_observer_test.go
+++ b/pkg/zpdb/config_observer_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	rolloutconfig "github.com/grafana/rollout-operator/pkg/config"
 )
@@ -86,6 +88,29 @@ func TestObserver_NewPdbObserver(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("stopCh should be closed after Stop()")
 	}
+}
+
+func TestObserver_StartWithoutCRD(t *testing.T) {
+	dynamicClient, observer := newConfigObserverTestCase()
+	dynamicClient.PrependReactor("list", ZoneAwarePodDisruptionBudgetsNamePlural, func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(schema.GroupResource{
+			Group:    ZoneAwarePodDisruptionBudgetsSpecGroup,
+			Resource: ZoneAwarePodDisruptionBudgetsNamePlural,
+		}, "")
+	})
+
+	started := make(chan error, 1)
+	go func() {
+		started <- observer.start()
+	}()
+
+	select {
+	case err := <-started:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("observer did not start while the CRD was missing")
+	}
+	observer.stop()
 }
 
 // TestObserver_InvalidObject - tests that no panics occur if an invalid object is passed from the informers

--- a/pkg/zpdb/config_observer_test.go
+++ b/pkg/zpdb/config_observer_test.go
@@ -3,6 +3,7 @@ package zpdb
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -73,6 +74,7 @@ func newPDB(name string) *unstructured.Unstructured {
 func TestObserver_NewPdbObserver(t *testing.T) {
 	_, observer := newConfigObserverTestCase()
 	require.NoError(t, observer.start())
+	require.Equal(t, float64(1), testutil.ToFloat64(observer.metrics.ConfigObserverReady))
 
 	select {
 	case <-observer.stopCh:
@@ -107,10 +109,36 @@ func TestObserver_StartWithoutCRD(t *testing.T) {
 	select {
 	case err := <-started:
 		require.NoError(t, err)
+		require.Equal(t, float64(0), testutil.ToFloat64(observer.metrics.ConfigObserverReady))
 	case <-time.After(time.Second):
 		t.Fatal("observer did not start while the CRD was missing")
 	}
 	observer.stop()
+}
+
+func TestObserver_ReadinessRecoversWithoutObjects(t *testing.T) {
+	dynamicClient, observer := newConfigObserverTestCase()
+	var unavailable atomic.Bool
+	dynamicClient.PrependReactor("list", ZoneAwarePodDisruptionBudgetsNamePlural, func(k8stesting.Action) (bool, runtime.Object, error) {
+		if !unavailable.Load() {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewNotFound(schema.GroupResource{
+			Group:    ZoneAwarePodDisruptionBudgetsSpecGroup,
+			Resource: ZoneAwarePodDisruptionBudgetsNamePlural,
+		}, "")
+	})
+
+	require.NoError(t, observer.start())
+	observer.stop()
+
+	unavailable.Store(true)
+	observer.updateReadiness()
+	require.Equal(t, float64(0), testutil.ToFloat64(observer.metrics.ConfigObserverReady))
+
+	unavailable.Store(false)
+	observer.updateReadiness()
+	require.Equal(t, float64(1), testutil.ToFloat64(observer.metrics.ConfigObserverReady))
 }
 
 // TestObserver_InvalidObject - tests that no panics occur if an invalid object is passed from the informers

--- a/pkg/zpdb/config_observer_test.go
+++ b/pkg/zpdb/config_observer_test.go
@@ -116,6 +116,42 @@ func TestObserver_StartWithoutCRD(t *testing.T) {
 	observer.stop()
 }
 
+func TestObserver_StartRetriesTransientErrors(t *testing.T) {
+	for _, probeErr := range []error{
+		context.DeadlineExceeded,
+		apierrors.NewServiceUnavailable("API unavailable"),
+	} {
+		t.Run(probeErr.Error(), func(t *testing.T) {
+			dynamicClient, observer := newConfigObserverTestCase()
+			defer observer.stop()
+			var recovered atomic.Bool
+			dynamicClient.PrependReactor("list", ZoneAwarePodDisruptionBudgetsNamePlural, func(k8stesting.Action) (bool, runtime.Object, error) {
+				if !recovered.Load() {
+					return true, nil, probeErr
+				}
+				return false, nil, nil
+			})
+
+			started := make(chan error, 1)
+			go func() { started <- observer.start() }()
+			select {
+			case err := <-started:
+				t.Fatalf("startup returned before API recovery: %v", err)
+			case <-time.After(100 * time.Millisecond):
+			}
+			require.False(t, observer.pdbInformer.HasSynced())
+			recovered.Store(true)
+			select {
+			case err := <-started:
+				require.NoError(t, err)
+				require.True(t, observer.pdbInformer.HasSynced())
+			case <-time.After(10 * time.Second):
+				t.Fatal("startup did not recover after API recovery")
+			}
+		})
+	}
+}
+
 func TestObserver_ReadinessRecoversWithoutObjects(t *testing.T) {
 	dynamicClient, observer := newConfigObserverTestCase()
 	var unavailable atomic.Bool

--- a/pkg/zpdb/metrics.go
+++ b/pkg/zpdb/metrics.go
@@ -9,10 +9,11 @@ type Metrics struct {
 	ConfigurationsObserved *prometheus.CounterVec
 	EvictionRequests       *prometheus.CounterVec
 	InFlightRequests       *prometheus.GaugeVec
+	ConfigObserverReady    prometheus.Gauge
 }
 
 func NewMetrics(reg prometheus.Registerer) *Metrics {
-	return &Metrics{
+	metrics := &Metrics{
 		ConfigurationsObserved: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "rollout_operator_zpdb_configurations_observed_total",
 			Help: "Number of zpdb configurations observed by the configuration controller.",
@@ -25,5 +26,11 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Name: "rollout_operator_zpdb_inflight_eviction_requests",
 			Help: "Number of zpdb eviction requests which are currently in-flight.",
 		}, []string{}),
+		ConfigObserverReady: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "rollout_operator_zpdb_config_observer_ready",
+			Help: "Whether the ZPDB configuration observer has synchronized with the Kubernetes API.",
+		}),
 	}
+	metrics.ConfigObserverReady.Set(0)
+	return metrics
 }


### PR DESCRIPTION
## Summary

Allow rollout-operator to start when its CRDs have not been installed yet while preserving normal ZPDB cache synchronization when the CRD is available.

- Expose ReplicaTemplate and ZPDB observer readiness gauges for alerting
- Keep retrying unavailable CRDs and reconcile automatically after late ReplicaTemplate installation
- Count mirror-resource scaling errors in failed reconcile metrics without stopping pod rollout
- Cover startup without either CRD and late recovery for both resources