### PR TITLE
healthcheck-POC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Rollout Operator
 
-Coordinates zone-aware rollouts and scaling of StatefulSets within a namespace, for multi-AZ deployments where each AZ is managed by a dedicated StatefulSet.
+Coordinates zone-aware rollouts and scaling of StatefulSets within a namespace, for multi-AZ deployments where each AZ is managed by a dedicated StatefulSet. Also supports opt-in phased rollouts of Deployments (dependency chaining with soak and restart gating).
 
 For full documentation (webhooks, ZPDB, TLS, scaling details, YAML examples), see [README.md](README.md).
 
@@ -8,7 +8,8 @@ For full documentation (webhooks, ZPDB, TLS, scaling details, YAML examples), se
 
 - **Rollout groups**: StatefulSets with `rollout-group` label and `OnDelete` strategy are rolled one zone at a time.
 - **Scaling**: Leader/follower pattern via `grafana.com/rollout-downscale-leader` annotation, or mirror-replicas from a reference resource.
-- **Webhooks**: `/admission/no-downscale` (blocks downscale), `/admission/prepare-downscale` (calls prepare-shutdown endpoint before downscale).
+- **Webhooks**: `/admission/no-downscale` (blocks downscale), `/admission/prepare-downscale` (calls prepare-shutdown endpoint before downscale), `/admission/phased-deployment` (pauses dependent Deployments during soak gates).
+- **Phased Deployments**: Opt-in via `grafana.com/rollout-phased`; followers use `grafana.com/rollout-depends-on` and a shared `grafana.com/rollout-revision`.
 - **ZPDB**: Custom `ZoneAwarePodDisruptionBudget` CRD evaluates eviction budgets per-zone (with optional partition awareness for ingest-storage).
 
 ## Development

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Rollout Operator
 
-Coordinates zone-aware rollouts and scaling of StatefulSets within a namespace, for multi-AZ deployments where each AZ is managed by a dedicated StatefulSet. Also supports opt-in phased rollouts of Deployments (dependency chaining with soak and restart gating).
+Coordinates zone-aware rollouts and scaling of StatefulSets within a namespace, for multi-AZ deployments where each AZ is managed by a dedicated StatefulSet. Also supports opt-in phased rollouts of Deployments (canary gating via explicit Git-defined Deployments).
 
 For full documentation (webhooks, ZPDB, TLS, scaling details, YAML examples), see [README.md](README.md).
 
@@ -8,8 +8,8 @@ For full documentation (webhooks, ZPDB, TLS, scaling details, YAML examples), se
 
 - **Rollout groups**: StatefulSets with `rollout-group` label and `OnDelete` strategy are rolled one zone at a time.
 - **Scaling**: Leader/follower pattern via `grafana.com/rollout-downscale-leader` annotation, or mirror-replicas from a reference resource.
-- **Webhooks**: `/admission/no-downscale` (blocks downscale), `/admission/prepare-downscale` (calls prepare-shutdown endpoint before downscale), `/admission/phased-deployment` (pauses dependent Deployments during soak gates).
-- **Phased Deployments**: Opt-in via `grafana.com/rollout-phased`; followers use `grafana.com/rollout-depends-on` and a shared `grafana.com/rollout-revision`.
+- **Webhooks**: `/admission/no-downscale` (blocks downscale), `/admission/prepare-downscale` (calls prepare-shutdown endpoint before downscale), `/admission/phased-deployment` (pauses main Deployments until canaries converge).
+- **Phased Deployments**: Opt-in via `grafana.com/rollout-phased`; mains use `grafana.com/rollout-canary` (comma-separated) and a shared `grafana.com/rollout-revision`. Incident bypass via `grafana.com/rollout-bypass-until`.
 - **ZPDB**: Custom `ZoneAwarePodDisruptionBudget` CRD evaluates eviction budgets per-zone (with optional partition awareness for ingest-storage).
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -156,6 +156,52 @@ spec:
 
 To resume normal rollout behavior, remove the annotation or set it to any value other than `true`.
 
+## Phased Deployment rollouts
+
+Opt-in sequencing for Kubernetes Deployments. A dependent Deployment stays paused until its upstream Deployment finishes rolling, soaks for a configurable period (default `5m`), and passes a restart check (default: container restart deltas divided by upstream pod count must be below `10%`).
+
+### Enablement
+
+Label opted-in Deployments and stamp a shared revision from Git/jsonnet. Point followers at their upstream with `grafana.com/rollout-depends-on`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-frontend-zone-a
+  labels:
+    grafana.com/rollout-phased: "true"
+  annotations:
+    grafana.com/rollout-revision: "r388"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-frontend-zone-b
+  labels:
+    grafana.com/rollout-phased: "true"
+  annotations:
+    grafana.com/rollout-depends-on: query-frontend-zone-a
+    grafana.com/rollout-revision: "r388"
+    # Optional overrides:
+    # grafana.com/rollout-soak-duration: "5m"
+    # grafana.com/rollout-restart-threshold: "10%"
+```
+
+The mutating webhook `/admission/phased-deployment` (scoped to `grafana.com/rollout-phased: "true"`) pauses the follower when the revision changes and re-applies `spec.paused: true` on later applies while the gate is active (including Flux server-side apply).
+
+Chains such as zone-a → zone-b → zone-c are supported by setting `depends-on` on each follower. Disable by removing `grafana.com/rollout-depends-on` (the webhook clears gate state and restores the prior pause intent) and optionally the `grafana.com/rollout-phased` label. If you remove only the label while the Deployment is still paused by the operator, unpause it manually.
+
+### Resume after a failed soak
+
+If the restart check fails, the follower stays paused with phase `blocked`. Resume for that revision:
+
+```bash
+kubectl annotate deployment query-frontend-zone-b grafana.com/rollout-resume=r388 --overwrite
+```
+
+The operator then marks the gate complete and unpauses immediately (no fresh soak).
+
 ## Operations
 
 ### HTTP endpoints
@@ -174,7 +220,11 @@ Prometheus metrics endpoint.
 
 #### `/admission/no-downscale`
 
-Offers a `ValidatingAdmissionWebhook` that rejects the requests that decrease the number of replicas in objects labeled as `grafana.com/no-downscale: true`. See [Webhooks](#webhooks) section below. 
+Offers a `ValidatingAdmissionWebhook` that rejects the requests that decrease the number of replicas in objects labeled as `grafana.com/no-downscale: true`. See [Webhooks](#webhooks) section below.
+
+#### `/admission/phased-deployment`
+
+Offers a `MutatingAdmissionWebhook` that pauses opted-in dependent Deployments while an upstream soak gate is active. See [Phased Deployment rollouts](#phased-deployment-rollouts).
 
 #### `/pods/eviction`
 
@@ -216,6 +266,15 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
 - apiGroups:
   - rollout-operator.grafana.com
   resources:

--- a/README.md
+++ b/README.md
@@ -156,6 +156,73 @@ spec:
 
 To resume normal rollout behavior, remove the annotation or set it to any value other than `true`.
 
+## Health-check driven rollout gating
+
+After the first zone in a rollout group finishes updating, the operator can evaluate cell-level health before starting the next zone. Pod readiness remains the within-zone gate; health checks are an additional between-zone gate.
+
+Attach a check to StatefulSets in the group:
+
+```yaml
+metadata:
+  annotations:
+    grafana.com/rollout-health-check: ingester-cell-health
+```
+
+Define the reusable configuration as a namespaced `RolloutHealthCheck`:
+
+```yaml
+apiVersion: rollout-operator.grafana.com/v1
+kind: RolloutHealthCheck
+metadata:
+  name: ingester-cell-health
+spec:
+  selector:
+    matchLabels:
+      rollout-group: ingester
+  prometheusURL: http://critical-prometheus.critical-o11y.svc.cluster.local.:9090/critical-prometheus
+  checks:
+    - name: request-error-rate
+      currentRange: 5m
+      baselineRange: 10m
+      queryTimeout: 10s
+      queryRetries: 3
+      onFailure: Pause   # Pause | Warn | Disabled
+      onNoData: Pause
+      # ${targetMatchers} is replaced with namespace + pod matchers for candidate or stable pods.
+      # ${range} is replaced with currentRange or baselineRange.
+      query: |
+        scalar(
+          sum(
+            rate(
+              cortex_request_duration_seconds_count{
+                ${targetMatchers},
+                status_code=~"5..",
+                route!~"ready|debug_pprof"
+              }[${range}]
+            )
+          )
+          or vector(0)
+        )
+      # ${current} and ${baseline} are the scalar results of the query above.
+      # Must return scalar 1 (pass) or 0 (fail).
+      successQuery: |
+        (
+          (${current} < bool 1)
+          +
+          (${current} < bool (2 * ${baseline}))
+        ) > bool 0
+```
+
+Behavior:
+
+- The first zone always rolls without a health evaluation (minimum blast radius is one zone).
+- Before starting a subsequent zone, each enabled check runs against candidate pods (already updated) and stable pods (not yet updated). Failed, no-data, or unreachable checks with `onFailure`/`onNoData: Pause` block progression.
+- `Warn` emits a warning event/log and continues. `Disabled` (or `disabled: true` on a check) skips that check.
+- If the annotation references a missing `RolloutHealthCheck`, or the check's selector does not match the StatefulSet, the rollout proceeds as today and the operator emits an error log, a Kubernetes event, and increments `rollout_operator_health_check_misconfigured_total`.
+- Remove the annotation (or set individual checks to `Disabled`) to bypass the gate. The operator never reverts workload versions.
+
+The operator stores `grafana.com/rollout-health-check-started-at: <updateRevision>=<RFC3339>` on StatefulSets when it first observes pods needing that revision; the earliest timestamp in the group is used as the baseline evaluation time.
+
 ## Operations
 
 ### HTTP endpoints

--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ To resume normal rollout behavior, remove the annotation or set it to any value 
 
 ## Phased Deployment rollouts
 
-Opt-in sequencing for Kubernetes Deployments. A dependent Deployment stays paused until its upstream Deployment finishes rolling, soaks for a configurable period (default `5m`), and passes a restart check (default: container restart deltas divided by upstream pod count must be below `10%`).
+Opt-in sequencing for Kubernetes Deployments (proposal 4c). A main Deployment stays paused until its canary Deployment(s) finish rolling and become ready. Batches are explicit Deployments in Git; the operator only toggles `spec.paused` and never manages ReplicaSets. Prometheus health gating is a separate feature (proposal 4b) and is not part of this gate.
 
 ### Enablement
 
-Label opted-in Deployments and stamp a shared revision from Git/jsonnet. Point followers at their upstream with `grafana.com/rollout-depends-on`:
+Label opted-in Deployments and stamp a shared revision from Git/jsonnet. Point the main Deployment at its canary with `grafana.com/rollout-canary` (comma-separated for coordinated groups):
 
 ```yaml
 apiVersion: apps/v1
@@ -181,26 +181,33 @@ metadata:
   labels:
     grafana.com/rollout-phased: "true"
   annotations:
-    grafana.com/rollout-depends-on: query-frontend-zone-a
+    grafana.com/rollout-canary: query-frontend-zone-a
     grafana.com/rollout-revision: "r388"
-    # Optional overrides:
-    # grafana.com/rollout-soak-duration: "5m"
-    # grafana.com/rollout-restart-threshold: "10%"
 ```
 
-The mutating webhook `/admission/phased-deployment` (scoped to `grafana.com/rollout-phased: "true"`) pauses the follower when the revision changes and re-applies `spec.paused: true` on later applies while the gate is active (including Flux server-side apply).
+Coordinated canary groups (for example querier zone-b waiting on both querier and query-frontend zone-a):
 
-Chains such as zone-a → zone-b → zone-c are supported by setting `depends-on` on each follower. Disable by removing `grafana.com/rollout-depends-on` (the webhook clears gate state and restores the prior pause intent) and optionally the `grafana.com/rollout-phased` label. If you remove only the label while the Deployment is still paused by the operator, unpause it manually.
+```yaml
+metadata:
+  annotations:
+    grafana.com/rollout-canary: querier-zone-a,query-frontend-zone-a
+    grafana.com/rollout-revision: "r388"
+```
 
-### Resume after a failed soak
+The mutating webhook `/admission/phased-deployment` (scoped to `grafana.com/rollout-phased: "true"`) pauses the main Deployment when the revision changes and re-applies `spec.paused: true` on later applies while the gate is active (including Flux server-side apply).
 
-If the restart check fails, the follower stays paused with phase `blocked`. Resume for that revision:
+Disable by removing `grafana.com/rollout-canary` (the webhook clears gate state and restores the prior pause intent) and optionally the `grafana.com/rollout-phased` label. If you remove only the label while the Deployment is still paused by the operator, unpause it manually.
+
+### Incident bypass
+
+During an incident, apply a time-limited bypass so the Deployment uses native Kubernetes rolling updates:
 
 ```bash
-kubectl annotate deployment query-frontend-zone-b grafana.com/rollout-resume=r388 --overwrite
+kubectl annotate deployment query-frontend-zone-b \
+  grafana.com/rollout-bypass-until="2026-07-24T16:00:00Z" --overwrite
 ```
 
-The operator then marks the gate complete and unpauses immediately (no fresh soak).
+While the bypass is active, the operator does not pause new updates and unpauses an already-gated Deployment. It emits a Warning event (`RolloutBypass`) and increments `rollout_operator_phased_deployment_bypass_total`. Existing readiness checks and the native Deployment strategy still apply.
 
 ## Operations
 
@@ -224,7 +231,7 @@ Offers a `ValidatingAdmissionWebhook` that rejects the requests that decrease th
 
 #### `/admission/phased-deployment`
 
-Offers a `MutatingAdmissionWebhook` that pauses opted-in dependent Deployments while an upstream soak gate is active. See [Phased Deployment rollouts](#phased-deployment-rollouts).
+Offers a `MutatingAdmissionWebhook` that pauses opted-in main Deployments while a canary gate is active. See [Phased Deployment rollouts](#phased-deployment-rollouts).
 
 #### `/pods/eviction`
 
@@ -275,6 +282,12 @@ rules:
   - get
   - watch
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
 - apiGroups:
   - rollout-operator.grafana.com
   resources:

--- a/README.md
+++ b/README.md
@@ -184,12 +184,21 @@ spec:
     - name: request-error-rate
       currentRange: 5m
       baselineRange: 10m
-      queryTimeout: 10s
-      queryRetries: 3
-      onFailure: Pause   # Pause | Warn | Disabled
-      onNoData: Pause
-      # ${targetMatchers} is replaced with namespace + pod matchers for candidate or stable pods.
-      # ${range} is replaced with currentRange or baselineRange.
+      errorPolicy:
+        retryInterval: 10s
+        maxAttempts: 3
+        exhaustedAction: Pause   # Pause | Warn | Disabled
+      failurePolicy:
+        reevaluationInterval: 2m30s
+        consecutiveFailures: 3
+        consecutiveSuccesses: 1
+        exceededAction: Pause   # Pause | Warn | Disabled
+      noDataPolicy:
+        retryInterval: 30s
+        maxAttempts: 3
+        exhaustedAction: Pause
+      # ${targetMatchers} is replaced with namespace, zone (pod "name" label), and pod matchers
+      # for candidate or stable pods. ${range} is replaced with currentRange or baselineRange.
       query: |
         scalar(
           sum(
@@ -216,12 +225,16 @@ spec:
 Behavior:
 
 - The first zone always rolls without a health evaluation (minimum blast radius is one zone).
-- Before starting a subsequent zone, each enabled check runs against candidate pods (already updated) and stable pods (not yet updated). Failed, no-data, or unreachable checks with `onFailure`/`onNoData: Pause` block progression.
+- Before starting a subsequent zone, each enabled check runs against candidate pods (already updated) and stable pods (not yet updated).
+- Query errors use `errorPolicy` (retries spaced by `retryInterval` across reconciles, then `exhaustedAction`). No-data uses `noDataPolicy` the same way. Defaults pause when attempts are exhausted.
+- Failed success queries accumulate under `failurePolicy`. Progression pauses until `consecutiveSuccesses` pass results are observed (default 1). After `consecutiveFailures`, `exceededAction` applies (`Pause` by default). Re-queries that update those counters are spaced by `reevaluationInterval`.
 - `Warn` emits a warning event/log and continues. `Disabled` (or `disabled: true` on a check) skips that check.
 - If the annotation references a missing `RolloutHealthCheck`, or the check's selector does not match the StatefulSet, the rollout proceeds as today and the operator emits an error log, a Kubernetes event, and increments `rollout_operator_health_check_misconfigured_total`.
 - Remove the annotation (or set individual checks to `Disabled`) to bypass the gate. The operator never reverts workload versions.
 
 The operator stores `grafana.com/rollout-health-check-started-at: <updateRevision>=<RFC3339>` on StatefulSets when it first observes pods needing that revision; the earliest timestamp in the group is used as the baseline evaluation time.
+
+Create/update of `RolloutHealthCheck` objects is validated by the `/admission/rollout-health-check-validation` webhook when webhooks are enabled.
 
 ## Operations
 
@@ -250,6 +263,10 @@ Offers a `ValidatingAdmissionWebhook` which can apply a `ZoneAwarePodDisruptionB
 #### `/admission/zpdb-validation`
 
 Offers a `ValidatingAdmissionWebhook` to validate `ZoneAwarePodDisruptionBudget` configuration files and will reject any misconfigured files.
+
+#### `/admission/rollout-health-check-validation`
+
+Offers a `ValidatingAdmissionWebhook` to validate `RolloutHealthCheck` configuration and will reject misconfigured objects.
 
 
 ### RBAC

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ To resume normal rollout behavior, remove the annotation or set it to any value 
 
 ## Phased Deployment rollouts
 
-Opt-in sequencing for Kubernetes Deployments (proposal 4c). A main Deployment stays paused until its canary Deployment(s) finish rolling and become ready. Batches are explicit Deployments in Git; the operator only toggles `spec.paused` and never manages ReplicaSets. Prometheus health gating is a separate feature (proposal 4b) and is not part of this gate.
+Opt-in sequencing for Kubernetes Deployments (proposal 4c). A main Deployment stays paused until its canary Deployment(s) finish rolling and become ready. Readiness is latched for the current shared revision once every canary is fully rolled, so routine pod evictions or autoscaling do not return an active gate to its initial readiness check. A canary must continue to report the target revision. Batches are explicit Deployments in Git; the operator only toggles `spec.paused` and never manages ReplicaSets. Prometheus health gating is a separate feature (proposal 4b) and is not part of this gate.
 
 ### Enablement
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ metadata:
 
 The mutating webhook `/admission/phased-deployment` (scoped to `grafana.com/rollout-phased: "true"`) pauses the main Deployment when the revision changes and re-applies `spec.paused: true` on later applies while the gate is active (including Flux server-side apply).
 
+Add `grafana.com/rollout-health-check` to a gated Deployment to evaluate the referenced `RolloutHealthCheck` after its canaries are fully rolled out and before it is unpaused. Canary pods are evaluated as the candidate and the paused Deployment's pods as the stable baseline. The `RolloutHealthCheck` selector must match the gated Deployment's labels.
+
 Disable by removing `grafana.com/rollout-canary` (the webhook clears gate state and restores the prior pause intent) and optionally the `grafana.com/rollout-phased` label. If you remove only the label while the Deployment is still paused by the operator, unpause it manually.
 
 ### Incident bypass

--- a/README.md
+++ b/README.md
@@ -238,11 +238,11 @@ Create/update of `RolloutHealthCheck` objects is validated by the `/admission/ro
 
 ## Phased Deployment rollouts
 
-Opt-in sequencing for Kubernetes Deployments. A dependent Deployment stays paused until its upstream Deployment finishes rolling, soaks for a configurable period (default `5m`), and passes a restart check (default: container restart deltas divided by upstream pod count must be below `10%`).
+Opt-in sequencing for Kubernetes Deployments (proposal 4c). A main Deployment stays paused until its canary Deployment(s) finish rolling and become ready. Batches are explicit Deployments in Git; the operator only toggles `spec.paused` and never manages ReplicaSets. Prometheus health gating is a separate feature (proposal 4b) and is not part of this gate.
 
 ### Enablement
 
-Label opted-in Deployments and stamp a shared revision from Git/jsonnet. Point followers at their upstream with `grafana.com/rollout-depends-on`:
+Label opted-in Deployments and stamp a shared revision from Git/jsonnet. Point the main Deployment at its canary with `grafana.com/rollout-canary` (comma-separated for coordinated groups):
 
 ```yaml
 apiVersion: apps/v1
@@ -261,26 +261,33 @@ metadata:
   labels:
     grafana.com/rollout-phased: "true"
   annotations:
-    grafana.com/rollout-depends-on: query-frontend-zone-a
+    grafana.com/rollout-canary: query-frontend-zone-a
     grafana.com/rollout-revision: "r388"
-    # Optional overrides:
-    # grafana.com/rollout-soak-duration: "5m"
-    # grafana.com/rollout-restart-threshold: "10%"
 ```
 
-The mutating webhook `/admission/phased-deployment` (scoped to `grafana.com/rollout-phased: "true"`) pauses the follower when the revision changes and re-applies `spec.paused: true` on later applies while the gate is active (including Flux server-side apply).
+Coordinated canary groups (for example querier zone-b waiting on both querier and query-frontend zone-a):
 
-Chains such as zone-a → zone-b → zone-c are supported by setting `depends-on` on each follower. Disable by removing `grafana.com/rollout-depends-on` (the webhook clears gate state and restores the prior pause intent) and optionally the `grafana.com/rollout-phased` label. If you remove only the label while the Deployment is still paused by the operator, unpause it manually.
+```yaml
+metadata:
+  annotations:
+    grafana.com/rollout-canary: querier-zone-a,query-frontend-zone-a
+    grafana.com/rollout-revision: "r388"
+```
 
-### Resume after a failed soak
+The mutating webhook `/admission/phased-deployment` (scoped to `grafana.com/rollout-phased: "true"`) pauses the main Deployment when the revision changes and re-applies `spec.paused: true` on later applies while the gate is active (including Flux server-side apply).
 
-If the restart check fails, the follower stays paused with phase `blocked`. Resume for that revision:
+Disable by removing `grafana.com/rollout-canary` (the webhook clears gate state and restores the prior pause intent) and optionally the `grafana.com/rollout-phased` label. If you remove only the label while the Deployment is still paused by the operator, unpause it manually.
+
+### Incident bypass
+
+During an incident, apply a time-limited bypass so the Deployment uses native Kubernetes rolling updates:
 
 ```bash
-kubectl annotate deployment query-frontend-zone-b grafana.com/rollout-resume=r388 --overwrite
+kubectl annotate deployment query-frontend-zone-b \
+  grafana.com/rollout-bypass-until="2026-07-24T16:00:00Z" --overwrite
 ```
 
-The operator then marks the gate complete and unpauses immediately (no fresh soak).
+While the bypass is active, the operator does not pause new updates and unpauses an already-gated Deployment. It emits a Warning event (`RolloutBypass`) and increments `rollout_operator_phased_deployment_bypass_total`. Existing readiness checks and the native Deployment strategy still apply.
 
 ## Operations
 
@@ -304,7 +311,7 @@ Offers a `ValidatingAdmissionWebhook` that rejects the requests that decrease th
 
 #### `/admission/phased-deployment`
 
-Offers a `MutatingAdmissionWebhook` that pauses opted-in dependent Deployments while an upstream soak gate is active. See [Phased Deployment rollouts](#phased-deployment-rollouts).
+Offers a `MutatingAdmissionWebhook` that pauses opted-in main Deployments while a canary gate is active. See [Phased Deployment rollouts](#phased-deployment-rollouts).
 
 #### `/pods/eviction`
 
@@ -359,6 +366,12 @@ rules:
   - get
   - watch
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
 - apiGroups:
   - rollout-operator.grafana.com
   resources:

--- a/README.md
+++ b/README.md
@@ -236,6 +236,52 @@ The operator stores `grafana.com/rollout-health-check-started-at: <updateRevisio
 
 Create/update of `RolloutHealthCheck` objects is validated by the `/admission/rollout-health-check-validation` webhook when webhooks are enabled.
 
+## Phased Deployment rollouts
+
+Opt-in sequencing for Kubernetes Deployments. A dependent Deployment stays paused until its upstream Deployment finishes rolling, soaks for a configurable period (default `5m`), and passes a restart check (default: container restart deltas divided by upstream pod count must be below `10%`).
+
+### Enablement
+
+Label opted-in Deployments and stamp a shared revision from Git/jsonnet. Point followers at their upstream with `grafana.com/rollout-depends-on`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-frontend-zone-a
+  labels:
+    grafana.com/rollout-phased: "true"
+  annotations:
+    grafana.com/rollout-revision: "r388"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-frontend-zone-b
+  labels:
+    grafana.com/rollout-phased: "true"
+  annotations:
+    grafana.com/rollout-depends-on: query-frontend-zone-a
+    grafana.com/rollout-revision: "r388"
+    # Optional overrides:
+    # grafana.com/rollout-soak-duration: "5m"
+    # grafana.com/rollout-restart-threshold: "10%"
+```
+
+The mutating webhook `/admission/phased-deployment` (scoped to `grafana.com/rollout-phased: "true"`) pauses the follower when the revision changes and re-applies `spec.paused: true` on later applies while the gate is active (including Flux server-side apply).
+
+Chains such as zone-a → zone-b → zone-c are supported by setting `depends-on` on each follower. Disable by removing `grafana.com/rollout-depends-on` (the webhook clears gate state and restores the prior pause intent) and optionally the `grafana.com/rollout-phased` label. If you remove only the label while the Deployment is still paused by the operator, unpause it manually.
+
+### Resume after a failed soak
+
+If the restart check fails, the follower stays paused with phase `blocked`. Resume for that revision:
+
+```bash
+kubectl annotate deployment query-frontend-zone-b grafana.com/rollout-resume=r388 --overwrite
+```
+
+The operator then marks the gate complete and unpauses immediately (no fresh soak).
+
 ## Operations
 
 ### HTTP endpoints
@@ -254,7 +300,11 @@ Prometheus metrics endpoint.
 
 #### `/admission/no-downscale`
 
-Offers a `ValidatingAdmissionWebhook` that rejects the requests that decrease the number of replicas in objects labeled as `grafana.com/no-downscale: true`. See [Webhooks](#webhooks) section below. 
+Offers a `ValidatingAdmissionWebhook` that rejects the requests that decrease the number of replicas in objects labeled as `grafana.com/no-downscale: true`. See [Webhooks](#webhooks) section below.
+
+#### `/admission/phased-deployment`
+
+Offers a `MutatingAdmissionWebhook` that pauses opted-in dependent Deployments while an upstream soak gate is active. See [Phased Deployment rollouts](#phased-deployment-rollouts).
 
 #### `/pods/eviction`
 
@@ -300,6 +350,15 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
 - apiGroups:
   - rollout-operator.grafana.com
   resources:

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -44,7 +44,7 @@ import (
 const defaultServerSelfSignedCertExpiration = model.Duration(365 * 24 * time.Hour)
 
 var (
-	defaultClusterValidationExcludePaths = []string{"admission/no-downscale", "admission/prepare-downscale"}
+	defaultClusterValidationExcludePaths = []string{"admission/no-downscale", "admission/prepare-downscale", "admission/phased-deployment"}
 )
 
 type config struct {
@@ -312,10 +312,16 @@ func main() {
 		fatal(fmt.Errorf("failed to init controller: %w", err))
 	}
 
+	phasedController := controller.NewPhasedDeploymentController(coreKubeClient, cfg.kubeNamespace, cfg.reconcileInterval, reg, logger)
+	if err := phasedController.Init(); err != nil {
+		fatal(fmt.Errorf("failed to init phased deployment controller: %w", err))
+	}
+
 	// Listen to sigterm, as well as for restart (like for certificate renewal).
 	go func() {
 		waitForSignalOrRestart(logger, restart)
 		c.Stop()
+		phasedController.Stop()
 		evictionController.Stop()
 		webhookObserver.Stop()
 		if webhookCollector != nil {
@@ -326,6 +332,8 @@ func main() {
 
 	// The operator is ready once the controller successfully initialised.
 	ready.Store(true)
+
+	go phasedController.Run()
 
 	// Run and block until stopped.
 	c.Run()
@@ -429,6 +437,7 @@ func maybeStartTLSServer(cfg config, wireComponentConfig func(component string) 
 
 	tlsSrv.Handle(admission.NoDownscaleWebhookPath, admission.Serve(admission.NoDownscale, logger, noDownscaleKubeClient, webhookHandlerTimeout))
 	tlsSrv.Handle(admission.PrepareDownscaleWebhookPath, admission.Serve(prepDownscaleAdmitFunc, logger, prepareDownscaleKubeClient, webhookHandlerTimeout))
+	tlsSrv.Handle(admission.PhasedDeploymentWebhookPath, admission.Serve(admission.PhasedDeployment, logger, nil, webhookHandlerTimeout))
 	tlsSrv.Handle(zpdb.PodEvictionWebhookPath, admission.Serve(podEvictionFunc, logger, nil, webhookHandlerTimeout))
 	tlsSrv.Handle(admission.ZpdbValidatorWebhookPath, admission.Serve(zpdbValidationFunc, logger, nil, webhookHandlerTimeout))
 	if err := tlsSrv.Start(); err != nil {

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -323,12 +323,14 @@ func main() {
 	// Init the controller
 	c := controller.NewRolloutController(coreKubeClient, restMapper, scaleClient, dynamicClient, cfg.kubeClusterDomain, cfg.kubeNamespace, podsFactory, podHTTPClient, cfg.reconcileInterval, reg, logger, evictionController)
 	healthEvaluator := healthcheck.NewEvaluator(nil, healthMetrics, logger)
-	c.SetHealthCheck(healthcheck.NewGate(healthObserver, healthEvaluator, healthMetrics, eventRecorder, logger), healthMetrics)
+	healthGate := healthcheck.NewGate(healthObserver, healthEvaluator, healthMetrics, eventRecorder, logger)
+	c.SetHealthCheck(healthGate, healthMetrics)
 	if err := c.Init(); err != nil {
 		fatal(fmt.Errorf("failed to init controller: %w", err))
 	}
 
 	phasedController := controller.NewPhasedDeploymentController(coreKubeClient, cfg.kubeNamespace, cfg.reconcileInterval, reg, logger)
+	phasedController.SetHealthCheck(healthGate, healthMetrics)
 	if err := phasedController.Init(); err != nil {
 		fatal(fmt.Errorf("failed to init phased deployment controller: %w", err))
 	}

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -420,6 +420,10 @@ func maybeStartTLSServer(cfg config, wireComponentConfig func(component string) 
 		return admission.ZoneAwarePdbValidatingWebhookHandler(ctx, l, ar)
 	}
 
+	rolloutHealthCheckValidationFunc := func(ctx context.Context, l log.Logger, ar v1.AdmissionReview, _ *kubernetes.Clientset) *v1.AdmissionResponse {
+		return admission.RolloutHealthCheckValidatingWebhookHandler(ctx, l, ar)
+	}
+
 	tlsSrv, err := newTLSServer(cfg, logger, cert, metrics)
 	if err != nil {
 		fatal(fmt.Errorf("failed to create tls server: %w", err))
@@ -428,7 +432,8 @@ func maybeStartTLSServer(cfg config, wireComponentConfig func(component string) 
 	// Each webhook that issues Kubernetes API calls gets its own dedicated client, so that an overloaded
 	// webhook is rate limited independently (its own per-API-group buckets) and cannot throttle the other
 	// webhooks or the core controller. The pod-eviction webhook uses the eviction controller's dedicated
-	// client; the zpdb-validation webhook makes no API calls, so it is served with a nil client.
+	// client; the zpdb-validation and rollout-health-check-validation webhooks make no API calls, so
+	// they are served with a nil client.
 	noDownscaleKubeClient, err := newDedicatedKubeClient(wireComponentConfig("no-downscale"))
 	if err != nil {
 		fatal(fmt.Errorf("failed to create no-downscale webhook Kubernetes client: %w", err))
@@ -449,6 +454,7 @@ func maybeStartTLSServer(cfg config, wireComponentConfig func(component string) 
 	tlsSrv.Handle(admission.PrepareDownscaleWebhookPath, admission.Serve(prepDownscaleAdmitFunc, logger, prepareDownscaleKubeClient, webhookHandlerTimeout))
 	tlsSrv.Handle(zpdb.PodEvictionWebhookPath, admission.Serve(podEvictionFunc, logger, nil, webhookHandlerTimeout))
 	tlsSrv.Handle(admission.ZpdbValidatorWebhookPath, admission.Serve(zpdbValidationFunc, logger, nil, webhookHandlerTimeout))
+	tlsSrv.Handle(admission.RolloutHealthCheckValidatorWebhookPath, admission.Serve(rolloutHealthCheckValidationFunc, logger, nil, webhookHandlerTimeout))
 	if err := tlsSrv.Start(); err != nil {
 		fatal(fmt.Errorf("failed to start tls server: %w", err))
 	}

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -25,16 +25,21 @@ import (
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Required to get the GCP auth provider working.
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/grafana/rollout-operator/pkg/admission"
 	"github.com/grafana/rollout-operator/pkg/controller"
+	"github.com/grafana/rollout-operator/pkg/healthcheck"
 	"github.com/grafana/rollout-operator/pkg/instrumentation"
 	"github.com/grafana/rollout-operator/pkg/tlscert"
 	"github.com/grafana/rollout-operator/pkg/webhooks"
@@ -167,6 +172,7 @@ func main() {
 	reg := prometheus.NewRegistry()
 	metrics := newMetrics(reg)
 	zpdbMetrics := zpdb.NewMetrics(reg)
+	healthMetrics := healthcheck.NewMetrics(reg)
 
 	ready := atomic.NewBool(false)
 	restart := make(chan string)
@@ -293,6 +299,14 @@ func main() {
 	evictionController := zpdb.NewEvictionController(evictionKubeClient, dynamicClient, cfg.kubeNamespace, podsFactory, cfg.zpdbPodReadyAnnotationPatchTimeout, logger, zpdbMetrics)
 	check(evictionController.Start())
 
+	healthObserver := healthcheck.NewObserver(dynamicClient, cfg.kubeNamespace, logger, healthMetrics)
+	check(healthObserver.Start())
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartStructuredLogging(0)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: coreKubeClient.CoreV1().Events(cfg.kubeNamespace)})
+	eventRecorder := eventBroadcaster.NewRecorder(clientgoscheme.Scheme, corev1.EventSource{Component: "rollout-operator"})
+
 	maybeStartTLSServer(cfg, wireComponentConfig, podHTTPClient, logger, coreKubeClient, restart, metrics, evictionController, webhookObserver)
 
 	// Monitors the validating and mutating webhook configurations and provides a metric
@@ -308,6 +322,8 @@ func main() {
 
 	// Init the controller
 	c := controller.NewRolloutController(coreKubeClient, restMapper, scaleClient, dynamicClient, cfg.kubeClusterDomain, cfg.kubeNamespace, podsFactory, podHTTPClient, cfg.reconcileInterval, reg, logger, evictionController)
+	healthEvaluator := healthcheck.NewEvaluator(nil, healthMetrics, logger)
+	c.SetHealthCheck(healthcheck.NewGate(healthObserver, healthEvaluator, healthMetrics, eventRecorder, logger), healthMetrics)
 	if err := c.Init(); err != nil {
 		fatal(fmt.Errorf("failed to init controller: %w", err))
 	}
@@ -317,6 +333,8 @@ func main() {
 		waitForSignalOrRestart(logger, restart)
 		c.Stop()
 		evictionController.Stop()
+		healthObserver.Stop()
+		eventBroadcaster.Shutdown()
 		webhookObserver.Stop()
 		if webhookCollector != nil {
 			reg.Unregister(webhookCollector)

--- a/cmd/rollout-operator/main.go
+++ b/cmd/rollout-operator/main.go
@@ -49,7 +49,7 @@ import (
 const defaultServerSelfSignedCertExpiration = model.Duration(365 * 24 * time.Hour)
 
 var (
-	defaultClusterValidationExcludePaths = []string{"admission/no-downscale", "admission/prepare-downscale"}
+	defaultClusterValidationExcludePaths = []string{"admission/no-downscale", "admission/prepare-downscale", "admission/phased-deployment"}
 )
 
 type config struct {
@@ -328,10 +328,16 @@ func main() {
 		fatal(fmt.Errorf("failed to init controller: %w", err))
 	}
 
+	phasedController := controller.NewPhasedDeploymentController(coreKubeClient, cfg.kubeNamespace, cfg.reconcileInterval, reg, logger)
+	if err := phasedController.Init(); err != nil {
+		fatal(fmt.Errorf("failed to init phased deployment controller: %w", err))
+	}
+
 	// Listen to sigterm, as well as for restart (like for certificate renewal).
 	go func() {
 		waitForSignalOrRestart(logger, restart)
 		c.Stop()
+		phasedController.Stop()
 		evictionController.Stop()
 		healthObserver.Stop()
 		eventBroadcaster.Shutdown()
@@ -344,6 +350,8 @@ func main() {
 
 	// The operator is ready once the controller successfully initialised.
 	ready.Store(true)
+
+	go phasedController.Run()
 
 	// Run and block until stopped.
 	c.Run()
@@ -452,6 +460,7 @@ func maybeStartTLSServer(cfg config, wireComponentConfig func(component string) 
 
 	tlsSrv.Handle(admission.NoDownscaleWebhookPath, admission.Serve(admission.NoDownscale, logger, noDownscaleKubeClient, webhookHandlerTimeout))
 	tlsSrv.Handle(admission.PrepareDownscaleWebhookPath, admission.Serve(prepDownscaleAdmitFunc, logger, prepareDownscaleKubeClient, webhookHandlerTimeout))
+	tlsSrv.Handle(admission.PhasedDeploymentWebhookPath, admission.Serve(admission.PhasedDeployment, logger, nil, webhookHandlerTimeout))
 	tlsSrv.Handle(zpdb.PodEvictionWebhookPath, admission.Serve(podEvictionFunc, logger, nil, webhookHandlerTimeout))
 	tlsSrv.Handle(admission.ZpdbValidatorWebhookPath, admission.Serve(zpdbValidationFunc, logger, nil, webhookHandlerTimeout))
 	tlsSrv.Handle(admission.RolloutHealthCheckValidatorWebhookPath, admission.Serve(rolloutHealthCheckValidationFunc, logger, nil, webhookHandlerTimeout))

--- a/development/apply.sh
+++ b/development/apply.sh
@@ -21,4 +21,10 @@ done
 kubectl apply --wait -f "$SCRIPT_DIR/namespace.yaml"
 kubectl apply --wait -f "$SCRIPT_DIR/zone-aware-pod-disruption-budget-custom-resource-definition.yaml"
 kubectl apply --wait -f "$SCRIPT_DIR/replica-templates-custom-resource-definition.yaml"
-find "$SCRIPT_DIR" -type f -name '*.yaml' -not -name 'namespace.yaml' -not -name 'zone-aware-pod-disruption-budget-custom-resource-definition.yaml' -not name 'replica-templates-custom-resource-definition.yaml' -exec kubectl apply --namespace=rollout-operator-development --wait -f {} \;
+kubectl apply --wait -f "$SCRIPT_DIR/rollout-health-check-custom-resource-definition.yaml"
+find "$SCRIPT_DIR" -type f -name '*.yaml' \
+  -not -name 'namespace.yaml' \
+  -not -name 'zone-aware-pod-disruption-budget-custom-resource-definition.yaml' \
+  -not -name 'replica-templates-custom-resource-definition.yaml' \
+  -not -name 'rollout-health-check-custom-resource-definition.yaml' \
+  -exec kubectl apply --namespace=rollout-operator-development --wait -f {} \;

--- a/development/phased-deployment-webhook.yaml
+++ b/development/phased-deployment-webhook.yaml
@@ -1,0 +1,32 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: phased-deployment-rollout-operator-development
+  labels:
+    grafana.com/namespace: rollout-operator-development
+    grafana.com/inject-rollout-operator-ca: "true"
+webhooks:
+  - name: phased-deployment-rollout-operator-development.grafana.com
+    admissionReviewVersions: [v1]
+    clientConfig:
+      service:
+        name: rollout-operator
+        namespace: rollout-operator-development
+        path: /admission/phased-deployment
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: 10
+    objectSelector:
+      matchLabels:
+        grafana.com/rollout-phased: "true"
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: rollout-operator-development
+    rules:
+      - apiGroups: [apps]
+        apiVersions: [v1]
+        operations: [CREATE, UPDATE]
+        resources: [deployments]
+        scope: Namespaced

--- a/development/rollout-health-check-custom-resource-definition.yaml
+++ b/development/rollout-health-check-custom-resource-definition.yaml
@@ -1,0 +1,1 @@
+../operations/rollout-operator/crds/rollout-health-check.yaml

--- a/development/rollout-health-check-example.yaml
+++ b/development/rollout-health-check-example.yaml
@@ -1,0 +1,37 @@
+apiVersion: rollout-operator.grafana.com/v1
+kind: RolloutHealthCheck
+metadata:
+  name: ingester-cell-health
+  namespace: rollout-operator-development
+spec:
+  selector:
+    matchLabels:
+      rollout-group: ingester
+  prometheusURL: http://critical-prometheus.critical-o11y.svc.cluster.local.:9090/critical-prometheus
+  checks:
+    - name: request-error-rate
+      currentRange: 5m
+      baselineRange: 10m
+      queryTimeout: 10s
+      queryRetries: 3
+      onFailure: Pause
+      onNoData: Pause
+      query: |
+        scalar(
+          sum(
+            rate(
+              cortex_request_duration_seconds_count{
+                ${targetMatchers},
+                status_code=~"5..",
+                route!~"ready|debug_pprof"
+              }[${range}]
+            )
+          )
+          or vector(0)
+        )
+      successQuery: |
+        (
+          (${current} < bool 1)
+          +
+          (${current} < bool (2 * ${baseline}))
+        ) > bool 0

--- a/development/rollout-health-check-example.yaml
+++ b/development/rollout-health-check-example.yaml
@@ -12,10 +12,19 @@ spec:
     - name: request-error-rate
       currentRange: 5m
       baselineRange: 10m
-      queryTimeout: 10s
-      queryRetries: 3
-      onFailure: Pause
-      onNoData: Pause
+      errorPolicy:
+        retryInterval: 10s
+        maxAttempts: 3
+        exhaustedAction: Pause
+      failurePolicy:
+        reevaluationInterval: 2m30s
+        consecutiveFailures: 3
+        consecutiveSuccesses: 1
+        exceededAction: Pause
+      noDataPolicy:
+        retryInterval: 30s
+        maxAttempts: 3
+        exhaustedAction: Pause
       query: |
         scalar(
           sum(

--- a/development/rollout-health-check-validating-webhook.yaml
+++ b/development/rollout-health-check-validating-webhook.yaml
@@ -1,0 +1,32 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: rollout-health-check-validation-rollout-operator-development
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: rollout-operator-development
+webhooks:
+- name: rollout-health-check-validation-rollout-operator-development.grafana.com
+  clientConfig:
+    service:
+      namespace: rollout-operator-development
+      name: rollout-operator
+      path: /admission/rollout-health-check-validation
+      port: 443
+  rules:
+  - operations:
+      - CREATE
+      - UPDATE
+    apiGroups:
+      - rollout-operator.grafana.com
+    apiVersions:
+      - v1
+    resources:
+      - rollouthealthchecks
+    scope: Namespaced
+  admissionReviewVersions: ["v1"]
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: rollout-operator-development
+  failurePolicy: Fail
+  sideEffects: None

--- a/development/rollout-operator-role.yaml
+++ b/development/rollout-operator-role.yaml
@@ -29,6 +29,15 @@ rules:
     verbs:
       - update
   - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - list
+      - get
+      - watch
+      - patch
+  - apiGroups:
       - rollout-operator.grafana.com
     resources:
       - zoneawarepoddisruptionbudgets

--- a/development/rollout-operator-role.yaml
+++ b/development/rollout-operator-role.yaml
@@ -13,6 +13,7 @@ rules:
       - get
       - watch
       - delete
+      - patch
   - apiGroups:
       - apps
     resources:
@@ -29,11 +30,18 @@ rules:
     verbs:
       - update
   - apiGroups:
+      -
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
       - rollout-operator.grafana.com
     resources:
       - zoneawarepoddisruptionbudgets
+      - rollouthealthchecks
     verbs:
       - get
       - list
       - watch
-      

--- a/development/rollout-operator-role.yaml
+++ b/development/rollout-operator-role.yaml
@@ -45,6 +45,12 @@ rules:
       - watch
       - patch
   - apiGroups:
+      -
+    resources:
+      - events
+    verbs:
+      - create
+  - apiGroups:
       - rollout-operator.grafana.com
     resources:
       - zoneawarepoddisruptionbudgets

--- a/development/rollout-operator-role.yaml
+++ b/development/rollout-operator-role.yaml
@@ -38,6 +38,12 @@ rules:
       - watch
       - patch
   - apiGroups:
+      -
+    resources:
+      - events
+    verbs:
+      - create
+  - apiGroups:
       - rollout-operator.grafana.com
     resources:
       - zoneawarepoddisruptionbudgets

--- a/development/rollout-operator-role.yaml
+++ b/development/rollout-operator-role.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: rollout-operator-development
 rules:
   - apiGroups:
-      -
+      - ""
     resources:
       - pods
     verbs:
@@ -30,11 +30,19 @@ rules:
     verbs:
       - update
   - apiGroups:
-      -
+      - ""
     resources:
       - events
     verbs:
       - create
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - list
+      - get
+      - watch
       - patch
   - apiGroups:
       - rollout-operator.grafana.com

--- a/integration/manifests_rollout_operator_test.go
+++ b/integration/manifests_rollout_operator_test.go
@@ -86,6 +86,7 @@ func createRolloutOperatorDependencies(t *testing.T, ctx context.Context, api *k
 	require.NoError(t, err)
 
 	_ = createZoneAwarePodDistruptionBudgetCustomResourceDefinition(t, extApi)
+	_ = createRolloutHealthCheckCustomResourceDefinition(t, extApi)
 
 	if webhook {
 		_ = createReplicaTemplateCustomResourceDefinition(t, extApi)
@@ -162,6 +163,12 @@ func loadValidatingWebhookConfigurationFromFile(t *testing.T, path string) *admi
 
 func createZoneAwarePodDistruptionBudgetCustomResourceDefinition(t *testing.T, extApi *apiextensionsclient.Clientset) *apiextensionsv1.CustomResourceDefinition {
 	obj, err := extApi.ApiextensionsV1().CustomResourceDefinitions().Create(context.Background(), loadCustomResourceDefinitionFromDisk(t, "../development/zone-aware-pod-disruption-budget-custom-resource-definition.yaml"), metav1.CreateOptions{})
+	require.NoError(t, err)
+	return obj
+}
+
+func createRolloutHealthCheckCustomResourceDefinition(t *testing.T, extApi *apiextensionsclient.Clientset) *apiextensionsv1.CustomResourceDefinition {
+	obj, err := extApi.ApiextensionsV1().CustomResourceDefinitions().Create(context.Background(), loadCustomResourceDefinitionFromDisk(t, "../development/rollout-health-check-custom-resource-definition.yaml"), metav1.CreateOptions{})
 	require.NoError(t, err)
 	return obj
 }

--- a/integration/phased_deployment_test.go
+++ b/integration/phased_deployment_test.go
@@ -1,0 +1,242 @@
+//go:build requires_docker
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+func TestPhasedDeploymentHappyCase(t *testing.T) {
+	ctx := context.Background()
+	cluster := createKindCluster(t, "rollout-operator:latest", "mock-service:latest")
+	api := cluster.API()
+
+	path := initManifestFiles(t, "webhooks-enabled")
+	createRolloutOperator(t, ctx, api, cluster.ExtAPI(), path, true)
+	rolloutOperatorPod := eventuallyGetFirstPod(ctx, t, api, "name=rollout-operator")
+	requireEventuallyPod(t, api, ctx, rolloutOperatorPod, expectPodPhase(corev1.PodRunning), expectReady())
+
+	whPath := path + "admissionregistration.k8s.io-v1.MutatingWebhookConfiguration-phased-deployment-default.yaml"
+	createMutatingWebhookConfiguration(t, api, ctx, whPath)
+	require.Eventually(t, awaitCABundleAssignment(1, ctx, api), 30*time.Second, 50*time.Millisecond, "phased webhook has CABundle")
+
+	const rev1 = "r1"
+	const rev2 = "r2"
+	createPhasedMockDeployment(t, ctx, api, "frontend-zone-a", "", rev1, 1)
+	createPhasedMockDeployment(t, ctx, api, "frontend-zone-b", "frontend-zone-a", rev1, 1)
+	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-a")
+	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-b")
+
+	updatePhasedMockDeployment(t, ctx, api, "frontend-zone-a", "", rev2)
+	updatePhasedMockDeployment(t, ctx, api, "frontend-zone-b", "frontend-zone-a", rev2)
+
+	require.Eventually(t, func() bool {
+		b, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, "frontend-zone-b", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return b.Spec.Paused && b.Annotations[config.RolloutDependencyPhaseAnnotationKey] != ""
+	}, 30*time.Second, 200*time.Millisecond, "zone-b should be paused by phased gate")
+
+	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-a")
+
+	// Still paused during short soak (3s configured on the Deployment).
+	time.Sleep(1 * time.Second)
+	b, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, "frontend-zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.True(t, b.Spec.Paused, "zone-b should remain paused during soak")
+
+	require.Eventually(t, func() bool {
+		b, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, "frontend-zone-b", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return !b.Spec.Paused && b.Annotations[config.RolloutDependencyPhaseAnnotationKey] == config.RolloutDependencyPhaseComplete
+	}, 30*time.Second, 200*time.Millisecond, "zone-b should unpause after soak")
+
+	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-b")
+}
+
+func TestPhasedDeploymentResumeAfterBlock(t *testing.T) {
+	ctx := context.Background()
+	cluster := createKindCluster(t, "rollout-operator:latest", "mock-service:latest")
+	api := cluster.API()
+
+	path := initManifestFiles(t, "webhooks-not-enabled")
+	createRolloutOperator(t, ctx, api, cluster.ExtAPI(), path, false)
+	rolloutOperatorPod := eventuallyGetFirstPod(ctx, t, api, "name=rollout-operator")
+	requireEventuallyPod(t, api, ctx, rolloutOperatorPod, expectPodPhase(corev1.PodRunning), expectReady())
+
+	const rev = "r-block"
+	createPhasedMockDeployment(t, ctx, api, "frontend-zone-a", "", rev, 1)
+	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-a")
+
+	replicas := int32(1)
+	b := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "frontend-zone-b",
+			Labels: map[string]string{
+				config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue,
+				"name":                       "frontend-zone-b",
+			},
+			Annotations: map[string]string{
+				config.RolloutDependsOnAnnotationKey:          "frontend-zone-a",
+				config.RolloutRevisionAnnotationKey:           rev,
+				config.RolloutSoakDurationAnnotationKey:       "3s",
+				config.RolloutRestartThresholdAnnotationKey:   "10%",
+				config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseBlocked,
+				config.RolloutDependencyRevisionAnnotationKey: rev,
+				config.RolloutDependencyReasonAnnotationKey:   "test block",
+				config.RolloutHadPausedAnnotationKey:          "false",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Paused:   true,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": "frontend-zone-b"}},
+			Template: phasedMockPodTemplate("frontend-zone-b", "1"),
+		},
+	}
+	_, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, b, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = api.AppsV1().Deployments(corev1.NamespaceDefault).Patch(ctx, "frontend-zone-b",
+		types.MergePatchType,
+		[]byte(`{"metadata":{"annotations":{"grafana.com/rollout-resume":"r-block"}}}`),
+		metav1.PatchOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		cur, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, "frontend-zone-b", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return !cur.Spec.Paused && cur.Annotations[config.RolloutDependencyPhaseAnnotationKey] == config.RolloutDependencyPhaseComplete
+	}, 30*time.Second, 200*time.Millisecond, "resume should complete the gate")
+}
+
+func createPhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernetes.Clientset, name, dependsOn, revision string, replicas int32) {
+	t.Helper()
+	labels := map[string]string{
+		config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue,
+		"name":                       name,
+	}
+	ann := map[string]string{
+		config.RolloutRevisionAnnotationKey:     revision,
+		config.RolloutSoakDurationAnnotationKey: "3s",
+	}
+	if dependsOn != "" {
+		ann[config.RolloutDependsOnAnnotationKey] = dependsOn
+		// Treat the initial revision as already gated so CREATE does not pause the first rollout.
+		ann[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseComplete
+		ann[config.RolloutDependencyRevisionAnnotationKey] = revision
+	}
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      labels,
+			Annotations: ann,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": name}},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: intstrPtr(0),
+					MaxSurge:       intstrPtr(1),
+				},
+			},
+			Template: phasedMockPodTemplate(name, "1"),
+		},
+	}
+	_, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, d, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func updatePhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernetes.Clientset, name, dependsOn, revision string) {
+	t.Helper()
+	d, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, name, metav1.GetOptions{})
+	require.NoError(t, err)
+	if d.Annotations == nil {
+		d.Annotations = map[string]string{}
+	}
+	d.Annotations[config.RolloutRevisionAnnotationKey] = revision
+	if dependsOn != "" {
+		d.Annotations[config.RolloutDependsOnAnnotationKey] = dependsOn
+	}
+	d.Spec.Template = phasedMockPodTemplate(name, "2")
+	_, err = api.AppsV1().Deployments(corev1.NamespaceDefault).Update(ctx, d, metav1.UpdateOptions{})
+	require.NoError(t, err)
+}
+
+func phasedMockPodTemplate(name, version string) corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"name": name, "version": version},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:            "app",
+				Image:           "mock-service:latest",
+				ImagePullPolicy: corev1.PullNever,
+				Ports:           []corev1.ContainerPort{{ContainerPort: 8080}},
+				Env: []corev1.EnvVar{
+					{Name: "VERSION", Value: version},
+					{Name: "READY", Value: "true"},
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromInt(8080)},
+					},
+					InitialDelaySeconds: 1,
+					PeriodSeconds:       1,
+				},
+			}},
+		},
+	}
+}
+
+func awaitDeploymentRolledOut(t *testing.T, ctx context.Context, api *kubernetes.Clientset, name string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		d, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, name, metav1.GetOptions{})
+		if err != nil || d.Spec.Paused {
+			return false
+		}
+		desired := int32(1)
+		if d.Spec.Replicas != nil {
+			desired = *d.Spec.Replicas
+		}
+		return d.Status.ObservedGeneration >= d.Generation &&
+			d.Status.UpdatedReplicas == desired &&
+			d.Status.ReadyReplicas == desired &&
+			d.Status.AvailableReplicas == desired
+	}, 2*time.Minute, 500*time.Millisecond, "deployment %s should be fully rolled out", name)
+}
+
+func intstrPtr(v int) *intstr.IntOrString {
+	i := intstr.FromInt(v)
+	return &i
+}
+
+func createMutatingWebhookConfiguration(t *testing.T, api *kubernetes.Clientset, ctx context.Context, file string) *admissionregistrationv1.MutatingWebhookConfiguration {
+	t.Helper()
+	wh := loadFromDisk[admissionregistrationv1.MutatingWebhookConfiguration](t, file, &admissionregistrationv1.MutatingWebhookConfiguration{})
+	created, err := api.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(ctx, wh, metav1.CreateOptions{})
+	require.NoError(t, err)
+	return created
+}

--- a/integration/phased_deployment_test.go
+++ b/integration/phased_deployment_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -31,7 +32,20 @@ func TestPhasedDeploymentHappyCase(t *testing.T) {
 
 	whPath := path + "admissionregistration.k8s.io-v1.MutatingWebhookConfiguration-phased-deployment-default.yaml"
 	createMutatingWebhookConfiguration(t, api, ctx, whPath)
-	require.Eventually(t, awaitCABundleAssignment(1, ctx, api), 30*time.Second, 50*time.Millisecond, "phased webhook has CABundle")
+	require.Eventually(t, func() bool {
+		list, err := api.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{
+			LabelSelector: "grafana.com/inject-rollout-operator-ca=true,grafana.com/namespace=default",
+		})
+		if err != nil || len(list.Items) == 0 {
+			return false
+		}
+		for _, wh := range list.Items {
+			if strings.HasPrefix(wh.Name, "phased-deployment-") && len(wh.Webhooks) > 0 && len(wh.Webhooks[0].ClientConfig.CABundle) > 0 {
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 50*time.Millisecond, "phased webhook has CABundle")
 
 	const rev1 = "r1"
 	const rev2 = "r2"

--- a/integration/phased_deployment_test.go
+++ b/integration/phased_deployment_test.go
@@ -13,7 +13,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 
@@ -67,24 +66,18 @@ func TestPhasedDeploymentHappyCase(t *testing.T) {
 
 	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-a")
 
-	// Still paused during short soak (3s configured on the Deployment).
-	time.Sleep(1 * time.Second)
-	b, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, "frontend-zone-b", metav1.GetOptions{})
-	require.NoError(t, err)
-	require.True(t, b.Spec.Paused, "zone-b should remain paused during soak")
-
 	require.Eventually(t, func() bool {
 		b, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, "frontend-zone-b", metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
 		return !b.Spec.Paused && b.Annotations[config.RolloutDependencyPhaseAnnotationKey] == config.RolloutDependencyPhaseComplete
-	}, 30*time.Second, 200*time.Millisecond, "zone-b should unpause after soak")
+	}, 30*time.Second, 200*time.Millisecond, "zone-b should unpause after canary is ready")
 
 	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-b")
 }
 
-func TestPhasedDeploymentResumeAfterBlock(t *testing.T) {
+func TestPhasedDeploymentBypass(t *testing.T) {
 	ctx := context.Background()
 	cluster := createKindCluster(t, "rollout-operator:latest", "mock-service:latest")
 	api := cluster.API()
@@ -94,7 +87,7 @@ func TestPhasedDeploymentResumeAfterBlock(t *testing.T) {
 	rolloutOperatorPod := eventuallyGetFirstPod(ctx, t, api, "name=rollout-operator")
 	requireEventuallyPod(t, api, ctx, rolloutOperatorPod, expectPodPhase(corev1.PodRunning), expectReady())
 
-	const rev = "r-block"
+	const rev = "r-bypass"
 	createPhasedMockDeployment(t, ctx, api, "frontend-zone-a", "", rev, 1)
 	awaitDeploymentRolledOut(t, ctx, api, "frontend-zone-a")
 
@@ -107,14 +100,13 @@ func TestPhasedDeploymentResumeAfterBlock(t *testing.T) {
 				"name":                       "frontend-zone-b",
 			},
 			Annotations: map[string]string{
-				config.RolloutDependsOnAnnotationKey:          "frontend-zone-a",
+				config.RolloutCanaryAnnotationKey:             "frontend-zone-a",
 				config.RolloutRevisionAnnotationKey:           rev,
-				config.RolloutSoakDurationAnnotationKey:       "3s",
-				config.RolloutRestartThresholdAnnotationKey:   "10%",
-				config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseBlocked,
+				config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseWaiting,
 				config.RolloutDependencyRevisionAnnotationKey: rev,
-				config.RolloutDependencyReasonAnnotationKey:   "test block",
+				config.RolloutDependencyReasonAnnotationKey:   "test wait",
 				config.RolloutHadPausedAnnotationKey:          "false",
+				config.RolloutBypassUntilAnnotationKey:        time.Now().UTC().Add(time.Hour).Format(time.RFC3339),
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -127,33 +119,26 @@ func TestPhasedDeploymentResumeAfterBlock(t *testing.T) {
 	_, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, b, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	_, err = api.AppsV1().Deployments(corev1.NamespaceDefault).Patch(ctx, "frontend-zone-b",
-		types.MergePatchType,
-		[]byte(`{"metadata":{"annotations":{"grafana.com/rollout-resume":"r-block"}}}`),
-		metav1.PatchOptions{})
-	require.NoError(t, err)
-
 	require.Eventually(t, func() bool {
 		cur, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, "frontend-zone-b", metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
 		return !cur.Spec.Paused && cur.Annotations[config.RolloutDependencyPhaseAnnotationKey] == config.RolloutDependencyPhaseComplete
-	}, 30*time.Second, 200*time.Millisecond, "resume should complete the gate")
+	}, 30*time.Second, 200*time.Millisecond, "bypass should complete the gate")
 }
 
-func createPhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernetes.Clientset, name, dependsOn, revision string, replicas int32) {
+func createPhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernetes.Clientset, name, canary, revision string, replicas int32) {
 	t.Helper()
 	labels := map[string]string{
 		config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue,
 		"name":                       name,
 	}
 	ann := map[string]string{
-		config.RolloutRevisionAnnotationKey:     revision,
-		config.RolloutSoakDurationAnnotationKey: "3s",
+		config.RolloutRevisionAnnotationKey: revision,
 	}
-	if dependsOn != "" {
-		ann[config.RolloutDependsOnAnnotationKey] = dependsOn
+	if canary != "" {
+		ann[config.RolloutCanaryAnnotationKey] = canary
 		// Treat the initial revision as already gated so CREATE does not pause the first rollout.
 		ann[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseComplete
 		ann[config.RolloutDependencyRevisionAnnotationKey] = revision
@@ -181,7 +166,7 @@ func createPhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernet
 	require.NoError(t, err)
 }
 
-func updatePhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernetes.Clientset, name, dependsOn, revision string) {
+func updatePhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernetes.Clientset, name, canary, revision string) {
 	t.Helper()
 	d, err := api.AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, name, metav1.GetOptions{})
 	require.NoError(t, err)
@@ -189,8 +174,8 @@ func updatePhasedMockDeployment(t *testing.T, ctx context.Context, api *kubernet
 		d.Annotations = map[string]string{}
 	}
 	d.Annotations[config.RolloutRevisionAnnotationKey] = revision
-	if dependsOn != "" {
-		d.Annotations[config.RolloutDependsOnAnnotationKey] = dependsOn
+	if canary != "" {
+		d.Annotations[config.RolloutCanaryAnnotationKey] = canary
 	}
 	d.Spec.Template = phasedMockPodTemplate(name, "2")
 	_, err = api.AppsV1().Deployments(corev1.NamespaceDefault).Update(ctx, d, metav1.UpdateOptions{})

--- a/operations/policies/common.rego
+++ b/operations/policies/common.rego
@@ -145,6 +145,15 @@ is_prepare_downscale_webhook(obj) if {
     startswith(obj.metadata.name, "prepare-downscale-")
 }
 
+has_phased_deployment_webhook if {
+    is_phased_deployment_webhook(input[_].contents)
+}
+
+is_phased_deployment_webhook(obj) if {
+    obj.kind == "MutatingWebhookConfiguration"
+    startswith(obj.metadata.name, "phased-deployment-")
+}
+
 has_no_downscale_webhook if {
     is_no_downscale_webhook(input[_].contents)
 }

--- a/operations/policies/policies_expected_objects.rego
+++ b/operations/policies/policies_expected_objects.rego
@@ -61,6 +61,12 @@ deny contains msg if {
 
 deny contains msg if {
     has_webhooks_deployment
+    not has_phased_deployment_webhook
+    msg := "Missing phased_deployment webhook"
+}
+
+deny contains msg if {
+    has_webhooks_deployment
     not has_no_downscale_webhook
     msg := "Missing no_downscale webhook"
 }

--- a/operations/policies/policies_role.rego
+++ b/operations/policies/policies_role.rego
@@ -19,6 +19,11 @@ expected_rules = [
     "verbs": ["update"],
   },
   {
+    "apiGroups": ["apps"],
+    "resources": ["deployments"],
+    "verbs": ["list", "get", "watch", "patch"],
+  },
+  {
     "apiGroups": [""],
     "resources": ["configmaps"],
     "verbs": ["get", "update", "create"],

--- a/operations/policies/policies_role.rego
+++ b/operations/policies/policies_role.rego
@@ -25,6 +25,11 @@ expected_rules = [
   },
   {
     "apiGroups": [""],
+    "resources": ["events"],
+    "verbs": ["create"],
+  },
+  {
+    "apiGroups": [""],
     "resources": ["configmaps"],
     "verbs": ["get", "update", "create"],
   },

--- a/operations/policies/policies_webhooks.rego
+++ b/operations/policies/policies_webhooks.rego
@@ -83,6 +83,24 @@ deny contains msg if {
     msg := sprintf("MutatingWebhookConfiguration does not have expected rule, %v. Expected %v, got %v", [display_name(obj), rule, obj.webhooks[0].rules])
 }
 
+# Assert that the phased-deployment has expected path
+deny contains msg if {
+    path := "/admission/phased-deployment"
+	obj := input[_].contents
+	is_phased_deployment_webhook(obj)
+	obj.webhooks[0].clientConfig.service.path != path
+    msg := sprintf("MutatingWebhookConfiguration does not have expected path, %v. Expected %v, got %v", [display_name(obj), path, obj.webhooks[0].clientConfig.service.path])
+}
+
+# Assert that the phased-deployment has expected rule
+deny contains msg if {
+    rule := { "apiGroups": ["apps"], "apiVersions": ["v1"], "operations": ["CREATE", "UPDATE"], "resources": ["deployments"] }
+	obj := input[_].contents
+	is_phased_deployment_webhook(obj)
+	not webhook_rule_present(obj, rule)
+    msg := sprintf("MutatingWebhookConfiguration does not have expected rule, %v. Expected %v, got %v", [display_name(obj), rule, obj.webhooks[0].rules])
+}
+
 # Assert that the no-downscale has expected path
 deny contains msg if {
     path := "/admission/no-downscale"

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -58,6 +58,114 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: zoneawarepoddisruptionbudgets.rollout-operator.grafana.com
 spec:
   group: rollout-operator.grafana.com
@@ -199,9 +307,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -191,6 +191,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -320,6 +329,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -348,6 +348,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -492,6 +501,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -546,6 +595,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -359,6 +359,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -202,6 +202,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -4,6 +4,114 @@ metadata:
   name: rollout-operator
   namespace: default
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -44,9 +152,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -36,6 +36,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -204,6 +204,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -193,6 +193,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -47,6 +47,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -42,38 +42,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -58,6 +58,114 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: zoneawarepoddisruptionbudgets.rollout-operator.grafana.com
 spec:
   group: rollout-operator.grafana.com
@@ -199,9 +307,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -191,6 +191,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -320,6 +329,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -546,6 +595,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Ignore
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -348,6 +348,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -492,6 +501,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -359,6 +359,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -202,6 +202,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy.jsonnet
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy.jsonnet
@@ -5,6 +5,7 @@ rollout_operator {
     namespace: 'default',
     ignore_rollout_operator_no_downscale_webhook_failures: true,
     ignore_rollout_operator_prepare_downscale_webhook_failures: true,
+    ignore_rollout_operator_phased_deployment_webhook_failures: true,
     ignore_rollout_operator_zpdb_eviction_webhook_failures: true,
     ignore_rollout_operator_zpdb_validation_webhook_failures: true,
   },

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy.jsonnet
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy.jsonnet
@@ -5,6 +5,7 @@ rollout_operator {
     namespace: 'default',
     ignore_rollout_operator_no_downscale_webhook_failures: true,
     ignore_rollout_operator_prepare_downscale_webhook_failures: true,
+    ignore_rollout_operator_phased_deployment_webhook_failures: true,
     ignore_rollout_operator_zpdb_eviction_webhook_failures: true,
     ignore_rollout_operator_zpdb_validation_webhook_failures: true,
     ignore_rollout_operator_rollout_health_check_validation_webhook_failures: true,

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy.jsonnet
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy.jsonnet
@@ -7,5 +7,6 @@ rollout_operator {
     ignore_rollout_operator_prepare_downscale_webhook_failures: true,
     ignore_rollout_operator_zpdb_eviction_webhook_failures: true,
     ignore_rollout_operator_zpdb_validation_webhook_failures: true,
+    ignore_rollout_operator_rollout_health_check_validation_webhook_failures: true,
   },
 }

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -115,6 +115,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -252,6 +261,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -55,6 +55,114 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -123,6 +231,13 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - replicatemplates/scale
@@ -134,6 +249,14 @@ rules:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -272,6 +272,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -424,6 +433,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -486,6 +535,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -126,6 +126,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -283,6 +283,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -58,6 +58,114 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: zoneawarepoddisruptionbudgets.rollout-operator.grafana.com
 spec:
   group: rollout-operator.grafana.com
@@ -199,6 +307,13 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - replicatemplates/scale
@@ -210,6 +325,14 @@ rules:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -191,6 +191,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -328,6 +337,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -348,6 +348,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -500,6 +509,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -359,6 +359,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -563,6 +612,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -202,6 +202,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -55,6 +55,114 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -123,9 +231,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -115,6 +115,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -244,6 +253,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -470,6 +519,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -126,6 +126,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -272,6 +272,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -416,6 +425,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -283,6 +283,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -55,6 +55,114 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -123,9 +231,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -115,6 +115,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -244,6 +253,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -470,6 +519,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -126,6 +126,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -272,6 +272,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -416,6 +425,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -283,6 +283,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -55,6 +55,114 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -123,9 +231,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -115,6 +115,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -244,6 +253,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -470,6 +519,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -126,6 +126,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -272,6 +272,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -416,6 +425,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -283,6 +283,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -55,6 +55,114 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -123,9 +231,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -115,6 +115,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -244,6 +253,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -470,6 +519,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -126,6 +126,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -272,6 +272,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -416,6 +425,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -283,6 +283,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -55,6 +55,114 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -123,9 +231,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -115,6 +115,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -244,6 +253,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -470,6 +519,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -126,6 +126,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -272,6 +272,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -416,6 +425,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -283,6 +283,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -55,6 +55,114 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    shortNames:
+    - rhc
+    singular: rollouthealthcheck
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              checks:
+                description: Ordered list of PromQL health checks evaluated before
+                  progressing to the next zone.
+                items:
+                  properties:
+                    baselineRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating stable pods at the pre-rollout timestamp.
+                        Defaults to 10m.
+                      type: string
+                    currentRange:
+                      description: Range vector duration substituted for ${range}
+                        when evaluating candidate pods. Defaults to 5m.
+                      type: string
+                    disabled:
+                      description: When true, this check is skipped while other checks
+                        remain active.
+                      type: boolean
+                    name:
+                      description: Unique name of this check within the RolloutHealthCheck.
+                      minLength: 1
+                      type: string
+                    onFailure:
+                      description: Behavior when the success query returns failure.
+                        Defaults to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    onNoData:
+                      description: Behavior when a query returns no data. Defaults
+                        to Pause.
+                      enum:
+                      - Pause
+                      - Warn
+                      - Disabled
+                      type: string
+                    query:
+                      description: |
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                      minLength: 1
+                      type: string
+                    queryRetries:
+                      description: Number of retries after the first attempt. Defaults
+                        to 3.
+                      minimum: 0
+                      type: integer
+                    queryTimeout:
+                      description: Per-query timeout. Defaults to 10s.
+                      type: string
+                    successQuery:
+                      description: |
+                        PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - query
+                  - successQuery
+                  type: object
+                minItems: 1
+                type: array
+              prometheusURL:
+                description: Base URL of the Prometheus HTTP API used to evaluate
+                  checks.
+                minLength: 1
+                type: string
+              selector:
+                description: Selector preventing this policy from being attached to
+                  an unrelated workload.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+            required:
+            - selector
+            - prometheusURL
+            - checks
+            type: object
+        type: object
+    served: true
+    storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -123,9 +231,24 @@ rules:
   - update
   - create
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - rollouthealthchecks
   verbs:
   - get
   - list

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -115,6 +115,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -244,6 +253,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -93,38 +93,87 @@ spec:
                       description: When true, this check is skipped while other checks
                         remain active.
                       type: boolean
+                    errorPolicy:
+                      description: Retry and action policy when a Prometheus query
+                        fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3,
+                        exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts fail. Defaults to
+                            Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after an error.
+                            Defaults to 10s.
+                          type: string
+                      type: object
+                    failurePolicy:
+                      description: How failed successQuery results accumulate before
+                        gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3,
+                        consecutiveSuccesses=1, exceededAction=Pause.
+                      properties:
+                        consecutiveFailures:
+                          description: Number of consecutive failed evaluations required
+                            before exceededAction. Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        consecutiveSuccesses:
+                          description: Number of consecutive successful evaluations
+                            required to pass. Defaults to 1.
+                          minimum: 1
+                          type: integer
+                        exceededAction:
+                          description: Behavior when consecutiveFailures is reached.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        reevaluationInterval:
+                          description: Minimum time between evaluations that update
+                            consecutive counters. Defaults to 2m30s.
+                          type: string
+                      type: object
                     name:
                       description: Unique name of this check within the RolloutHealthCheck.
                       minLength: 1
                       type: string
-                    onFailure:
-                      description: Behavior when the success query returns failure.
-                        Defaults to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
-                    onNoData:
-                      description: Behavior when a query returns no data. Defaults
-                        to Pause.
-                      enum:
-                      - Pause
-                      - Warn
-                      - Disabled
-                      type: string
+                    noDataPolicy:
+                      description: Retry and action policy when a query returns no
+                        data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                      properties:
+                        exhaustedAction:
+                          description: Behavior when all attempts return no data.
+                            Defaults to Pause.
+                          enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                          type: string
+                        maxAttempts:
+                          description: Maximum query attempts including the first.
+                            Defaults to 3.
+                          minimum: 1
+                          type: integer
+                        retryInterval:
+                          description: Delay between query attempts after no-data.
+                            Defaults to 30s.
+                          type: string
+                      type: object
                     query:
                       description: |
-                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                       minLength: 1
-                      type: string
-                    queryRetries:
-                      description: Number of retries after the first attempt. Defaults
-                        to 3.
-                      minimum: 0
-                      type: integer
-                    queryTimeout:
-                      description: Per-query timeout. Defaults to 10s.
                       type: string
                     successQuery:
                       description: |
@@ -470,6 +519,40 @@ webhooks:
     - CREATE
     resources:
     - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: rollout-health-check-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/rollout-health-check-validation
+      port: 443
+  failurePolicy: Fail
+  name: rollout-health-check-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rollouthealthchecks
     scope: Namespaced
   sideEffects: None
 ---

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -126,6 +126,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -272,6 +272,15 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -416,6 +425,45 @@ spec:
             cpu: 100m
             memory: 100Mi
       serviceAccountName: rollout-operator
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: phased-deployment-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/phased-deployment
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: phased-deployment-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  objectSelector:
+    matchLabels:
+      grafana.com/rollout-phased: "true"
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -283,6 +283,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/operations/rollout-operator/crds/rollout-health-check.yaml
+++ b/operations/rollout-operator/crds/rollout-health-check.yaml
@@ -1,0 +1,97 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - selector
+                - prometheusURL
+                - checks
+              properties:
+                selector:
+                  type: object
+                  description: Selector preventing this policy from being attached to an unrelated workload.
+                  required:
+                    - matchLabels
+                  properties:
+                    matchLabels:
+                      type: object
+                      additionalProperties:
+                        type: string
+                prometheusURL:
+                  type: string
+                  description: Base URL of the Prometheus HTTP API used to evaluate checks.
+                  minLength: 1
+                checks:
+                  type: array
+                  description: Ordered list of PromQL health checks evaluated before progressing to the next zone.
+                  minItems: 1
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - query
+                      - successQuery
+                    properties:
+                      name:
+                        type: string
+                        description: Unique name of this check within the RolloutHealthCheck.
+                        minLength: 1
+                      currentRange:
+                        type: string
+                        description: Range vector duration substituted for ${range} when evaluating candidate pods. Defaults to 5m.
+                      baselineRange:
+                        type: string
+                        description: Range vector duration substituted for ${range} when evaluating stable pods at the pre-rollout timestamp. Defaults to 10m.
+                      queryTimeout:
+                        type: string
+                        description: Per-query timeout. Defaults to 10s.
+                      queryRetries:
+                        type: integer
+                        description: Number of retries after the first attempt. Defaults to 3.
+                        minimum: 0
+                      onFailure:
+                        type: string
+                        description: Behavior when the success query returns failure. Defaults to Pause.
+                        enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                      onNoData:
+                        type: string
+                        description: Behavior when a query returns no data. Defaults to Pause.
+                        enum:
+                          - Pause
+                          - Warn
+                          - Disabled
+                      disabled:
+                        type: boolean
+                        description: When true, this check is skipped while other checks remain active.
+                      query:
+                        type: string
+                        description: |
+                          PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                        minLength: 1
+                      successQuery:
+                        type: string
+                        description: |
+                          PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                        minLength: 1
+  scope: Namespaced
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    singular: rollouthealthcheck
+    shortNames:
+      - rhc

--- a/operations/rollout-operator/crds/rollout-health-check.yaml
+++ b/operations/rollout-operator/crds/rollout-health-check.yaml
@@ -54,34 +54,71 @@ spec:
                       baselineRange:
                         type: string
                         description: Range vector duration substituted for ${range} when evaluating stable pods at the pre-rollout timestamp. Defaults to 10m.
-                      queryTimeout:
-                        type: string
-                        description: Per-query timeout. Defaults to 10s.
-                      queryRetries:
-                        type: integer
-                        description: Number of retries after the first attempt. Defaults to 3.
-                        minimum: 0
-                      onFailure:
-                        type: string
-                        description: Behavior when the success query returns failure. Defaults to Pause.
-                        enum:
-                          - Pause
-                          - Warn
-                          - Disabled
-                      onNoData:
-                        type: string
-                        description: Behavior when a query returns no data. Defaults to Pause.
-                        enum:
-                          - Pause
-                          - Warn
-                          - Disabled
+                      errorPolicy:
+                        type: object
+                        description: Retry and action policy when a Prometheus query fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3, exhaustedAction=Pause.
+                        properties:
+                          retryInterval:
+                            type: string
+                            description: Delay between query attempts after an error. Defaults to 10s.
+                          maxAttempts:
+                            type: integer
+                            description: Maximum query attempts including the first. Defaults to 3.
+                            minimum: 1
+                          exhaustedAction:
+                            type: string
+                            description: Behavior when all attempts fail. Defaults to Pause.
+                            enum:
+                              - Pause
+                              - Warn
+                              - Disabled
+                      failurePolicy:
+                        type: object
+                        description: How failed successQuery results accumulate before gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3, consecutiveSuccesses=1, exceededAction=Pause.
+                        properties:
+                          reevaluationInterval:
+                            type: string
+                            description: Minimum time between evaluations that update consecutive counters. Defaults to 2m30s.
+                          consecutiveFailures:
+                            type: integer
+                            description: Number of consecutive failed evaluations required before exceededAction. Defaults to 3.
+                            minimum: 1
+                          consecutiveSuccesses:
+                            type: integer
+                            description: Number of consecutive successful evaluations required to pass. Defaults to 1.
+                            minimum: 1
+                          exceededAction:
+                            type: string
+                            description: Behavior when consecutiveFailures is reached. Defaults to Pause.
+                            enum:
+                              - Pause
+                              - Warn
+                              - Disabled
+                      noDataPolicy:
+                        type: object
+                        description: Retry and action policy when a query returns no data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                        properties:
+                          retryInterval:
+                            type: string
+                            description: Delay between query attempts after no-data. Defaults to 30s.
+                          maxAttempts:
+                            type: integer
+                            description: Maximum query attempts including the first. Defaults to 3.
+                            minimum: 1
+                          exhaustedAction:
+                            type: string
+                            description: Behavior when all attempts return no data. Defaults to Pause.
+                            enum:
+                              - Pause
+                              - Warn
+                              - Disabled
                       disabled:
                         type: boolean
                         description: When true, this check is skipped while other checks remain active.
                       query:
                         type: string
                         description: |
-                          PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} and ${range}.
+                          PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
                         minLength: 1
                       successQuery:
                         type: string

--- a/operations/rollout-operator/rollout-operator.libsonnet
+++ b/operations/rollout-operator/rollout-operator.libsonnet
@@ -50,6 +50,7 @@
     // block other operations that would block the service creation.
     ignore_rollout_operator_no_downscale_webhook_failures: false,
     ignore_rollout_operator_prepare_downscale_webhook_failures: false,
+    ignore_rollout_operator_phased_deployment_webhook_failures: false,
     ignore_rollout_operator_zpdb_eviction_webhook_failures: false,
     ignore_rollout_operator_zpdb_validation_webhook_failures: false,
   },
@@ -59,6 +60,7 @@
   assert !$._config.rollout_operator_webhooks_enabled || $._config.rollout_operator_enabled : 'rollout_operator_webhooks_enabled requires rollout_operator_enabled=true',
   assert !$._config.ignore_rollout_operator_no_downscale_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_no_downscale_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.ignore_rollout_operator_prepare_downscale_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_prepare_downscale_webhook_failures requires rollout_operator_webhooks_enabled=true',
+  assert !$._config.ignore_rollout_operator_phased_deployment_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_phased_deployment_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.ignore_rollout_operator_zpdb_eviction_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_zpdb_eviction_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.ignore_rollout_operator_zpdb_validation_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_zpdb_validation_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.replica_template_custom_resource_definition_enabled || $._config.rollout_operator_webhooks_enabled : 'replica_template_custom_resource_definition_enabled requires rollout_operator_webhooks_enabled=true',
@@ -131,6 +133,9 @@
         policyRule.withApiGroups('apps') +
         policyRule.withResources(['statefulsets/status']) +
         policyRule.withVerbs(['update']),
+        policyRule.withApiGroups('apps') +
+        policyRule.withResources(['deployments']) +
+        policyRule.withVerbs(['list', 'get', 'watch', 'patch']),
         policyRule.withApiGroups('') +
         policyRule.withResources(['configmaps']) +
         policyRule.withVerbs(['get', 'update', 'create']),
@@ -352,6 +357,50 @@
             name: 'rollout-operator',
             namespace: $._config.namespace,
             path: '/admission/prepare-downscale',
+            port: 443,
+          },
+        },
+      },
+    ]),
+
+  phased_deployment_webhook: if !enableWebhooks then null else
+    mutatingWebhookConfiguration.new('phased-deployment-%s' % $._config.namespace) +
+    mutatingWebhookConfiguration.mixin.metadata.withLabels({
+      'grafana.com/namespace': $._config.namespace,
+      'grafana.com/inject-rollout-operator-ca': 'true',
+    }) +
+    mutatingWebhookConfiguration.withWebhooksMixin([
+      mutatingWebhook.withName('phased-deployment-%s.grafana.com' % $._config.namespace)
+      + mutatingWebhook.withAdmissionReviewVersions(['v1'])
+      + mutatingWebhook.withFailurePolicy(if $._config.ignore_rollout_operator_phased_deployment_webhook_failures then 'Ignore' else 'Fail')
+      + mutatingWebhook.withMatchPolicy('Equivalent')
+      + mutatingWebhook.withSideEffects('NoneOnDryRun')
+      + mutatingWebhook.withTimeoutSeconds(10)
+      + mutatingWebhook.withRulesMixin([
+        {
+          apiGroups: ['apps'],
+          apiVersions: ['v1'],
+          operations: ['CREATE', 'UPDATE'],
+          resources: ['deployments'],
+          scope: 'Namespaced',
+        },
+      ])
+      + {
+        namespaceSelector: {
+          matchLabels: {
+            'kubernetes.io/metadata.name': $._config.namespace,
+          },
+        },
+        objectSelector: {
+          matchLabels: {
+            'grafana.com/rollout-phased': 'true',
+          },
+        },
+        clientConfig: {
+          service: {
+            name: 'rollout-operator',
+            namespace: $._config.namespace,
+            path: '/admission/phased-deployment',
             port: 443,
           },
         },

--- a/operations/rollout-operator/rollout-operator.libsonnet
+++ b/operations/rollout-operator/rollout-operator.libsonnet
@@ -38,6 +38,10 @@
     // Include the custom resource definiton for the zpdb.
     zpdb_custom_resource_definition_enabled: $._config.rollout_operator_webhooks_enabled,
 
+    // Include the custom resource definition for RolloutHealthCheck.
+    // Enabled whenever the operator is enabled; health checks are evaluated by the controller, not webhooks.
+    rollout_health_check_custom_resource_definition_enabled: $._config.rollout_operator_enabled,
+
     // Configure the rollout operator to enable support for ReplicaTemplates
     rollout_operator_replica_template_access_enabled: false,
 
@@ -67,6 +71,9 @@
 
   zpdb_template:: std.parseYaml(importstr 'crds/zone-aware-pod-disruption-budget.yaml'),
   zpdb_custom_resource: if !$._config.zpdb_custom_resource_definition_enabled then null else $.zpdb_template,
+
+  rollout_health_check_template:: std.parseYaml(importstr 'crds/rollout-health-check.yaml'),
+  rollout_health_check_custom_resource: if !$._config.rollout_health_check_custom_resource_definition_enabled then null else $.rollout_health_check_template,
 
   replica_template:: std.parseYaml(importstr 'crds/replica-templates.yaml'),
   replica_template_custom_resource: if !$._config.replica_template_custom_resource_definition_enabled then null else $.replica_template,
@@ -134,6 +141,9 @@
         policyRule.withApiGroups('') +
         policyRule.withResources(['configmaps']) +
         policyRule.withVerbs(['get', 'update', 'create']),
+        policyRule.withApiGroups('') +
+        policyRule.withResources(['events']) +
+        policyRule.withVerbs(['create', 'patch']),
       ] +
       (
         if $._config.rollout_operator_replica_template_access_enabled then [
@@ -145,6 +155,9 @@
       [
         policyRule.withApiGroups($.zpdb_template.spec.group) +
         policyRule.withResources([$.zpdb_template.spec.names.plural]) +
+        policyRule.withVerbs(['get', 'list', 'watch']),
+        policyRule.withApiGroups($.rollout_health_check_template.spec.group) +
+        policyRule.withResources([$.rollout_health_check_template.spec.names.plural]) +
         policyRule.withVerbs(['get', 'list', 'watch']),
       ]
 

--- a/operations/rollout-operator/rollout-operator.libsonnet
+++ b/operations/rollout-operator/rollout-operator.libsonnet
@@ -137,6 +137,9 @@
         policyRule.withResources(['deployments']) +
         policyRule.withVerbs(['list', 'get', 'watch', 'patch']),
         policyRule.withApiGroups('') +
+        policyRule.withResources(['events']) +
+        policyRule.withVerbs(['create']),
+        policyRule.withApiGroups('') +
         policyRule.withResources(['configmaps']) +
         policyRule.withVerbs(['get', 'update', 'create']),
       ] +

--- a/operations/rollout-operator/rollout-operator.libsonnet
+++ b/operations/rollout-operator/rollout-operator.libsonnet
@@ -55,6 +55,7 @@
     // block other operations that would block the service creation.
     ignore_rollout_operator_no_downscale_webhook_failures: false,
     ignore_rollout_operator_prepare_downscale_webhook_failures: false,
+    ignore_rollout_operator_phased_deployment_webhook_failures: false,
     ignore_rollout_operator_zpdb_eviction_webhook_failures: false,
     ignore_rollout_operator_zpdb_validation_webhook_failures: false,
     ignore_rollout_operator_rollout_health_check_validation_webhook_failures: false,
@@ -65,6 +66,7 @@
   assert !$._config.rollout_operator_webhooks_enabled || $._config.rollout_operator_enabled : 'rollout_operator_webhooks_enabled requires rollout_operator_enabled=true',
   assert !$._config.ignore_rollout_operator_no_downscale_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_no_downscale_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.ignore_rollout_operator_prepare_downscale_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_prepare_downscale_webhook_failures requires rollout_operator_webhooks_enabled=true',
+  assert !$._config.ignore_rollout_operator_phased_deployment_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_phased_deployment_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.ignore_rollout_operator_zpdb_eviction_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_zpdb_eviction_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.ignore_rollout_operator_zpdb_validation_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_zpdb_validation_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.ignore_rollout_operator_rollout_health_check_validation_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_rollout_health_check_validation_webhook_failures requires rollout_operator_webhooks_enabled=true',
@@ -141,6 +143,9 @@
         policyRule.withApiGroups('apps') +
         policyRule.withResources(['statefulsets/status']) +
         policyRule.withVerbs(['update']),
+        policyRule.withApiGroups('apps') +
+        policyRule.withResources(['deployments']) +
+        policyRule.withVerbs(['list', 'get', 'watch', 'patch']),
         policyRule.withApiGroups('') +
         policyRule.withResources(['configmaps']) +
         policyRule.withVerbs(['get', 'update', 'create']),
@@ -405,6 +410,50 @@
             name: 'rollout-operator',
             namespace: $._config.namespace,
             path: '/admission/prepare-downscale',
+            port: 443,
+          },
+        },
+      },
+    ]),
+
+  phased_deployment_webhook: if !enableWebhooks then null else
+    mutatingWebhookConfiguration.new('phased-deployment-%s' % $._config.namespace) +
+    mutatingWebhookConfiguration.mixin.metadata.withLabels({
+      'grafana.com/namespace': $._config.namespace,
+      'grafana.com/inject-rollout-operator-ca': 'true',
+    }) +
+    mutatingWebhookConfiguration.withWebhooksMixin([
+      mutatingWebhook.withName('phased-deployment-%s.grafana.com' % $._config.namespace)
+      + mutatingWebhook.withAdmissionReviewVersions(['v1'])
+      + mutatingWebhook.withFailurePolicy(if $._config.ignore_rollout_operator_phased_deployment_webhook_failures then 'Ignore' else 'Fail')
+      + mutatingWebhook.withMatchPolicy('Equivalent')
+      + mutatingWebhook.withSideEffects('NoneOnDryRun')
+      + mutatingWebhook.withTimeoutSeconds(10)
+      + mutatingWebhook.withRulesMixin([
+        {
+          apiGroups: ['apps'],
+          apiVersions: ['v1'],
+          operations: ['CREATE', 'UPDATE'],
+          resources: ['deployments'],
+          scope: 'Namespaced',
+        },
+      ])
+      + {
+        namespaceSelector: {
+          matchLabels: {
+            'kubernetes.io/metadata.name': $._config.namespace,
+          },
+        },
+        objectSelector: {
+          matchLabels: {
+            'grafana.com/rollout-phased': 'true',
+          },
+        },
+        clientConfig: {
+          service: {
+            name: 'rollout-operator',
+            namespace: $._config.namespace,
+            path: '/admission/phased-deployment',
             port: 443,
           },
         },

--- a/operations/rollout-operator/rollout-operator.libsonnet
+++ b/operations/rollout-operator/rollout-operator.libsonnet
@@ -39,7 +39,8 @@
     zpdb_custom_resource_definition_enabled: $._config.rollout_operator_webhooks_enabled,
 
     // Include the custom resource definition for RolloutHealthCheck.
-    // Enabled whenever the operator is enabled; health checks are evaluated by the controller, not webhooks.
+    // Enabled whenever the operator is enabled; health checks are evaluated by the controller.
+    // When webhooks are enabled, CREATE/UPDATE are also validated by admission.
     rollout_health_check_custom_resource_definition_enabled: $._config.rollout_operator_enabled,
 
     // Configure the rollout operator to enable support for ReplicaTemplates
@@ -56,6 +57,7 @@
     ignore_rollout_operator_prepare_downscale_webhook_failures: false,
     ignore_rollout_operator_zpdb_eviction_webhook_failures: false,
     ignore_rollout_operator_zpdb_validation_webhook_failures: false,
+    ignore_rollout_operator_rollout_health_check_validation_webhook_failures: false,
   },
 
   assert !$._config.rollout_operator_replica_template_access_enabled || $._config.rollout_operator_webhooks_enabled : 'rollout_operator_replica_template_access_enabled requires rollout_operator_webhooks_enabled=true',
@@ -65,6 +67,7 @@
   assert !$._config.ignore_rollout_operator_prepare_downscale_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_prepare_downscale_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.ignore_rollout_operator_zpdb_eviction_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_zpdb_eviction_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.ignore_rollout_operator_zpdb_validation_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_zpdb_validation_webhook_failures requires rollout_operator_webhooks_enabled=true',
+  assert !$._config.ignore_rollout_operator_rollout_health_check_validation_webhook_failures || $._config.rollout_operator_webhooks_enabled : 'ignore_rollout_operator_rollout_health_check_validation_webhook_failures requires rollout_operator_webhooks_enabled=true',
   assert !$._config.replica_template_custom_resource_definition_enabled || $._config.rollout_operator_webhooks_enabled : 'replica_template_custom_resource_definition_enabled requires rollout_operator_webhooks_enabled=true',
 
   local enableWebhooks = $._config.rollout_operator_replica_template_access_enabled || $._config.rollout_operator_webhooks_enabled,
@@ -250,6 +253,43 @@
             name: 'rollout-operator',
             namespace: $._config.namespace,
             path: '/admission/zpdb-validation',
+            port: 443,
+          },
+        },
+      },
+    ]),
+
+  rollout_health_check_validation_webhook: if !enableWebhooks then null else
+    validatingWebhookConfiguration.new('rollout-health-check-validation-%s' % $._config.namespace) +
+    validatingWebhookConfiguration.mixin.metadata.withLabels({
+      'grafana.com/namespace': $._config.namespace,
+      'grafana.com/inject-rollout-operator-ca': 'true',
+    }) +
+    validatingWebhookConfiguration.withWebhooksMixin([
+      validatingWebhook.withName('rollout-health-check-validation-%s.grafana.com' % $._config.namespace)
+      + validatingWebhook.withAdmissionReviewVersions(['v1'])
+      + validatingWebhook.withFailurePolicy(if $._config.ignore_rollout_operator_rollout_health_check_validation_webhook_failures then 'Ignore' else 'Fail')
+      + validatingWebhook.withSideEffects('None')
+      + validatingWebhook.withRulesMixin([
+        {
+          apiGroups: ['rollout-operator.grafana.com'],
+          apiVersions: ['v1'],
+          operations: ['CREATE', 'UPDATE'],
+          resources: ['rollouthealthchecks'],
+          scope: 'Namespaced',
+        },
+      ])
+      + {
+        namespaceSelector: {
+          matchLabels: {
+            'kubernetes.io/metadata.name': $._config.namespace,
+          },
+        },
+        clientConfig: {
+          service: {
+            name: 'rollout-operator',
+            namespace: $._config.namespace,
+            path: '/admission/rollout-health-check-validation',
             port: 443,
           },
         },

--- a/operations/rollout-operator/rollout-operator.libsonnet
+++ b/operations/rollout-operator/rollout-operator.libsonnet
@@ -147,6 +147,9 @@
         policyRule.withResources(['deployments']) +
         policyRule.withVerbs(['list', 'get', 'watch', 'patch']),
         policyRule.withApiGroups('') +
+        policyRule.withResources(['events']) +
+        policyRule.withVerbs(['create']),
+        policyRule.withApiGroups('') +
         policyRule.withResources(['configmaps']) +
         policyRule.withVerbs(['get', 'update', 'create']),
         policyRule.withApiGroups('') +

--- a/pkg/admission/phased_deployment.go
+++ b/pkg/admission/phased_deployment.go
@@ -1,0 +1,253 @@
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/spanlogger"
+	v1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/phased"
+)
+
+const (
+	PhasedDeploymentWebhookPath = "/admission/phased-deployment"
+)
+
+type jsonPatchOp struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+// PhasedDeployment is a mutating webhook that pauses opted-in dependent Deployments
+// when their shared rollout revision changes, and re-applies pause while the gate is active.
+func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, _ *kubernetes.Clientset) *v1.AdmissionResponse {
+	logger, ctx := spanlogger.New(ctx, l, "admission.PhasedDeployment()", tenantResolver)
+	defer logger.Finish()
+	_ = ctx
+
+	if ar.Request == nil {
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	logger.SetSpanAndLogTag("object.name", ar.Request.Name)
+	logger.SetSpanAndLogTag("object.namespace", ar.Request.Namespace)
+	logger.SetSpanAndLogTag("object.operation", string(ar.Request.Operation))
+
+	if ar.Request.Kind.Kind != "Deployment" {
+		return allowWarn(logger, fmt.Sprintf("unsupported kind %s, allowing", ar.Request.Kind.Kind))
+	}
+
+	obj, _, err := codecs.UniversalDeserializer().Decode(ar.Request.Object.Raw, nil, nil)
+	if err != nil {
+		return allowErr(logger, "can't decode object, allowing the change", err)
+	}
+	dep, ok := obj.(*appsv1.Deployment)
+	if !ok {
+		return allowWarn(logger, fmt.Sprintf("unexpected type %T, allowing", obj))
+	}
+
+	if !phased.IsOptedIn(dep) {
+		level.Debug(logger).Log("msg", "deployment not opted into phased rollouts, allowing")
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	dependsOn := phased.DependsOn(dep)
+	if dependsOn == "" {
+		// Upstream / first Deployment in a chain: clear leftover gate state if present.
+		if patch := clearGateStatePatch(dep); patch != nil {
+			level.Info(logger).Log("msg", "clearing leftover phased gate state from non-dependent deployment")
+			return mutate(patch)
+		}
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	revision := phased.Revision(dep)
+	if revision == "" {
+		level.Warn(logger).Log("msg", "phased deployment missing rollout revision, allowing without gate")
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	// Gate already completed for this revision: allow (including unpause).
+	if phased.Phase(dep) == config.RolloutDependencyPhaseComplete && phased.DependencyRevision(dep) == revision {
+		level.Debug(logger).Log("msg", "phased gate complete for revision, allowing", "revision", revision)
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	var oldDep *appsv1.Deployment
+	if len(ar.Request.OldObject.Raw) > 0 {
+		oldObj, _, err := codecs.UniversalDeserializer().Decode(ar.Request.OldObject.Raw, nil, nil)
+		if err == nil {
+			oldDep, _ = oldObj.(*appsv1.Deployment)
+		}
+	}
+
+	patch, err := buildGatePatch(dep, oldDep, revision)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to build phased gate patch", "err", err)
+		return &v1.AdmissionResponse{
+			Allowed: false,
+			Result:  &metav1.Status{Message: err.Error()},
+		}
+	}
+	if patch == nil {
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	level.Info(logger).Log(
+		"msg", "pausing deployment for phased rollout gate",
+		"depends_on", dependsOn,
+		"revision", revision,
+		"phase", phased.Phase(dep),
+	)
+	return mutate(patch)
+}
+
+func mutate(patch []byte) *v1.AdmissionResponse {
+	pt := v1.PatchTypeJSONPatch
+	return &v1.AdmissionResponse{
+		Allowed:   true,
+		Patch:     patch,
+		PatchType: &pt,
+	}
+}
+
+func buildGatePatch(dep, oldDep *appsv1.Deployment, revision string) ([]byte, error) {
+	ops := []jsonPatchOp{}
+
+	if dep.Annotations == nil {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/metadata/annotations", Value: map[string]string{}})
+	}
+
+	needsNewGate := phased.NeedsNewGate(dep)
+	hadPaused := resolveHadPaused(dep, oldDep, needsNewGate)
+
+	if !dep.Spec.Paused {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+	}
+
+	setAnn := func(key, value string) {
+		cur := ""
+		if dep.Annotations != nil {
+			cur = dep.Annotations[key]
+		}
+		if cur == value {
+			return
+		}
+		ops = append(ops, jsonPatchOp{Op: "add", Path: phased.AnnotationJSONPointer(key), Value: value})
+	}
+
+	if needsNewGate {
+		setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseWaiting)
+		setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
+		setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for upstream deployment")
+		setAnn(config.RolloutHadPausedAnnotationKey, hadPaused)
+		if dep.Annotations != nil && dep.Annotations[config.RolloutSoakStartedAtAnnotationKey] != "" {
+			ops = append(ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(config.RolloutSoakStartedAtAnnotationKey)})
+		}
+		if dep.Annotations != nil && dep.Annotations[config.RolloutRestartBaselineAnnotationKey] != "" {
+			ops = append(ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(config.RolloutRestartBaselineAnnotationKey)})
+		}
+	} else {
+		setAnn(config.RolloutHadPausedAnnotationKey, hadPaused)
+		if phased.Phase(dep) == "" {
+			setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseWaiting)
+			setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
+			setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for upstream deployment")
+		}
+	}
+
+	if len(ops) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(ops)
+}
+
+func resolveHadPaused(dep, oldDep *appsv1.Deployment, needsNewGate bool) string {
+	if !needsNewGate {
+		if dep.Annotations != nil && dep.Annotations[config.RolloutHadPausedAnnotationKey] != "" {
+			return dep.Annotations[config.RolloutHadPausedAnnotationKey]
+		}
+		if oldDep != nil && oldDep.Annotations != nil && oldDep.Annotations[config.RolloutHadPausedAnnotationKey] != "" {
+			return oldDep.Annotations[config.RolloutHadPausedAnnotationKey]
+		}
+		return phased.HadPausedAnnotationFalse
+	}
+
+	// New gate: preserve prior user pause intent across revision changes.
+	if oldDep != nil {
+		if wasPausedByOurGate(oldDep) && oldDep.Annotations != nil && oldDep.Annotations[config.RolloutHadPausedAnnotationKey] != "" {
+			return oldDep.Annotations[config.RolloutHadPausedAnnotationKey]
+		}
+		if oldDep.Spec.Paused && !wasPausedByOurGate(oldDep) {
+			return phased.HadPausedAnnotationTrue
+		}
+		return phased.HadPausedAnnotationFalse
+	}
+	if dep.Spec.Paused {
+		return phased.HadPausedAnnotationTrue
+	}
+	return phased.HadPausedAnnotationFalse
+}
+
+func wasPausedByOurGate(d *appsv1.Deployment) bool {
+	if d == nil || !d.Spec.Paused {
+		return false
+	}
+	return phased.GateActive(d)
+}
+
+func clearGateStatePatch(dep *appsv1.Deployment) []byte {
+	if dep.Annotations == nil {
+		return nil
+	}
+	keys := []string{
+		config.RolloutDependencyPhaseAnnotationKey,
+		config.RolloutDependencyRevisionAnnotationKey,
+		config.RolloutDependencyReasonAnnotationKey,
+		config.RolloutSoakStartedAtAnnotationKey,
+		config.RolloutRestartBaselineAnnotationKey,
+		config.RolloutHadPausedAnnotationKey,
+		config.RolloutResumeAnnotationKey,
+	}
+	hasGateState := false
+	for _, key := range keys {
+		if dep.Annotations[key] != "" {
+			hasGateState = true
+			break
+		}
+	}
+	if !hasGateState {
+		return nil
+	}
+
+	ops := []jsonPatchOp{}
+	hadPaused := dep.Annotations[config.RolloutHadPausedAnnotationKey] == phased.HadPausedAnnotationTrue
+	phase := dep.Annotations[config.RolloutDependencyPhaseAnnotationKey]
+	gateWasActive := phase != "" && phase != config.RolloutDependencyPhaseComplete
+	for _, key := range keys {
+		if dep.Annotations[key] != "" {
+			ops = append(ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(key)})
+		}
+	}
+	// Only unpause when releasing an active gate that we owned.
+	if gateWasActive && dep.Spec.Paused && !hadPaused {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: false})
+	}
+	if len(ops) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(ops)
+	if err != nil {
+		return nil
+	}
+	return b
+}

--- a/pkg/admission/phased_deployment.go
+++ b/pkg/admission/phased_deployment.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -27,8 +29,9 @@ type jsonPatchOp struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
-// PhasedDeployment is a mutating webhook that pauses opted-in dependent Deployments
-// when their shared rollout revision changes, and re-applies pause while the gate is active.
+// PhasedDeployment is a mutating webhook that pauses opted-in Deployments with canary
+// dependencies when their shared rollout revision changes, and re-applies pause while
+// the gate is active. A time-limited bypass annotation skips gating.
 func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, _ *kubernetes.Clientset) *v1.AdmissionResponse {
 	logger, ctx := spanlogger.New(ctx, l, "admission.PhasedDeployment()", tenantResolver)
 	defer logger.Finish()
@@ -60,11 +63,21 @@ func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 		return &v1.AdmissionResponse{Allowed: true}
 	}
 
-	dependsOn := phased.DependsOn(dep)
-	if dependsOn == "" {
-		// Upstream / first Deployment in a chain: clear leftover gate state if present.
+	canaries := phased.Canaries(dep)
+	if len(canaries) == 0 {
+		// Canary / first Deployment in a chain: clear leftover gate state if present.
 		if patch := clearGateStatePatch(dep); patch != nil {
-			level.Info(logger).Log("msg", "clearing leftover phased gate state from non-dependent deployment")
+			level.Info(logger).Log("msg", "clearing leftover phased gate state from canary deployment")
+			return mutate(patch)
+		}
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	if _, ok, err := phased.BypassUntil(dep); err != nil {
+		level.Warn(logger).Log("msg", "invalid rollout-bypass-until, ignoring", "err", err)
+	} else if ok && phased.BypassActive(dep, time.Now()) {
+		level.Info(logger).Log("msg", "phased rollout bypass active, allowing without gate")
+		if patch := bypassReleasePatch(dep); patch != nil {
 			return mutate(patch)
 		}
 		return &v1.AdmissionResponse{Allowed: true}
@@ -104,7 +117,7 @@ func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 
 	level.Info(logger).Log(
 		"msg", "pausing deployment for phased rollout gate",
-		"depends_on", dependsOn,
+		"canaries", fmt.Sprintf("%v", canaries),
 		"revision", revision,
 		"phase", phased.Phase(dep),
 	)
@@ -148,20 +161,14 @@ func buildGatePatch(dep, oldDep *appsv1.Deployment, revision string) ([]byte, er
 	if needsNewGate {
 		setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseWaiting)
 		setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
-		setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for upstream deployment")
+		setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for canary deployment(s)")
 		setAnn(config.RolloutHadPausedAnnotationKey, hadPaused)
-		if dep.Annotations != nil && dep.Annotations[config.RolloutSoakStartedAtAnnotationKey] != "" {
-			ops = append(ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(config.RolloutSoakStartedAtAnnotationKey)})
-		}
-		if dep.Annotations != nil && dep.Annotations[config.RolloutRestartBaselineAnnotationKey] != "" {
-			ops = append(ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(config.RolloutRestartBaselineAnnotationKey)})
-		}
 	} else {
 		setAnn(config.RolloutHadPausedAnnotationKey, hadPaused)
 		if phased.Phase(dep) == "" {
 			setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseWaiting)
 			setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
-			setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for upstream deployment")
+			setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for canary deployment(s)")
 		}
 	}
 
@@ -213,10 +220,7 @@ func clearGateStatePatch(dep *appsv1.Deployment) []byte {
 		config.RolloutDependencyPhaseAnnotationKey,
 		config.RolloutDependencyRevisionAnnotationKey,
 		config.RolloutDependencyReasonAnnotationKey,
-		config.RolloutSoakStartedAtAnnotationKey,
-		config.RolloutRestartBaselineAnnotationKey,
 		config.RolloutHadPausedAnnotationKey,
-		config.RolloutResumeAnnotationKey,
 	}
 	hasGateState := false
 	for _, key := range keys {
@@ -240,6 +244,45 @@ func clearGateStatePatch(dep *appsv1.Deployment) []byte {
 	}
 	// Only unpause when releasing an active gate that we owned.
 	if gateWasActive && dep.Spec.Paused && !hadPaused {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: false})
+	}
+	if len(ops) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(ops)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// bypassReleasePatch unpauses a Deployment that is still held by an active gate when bypass is used.
+func bypassReleasePatch(dep *appsv1.Deployment) []byte {
+	if !phased.GateActive(dep) && !dep.Spec.Paused {
+		return nil
+	}
+	hadPaused := dep.Annotations != nil && dep.Annotations[config.RolloutHadPausedAnnotationKey] == phased.HadPausedAnnotationTrue
+	ops := []jsonPatchOp{}
+	if dep.Annotations == nil {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/metadata/annotations", Value: map[string]string{}})
+	}
+	revision := phased.Revision(dep)
+	setAnn := func(key, value string) {
+		cur := ""
+		if dep.Annotations != nil {
+			cur = dep.Annotations[key]
+		}
+		if cur == value {
+			return
+		}
+		ops = append(ops, jsonPatchOp{Op: "add", Path: phased.AnnotationJSONPointer(key), Value: value})
+	}
+	if revision != "" {
+		setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseComplete)
+		setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
+		setAnn(config.RolloutDependencyReasonAnnotationKey, "bypassed until "+strings.TrimSpace(dep.Annotations[config.RolloutBypassUntilAnnotationKey]))
+	}
+	if dep.Spec.Paused && !hadPaused {
 		ops = append(ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: false})
 	}
 	if len(ops) == 0 {

--- a/pkg/admission/phased_deployment.go
+++ b/pkg/admission/phased_deployment.go
@@ -197,12 +197,18 @@ func buildGatePatch(dep, oldDep *appsv1.Deployment, revision string) ([]byte, er
 		}
 		ops = append(ops, jsonPatchOp{Op: "add", Path: phased.AnnotationJSONPointer(key), Value: value})
 	}
+	removeAnn := func(key string) {
+		if dep.Annotations != nil && dep.Annotations[key] != "" {
+			ops = append(ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(key)})
+		}
+	}
 
 	if needsNewGate {
 		setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseWaiting)
 		setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
 		setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for canary deployment(s)")
 		setAnn(config.RolloutHadPausedAnnotationKey, hadPaused)
+		removeAnn(config.RolloutCanariesReadyRevisionAnnotationKey)
 	} else {
 		setAnn(config.RolloutHadPausedAnnotationKey, hadPaused)
 		if phased.Phase(dep) == "" {
@@ -261,6 +267,7 @@ func clearGateStatePatch(dep *appsv1.Deployment) []byte {
 		config.RolloutDependencyRevisionAnnotationKey,
 		config.RolloutDependencyReasonAnnotationKey,
 		config.RolloutHadPausedAnnotationKey,
+		config.RolloutCanariesReadyRevisionAnnotationKey,
 	}
 	hasGateState := false
 	for _, key := range keys {

--- a/pkg/admission/phased_deployment.go
+++ b/pkg/admission/phased_deployment.go
@@ -73,10 +73,16 @@ func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 		return &v1.AdmissionResponse{Allowed: true}
 	}
 
-	if _, ok, err := phased.BypassUntil(dep); err != nil {
+	if until, ok, err := phased.BypassUntil(dep); err != nil {
 		level.Warn(logger).Log("msg", "invalid rollout-bypass-until, ignoring", "err", err)
 	} else if ok && phased.BypassActive(dep, time.Now()) {
-		level.Info(logger).Log("msg", "phased rollout bypass active, allowing without gate")
+		level.Info(logger).Log(
+			"msg", "phased rollout bypass active, allowing without gate",
+			"revision", phased.Revision(dep),
+			"bypass_until", until.Format(time.RFC3339),
+			"gate_phase", phased.Phase(dep),
+			"paused", dep.Spec.Paused,
+		)
 		if patch := bypassReleasePatch(dep); patch != nil {
 			return mutate(patch)
 		}
@@ -91,7 +97,11 @@ func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 
 	// Gate already completed for this revision: allow (including unpause).
 	if phased.Phase(dep) == config.RolloutDependencyPhaseComplete && phased.DependencyRevision(dep) == revision {
-		level.Debug(logger).Log("msg", "phased gate complete for revision, allowing", "revision", revision)
+		level.Debug(logger).Log(
+			"msg", "phased gate complete for revision, allowing",
+			"revision", revision,
+			"paused", dep.Spec.Paused,
+		)
 		return &v1.AdmissionResponse{Allowed: true}
 	}
 
@@ -103,6 +113,20 @@ func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 		}
 	}
 
+	needsNewGate := phased.NeedsNewGate(dep)
+	if needsNewGate {
+		previousRevision := phased.DependencyRevision(dep)
+		if oldDep != nil && previousRevision == "" {
+			previousRevision = phased.Revision(oldDep)
+		}
+		level.Info(logger).Log(
+			"msg", "phased deployment revision change detected",
+			"previous_revision", previousRevision,
+			"target_revision", revision,
+			"canaries", strings.Join(canaries, ","),
+		)
+	}
+
 	patch, err := buildGatePatch(dep, oldDep, revision)
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to build phased gate patch", "err", err)
@@ -112,15 +136,31 @@ func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, 
 		}
 	}
 	if patch == nil {
+		level.Debug(logger).Log(
+			"msg", "phased deployment gate already enforced",
+			"revision", revision,
+			"phase", phased.Phase(dep),
+			"paused", dep.Spec.Paused,
+		)
 		return &v1.AdmissionResponse{Allowed: true}
 	}
 
-	level.Info(logger).Log(
-		"msg", "pausing deployment for phased rollout gate",
-		"canaries", fmt.Sprintf("%v", canaries),
-		"revision", revision,
-		"phase", phased.Phase(dep),
-	)
+	if !needsNewGate && !dep.Spec.Paused {
+		level.Warn(logger).Log(
+			"msg", "re-pausing deployment while phased rollout gate is active",
+			"canaries", strings.Join(canaries, ","),
+			"revision", revision,
+			"phase", phased.Phase(dep),
+		)
+	} else {
+		level.Info(logger).Log(
+			"msg", "pausing deployment for phased rollout gate",
+			"canaries", strings.Join(canaries, ","),
+			"revision", revision,
+			"phase", phased.Phase(dep),
+			"had_paused", resolveHadPaused(dep, oldDep, needsNewGate),
+		)
+	}
 	return mutate(patch)
 }
 

--- a/pkg/admission/phased_deployment_test.go
+++ b/pkg/admission/phased_deployment_test.go
@@ -1,0 +1,143 @@
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+func TestPhasedDeployment_PausesOnRevisionChange(t *testing.T) {
+	newDep := phasedDeployment("query-frontend-zone-b", "query-frontend-zone-a", "r2", false, "", "")
+	oldDep := phasedDeployment("query-frontend-zone-b", "query-frontend-zone-a", "r1", false, config.RolloutDependencyPhaseComplete, "r1")
+
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(oldDep, newDep), nil)
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.PatchType)
+	require.NotEmpty(t, resp.Patch)
+
+	var ops []jsonPatchOp
+	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
+	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+}
+
+func TestPhasedDeployment_RePausesWhileGateActive(t *testing.T) {
+	newDep := phasedDeployment("b", "a", "r1", false, config.RolloutDependencyPhaseSoaking, "r1")
+	oldDep := phasedDeployment("b", "a", "r1", true, config.RolloutDependencyPhaseSoaking, "r1")
+	oldDep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
+	newDep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
+
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(oldDep, newDep), nil)
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patch)
+
+	var ops []jsonPatchOp
+	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
+	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+}
+
+func TestPhasedDeployment_AllowsWhenComplete(t *testing.T) {
+	dep := phasedDeployment("b", "a", "r1", false, config.RolloutDependencyPhaseComplete, "r1")
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(dep, dep), nil)
+	require.True(t, resp.Allowed)
+	require.Nil(t, resp.Patch)
+}
+
+func TestPhasedDeployment_AllowsWithoutDependsOn(t *testing.T) {
+	dep := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "a",
+			Labels: map[string]string{config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue},
+			Annotations: map[string]string{
+				config.RolloutRevisionAnnotationKey: "r1",
+			},
+		},
+	}
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(nil, dep), nil)
+	require.True(t, resp.Allowed)
+	require.Nil(t, resp.Patch)
+}
+
+func TestPhasedDeployment_PreservesPreExistingPause(t *testing.T) {
+	oldDep := phasedDeployment("b", "a", "r1", true, "", "")
+	newDep := phasedDeployment("b", "a", "r2", true, "", "")
+
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(oldDep, newDep), nil)
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patch)
+
+	var ops []jsonPatchOp
+	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
+	found := false
+	for _, op := range ops {
+		if op.Path == "/metadata/annotations/grafana.com~1rollout-had-paused" {
+			require.Equal(t, "true", op.Value)
+			found = true
+		}
+	}
+	require.True(t, found, "expected had-paused annotation in patch")
+}
+
+func phasedDeployment(name, dependsOn, revision string, paused bool, phase, depRevision string) *appsv1.Deployment {
+	ann := map[string]string{
+		config.RolloutDependsOnAnnotationKey: dependsOn,
+		config.RolloutRevisionAnnotationKey:  revision,
+	}
+	if phase != "" {
+		ann[config.RolloutDependencyPhaseAnnotationKey] = phase
+	}
+	if depRevision != "" {
+		ann[config.RolloutDependencyRevisionAnnotationKey] = depRevision
+	}
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "default",
+			Labels:      map[string]string{config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue},
+			Annotations: ann,
+		},
+		Spec: appsv1.DeploymentSpec{Paused: paused},
+	}
+}
+
+func admissionReview(oldDep, newDep *appsv1.Deployment) admissionv1.AdmissionReview {
+	rawNew, err := json.Marshal(newDep)
+	if err != nil {
+		panic(err)
+	}
+	ar := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID:       "test",
+			Kind:      metav1.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			Resource:  metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			Name:      newDep.Name,
+			Namespace: newDep.Namespace,
+			Operation: admissionv1.Update,
+			Object:    runtime.RawExtension{Raw: rawNew},
+		},
+	}
+	if oldDep != nil {
+		rawOld, err := json.Marshal(oldDep)
+		if err != nil {
+			panic(err)
+		}
+		ar.Request.OldObject = runtime.RawExtension{Raw: rawOld}
+	}
+	return ar
+}

--- a/pkg/admission/phased_deployment_test.go
+++ b/pkg/admission/phased_deployment_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
@@ -30,8 +31,8 @@ func TestPhasedDeployment_PausesOnRevisionChange(t *testing.T) {
 }
 
 func TestPhasedDeployment_RePausesWhileGateActive(t *testing.T) {
-	newDep := phasedDeployment("b", "a", "r1", false, config.RolloutDependencyPhaseSoaking, "r1")
-	oldDep := phasedDeployment("b", "a", "r1", true, config.RolloutDependencyPhaseSoaking, "r1")
+	newDep := phasedDeployment("b", "a", "r1", false, config.RolloutDependencyPhaseWaiting, "r1")
+	oldDep := phasedDeployment("b", "a", "r1", true, config.RolloutDependencyPhaseWaiting, "r1")
 	oldDep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
 	newDep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
 
@@ -51,7 +52,7 @@ func TestPhasedDeployment_AllowsWhenComplete(t *testing.T) {
 	require.Nil(t, resp.Patch)
 }
 
-func TestPhasedDeployment_AllowsWithoutDependsOn(t *testing.T) {
+func TestPhasedDeployment_AllowsWithoutCanary(t *testing.T) {
 	dep := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -68,6 +69,20 @@ func TestPhasedDeployment_AllowsWithoutDependsOn(t *testing.T) {
 	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(nil, dep), nil)
 	require.True(t, resp.Allowed)
 	require.Nil(t, resp.Patch)
+}
+
+func TestPhasedDeployment_AllowsWhenBypassActive(t *testing.T) {
+	dep := phasedDeployment("b", "a", "r2", true, config.RolloutDependencyPhaseWaiting, "r2")
+	dep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
+	dep.Annotations[config.RolloutBypassUntilAnnotationKey] = time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(nil, dep), nil)
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patch)
+
+	var ops []jsonPatchOp
+	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
+	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: false})
 }
 
 func TestPhasedDeployment_PreservesPreExistingPause(t *testing.T) {
@@ -90,10 +105,10 @@ func TestPhasedDeployment_PreservesPreExistingPause(t *testing.T) {
 	require.True(t, found, "expected had-paused annotation in patch")
 }
 
-func phasedDeployment(name, dependsOn, revision string, paused bool, phase, depRevision string) *appsv1.Deployment {
+func phasedDeployment(name, canary, revision string, paused bool, phase, depRevision string) *appsv1.Deployment {
 	ann := map[string]string{
-		config.RolloutDependsOnAnnotationKey: dependsOn,
-		config.RolloutRevisionAnnotationKey:  revision,
+		config.RolloutCanaryAnnotationKey:   canary,
+		config.RolloutRevisionAnnotationKey: revision,
 	}
 	if phase != "" {
 		ann[config.RolloutDependencyPhaseAnnotationKey] = phase

--- a/pkg/admission/phased_deployment_test.go
+++ b/pkg/admission/phased_deployment_test.go
@@ -1,8 +1,10 @@
 package admission
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,8 +21,9 @@ import (
 func TestPhasedDeployment_PausesOnRevisionChange(t *testing.T) {
 	newDep := phasedDeployment("query-frontend-zone-b", "query-frontend-zone-a", "r2", false, "", "")
 	oldDep := phasedDeployment("query-frontend-zone-b", "query-frontend-zone-a", "r1", false, config.RolloutDependencyPhaseComplete, "r1")
+	var logs bytes.Buffer
 
-	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(oldDep, newDep), nil)
+	resp := PhasedDeployment(context.Background(), log.NewLogfmtLogger(&logs), admissionReview(oldDep, newDep), nil)
 	require.True(t, resp.Allowed)
 	require.NotNil(t, resp.PatchType)
 	require.NotEmpty(t, resp.Patch)
@@ -28,6 +31,9 @@ func TestPhasedDeployment_PausesOnRevisionChange(t *testing.T) {
 	var ops []jsonPatchOp
 	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
 	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+	require.True(t, strings.Contains(logs.String(), `msg="phased deployment revision change detected"`))
+	require.Contains(t, logs.String(), "previous_revision=r1")
+	require.Contains(t, logs.String(), "target_revision=r2")
 }
 
 func TestPhasedDeployment_RePausesWhileGateActive(t *testing.T) {
@@ -35,14 +41,17 @@ func TestPhasedDeployment_RePausesWhileGateActive(t *testing.T) {
 	oldDep := phasedDeployment("b", "a", "r1", true, config.RolloutDependencyPhaseWaiting, "r1")
 	oldDep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
 	newDep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
+	var logs bytes.Buffer
 
-	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(oldDep, newDep), nil)
+	resp := PhasedDeployment(context.Background(), log.NewLogfmtLogger(&logs), admissionReview(oldDep, newDep), nil)
 	require.True(t, resp.Allowed)
 	require.NotEmpty(t, resp.Patch)
 
 	var ops []jsonPatchOp
 	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
 	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+	require.Contains(t, logs.String(), `msg="re-pausing deployment while phased rollout gate is active"`)
+	require.Contains(t, logs.String(), "revision=r1")
 }
 
 func TestPhasedDeployment_AllowsWhenComplete(t *testing.T) {

--- a/pkg/admission/phased_deployment_test.go
+++ b/pkg/admission/phased_deployment_test.go
@@ -16,11 +16,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/phased"
 )
 
 func TestPhasedDeployment_PausesOnRevisionChange(t *testing.T) {
 	newDep := phasedDeployment("query-frontend-zone-b", "query-frontend-zone-a", "r2", false, "", "")
 	oldDep := phasedDeployment("query-frontend-zone-b", "query-frontend-zone-a", "r1", false, config.RolloutDependencyPhaseComplete, "r1")
+	newDep.Annotations[config.RolloutCanariesReadyRevisionAnnotationKey] = "r1"
+	oldDep.Annotations[config.RolloutCanariesReadyRevisionAnnotationKey] = "r1"
 	var logs bytes.Buffer
 
 	resp := PhasedDeployment(context.Background(), log.NewLogfmtLogger(&logs), admissionReview(oldDep, newDep), nil)
@@ -31,6 +34,7 @@ func TestPhasedDeployment_PausesOnRevisionChange(t *testing.T) {
 	var ops []jsonPatchOp
 	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
 	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+	require.Contains(t, ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(config.RolloutCanariesReadyRevisionAnnotationKey)})
 	require.True(t, strings.Contains(logs.String(), `msg="phased deployment revision change detected"`))
 	require.Contains(t, logs.String(), "previous_revision=r1")
 	require.Contains(t, logs.String(), "target_revision=r2")

--- a/pkg/admission/rollout_health_check_validating_webhook.go
+++ b/pkg/admission/rollout_health_check_validating_webhook.go
@@ -1,0 +1,92 @@
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/spanlogger"
+	v1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/rollout-operator/pkg/healthcheck"
+)
+
+const (
+	RolloutHealthCheckValidatorWebhookPath = "/admission/rollout-health-check-validation"
+)
+
+type rolloutHealthCheckValidatingWebhook struct {
+	ctx     context.Context
+	logger  *spanlogger.SpanLogger
+	request v1.AdmissionReview
+}
+
+func (v *rolloutHealthCheckValidatingWebhook) initLogger() {
+	v.logger.SetSpanAndLogTag("object.name", v.request.Request.Name)
+	v.logger.SetSpanAndLogTag("object.resource", v.request.Request.Resource.Resource)
+	v.logger.SetSpanAndLogTag("object.namespace", v.request.Request.Namespace)
+	v.logger.SetSpanAndLogTag("request.uid", v.request.Request.UID)
+
+	if v.request.Request.DryRun != nil {
+		v.logger.SetSpanAndLogTag("request.dry_run", v.request.Request.DryRun)
+	}
+}
+
+func (v *rolloutHealthCheckValidatingWebhook) parse() (int32, error) {
+	var obj unstructured.Unstructured
+	if err := json.Unmarshal(v.request.Request.Object.Raw, &obj); err != nil {
+		level.Info(v.logger).Log("msg", errors.New("failed to unmarshal object"), "err", err)
+		return int32(http.StatusBadRequest), err
+	}
+
+	_, err := healthcheck.ParseAndValidate(&obj)
+	if err != nil {
+		level.Info(v.logger).Log("msg", errors.New("parsing failed"), "err", err)
+		return int32(http.StatusBadRequest), err
+	}
+
+	return 0, nil
+}
+
+func (v *rolloutHealthCheckValidatingWebhook) allow() *v1.AdmissionResponse {
+	return &v1.AdmissionResponse{
+		Allowed: true,
+		UID:     v.request.Request.UID,
+	}
+}
+
+func (v *rolloutHealthCheckValidatingWebhook) deny(reason string, httpStatusCode int32) *v1.AdmissionResponse {
+	return &v1.AdmissionResponse{
+		Allowed: false,
+		UID:     v.request.Request.UID,
+		Result: &metav1.Status{
+			Message: reason,
+			Code:    httpStatusCode,
+		},
+	}
+}
+
+// RolloutHealthCheckValidatingWebhookHandler validates RolloutHealthCheck custom resources.
+func RolloutHealthCheckValidatingWebhookHandler(ctx context.Context, l log.Logger, ar v1.AdmissionReview) *v1.AdmissionResponse {
+	logger, ctx := spanlogger.New(ctx, l, "admission.RolloutHealthCheckValidatingWebhookHandler()", tenantResolver)
+	defer logger.Finish()
+
+	validator := &rolloutHealthCheckValidatingWebhook{
+		ctx:     ctx,
+		logger:  logger,
+		request: ar,
+	}
+
+	validator.initLogger()
+
+	if httpStatusCode, err := validator.parse(); err != nil {
+		return validator.deny(err.Error(), httpStatusCode)
+	}
+
+	return validator.allow()
+}

--- a/pkg/admission/rollout_health_check_validating_webhook_test.go
+++ b/pkg/admission/rollout_health_check_validating_webhook_test.go
@@ -1,0 +1,105 @@
+package admission
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestRolloutHealthCheckValidatorHandlerSuccess(t *testing.T) {
+	request := createRolloutHealthCheckAdmissionReviewValid()
+	response := RolloutHealthCheckValidatingWebhookHandler(context.Background(), log.NewNopLogger(), request)
+	require.NotNil(t, response.UID)
+	require.True(t, response.Allowed)
+}
+
+func TestRolloutHealthCheckValidatorHandlerBadConfig(t *testing.T) {
+	request := createRolloutHealthCheckAdmissionReviewInvalid()
+	response := RolloutHealthCheckValidatingWebhookHandler(context.Background(), log.NewNopLogger(), request)
+	require.NotNil(t, response.UID)
+	require.False(t, response.Allowed)
+	require.Contains(t, response.Result.Message, "prometheusURL")
+	require.Equal(t, int32(http.StatusBadRequest), response.Result.Code)
+}
+
+func TestRolloutHealthCheckValidatorHandlerParseError(t *testing.T) {
+	request := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID:    "test-request-uid",
+			Object: runtime.RawExtension{Raw: []byte(``)},
+		},
+	}
+	response := RolloutHealthCheckValidatingWebhookHandler(context.Background(), log.NewNopLogger(), request)
+	require.False(t, response.Allowed)
+	require.Equal(t, int32(http.StatusBadRequest), response.Result.Code)
+}
+
+func createRolloutHealthCheckAdmissionReviewValid() admissionv1.AdmissionReview {
+	return admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID: "test-request-uid",
+			Object: runtime.RawExtension{
+				Raw: []byte(`{
+					"apiVersion": "rollout-operator.grafana.com/v1",
+					"kind": "RolloutHealthCheck",
+					"metadata": {
+						"name": "ingester-cell-health",
+						"namespace": "test"
+					},
+					"spec": {
+						"selector": {
+							"matchLabels": {
+								"rollout-group": "ingester"
+							}
+						},
+						"prometheusURL": "http://prometheus:9090",
+						"checks": [
+							{
+								"name": "errors",
+								"query": "scalar(sum(rate(errors{${targetMatchers}}[${range}])))",
+								"successQuery": "(${current} < bool (${baseline}))"
+							}
+						]
+					}
+				}`),
+			},
+		},
+	}
+}
+
+func createRolloutHealthCheckAdmissionReviewInvalid() admissionv1.AdmissionReview {
+	return admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID: "test-request-uid",
+			Object: runtime.RawExtension{
+				Raw: []byte(`{
+					"apiVersion": "rollout-operator.grafana.com/v1",
+					"kind": "RolloutHealthCheck",
+					"metadata": {
+						"name": "ingester-cell-health",
+						"namespace": "test"
+					},
+					"spec": {
+						"selector": {
+							"matchLabels": {
+								"rollout-group": "ingester"
+							}
+						},
+						"checks": [
+							{
+								"name": "errors",
+								"query": "scalar(sum(rate(errors{${targetMatchers}}[${range}])))",
+								"successQuery": "(${current} < bool (${baseline}))"
+							}
+						]
+					}
+				}`),
+			},
+		},
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,40 +71,29 @@ const (
 	// evaluation timestamp (T0) for health checks.
 	RolloutHealthCheckStartedAtAnnotationKey = "grafana.com/rollout-health-check-started-at"
 
-	// RolloutPhasedLabelKey opts a Deployment into phased (dependency-chained) rollouts.
+	// RolloutPhasedLabelKey opts a Deployment into phased (canary-gated) rollouts.
 	RolloutPhasedLabelKey   = "grafana.com/rollout-phased"
 	RolloutPhasedLabelValue = "true"
 
-	// RolloutDependsOnAnnotationKey names the upstream Deployment that must finish and soak
-	// before this Deployment is allowed to roll.
-	RolloutDependsOnAnnotationKey = "grafana.com/rollout-depends-on"
+	// RolloutCanaryAnnotationKey names one or more canary Deployments (comma-separated) that must
+	// finish rolling before this Deployment is allowed to proceed.
+	RolloutCanaryAnnotationKey = "grafana.com/rollout-canary"
 
 	// RolloutRevisionAnnotationKey is a shared revision stamp set by Git/jsonnet. The operator
 	// only gates when this value changes, so zone-local template differences are ignored.
 	RolloutRevisionAnnotationKey = "grafana.com/rollout-revision"
 
-	// RolloutSoakDurationAnnotationKey overrides the default soak duration (Prometheus duration, e.g. "5m").
-	RolloutSoakDurationAnnotationKey = "grafana.com/rollout-soak-duration"
-
-	// RolloutRestartThresholdAnnotationKey overrides the default restart ratio threshold
-	// (e.g. "10%" or "0.1") evaluated at the end of the soak.
-	RolloutRestartThresholdAnnotationKey = "grafana.com/rollout-restart-threshold"
-
-	// RolloutResumeAnnotationKey, when set to the gated revision, bypasses a failed soak gate
-	// and immediately unpauses the Deployment.
-	RolloutResumeAnnotationKey = "grafana.com/rollout-resume"
+	// RolloutBypassUntilAnnotationKey is an RFC3339 timestamp. While now is before that time,
+	// the operator skips pausing and unpauses an already-gated Deployment.
+	RolloutBypassUntilAnnotationKey = "grafana.com/rollout-bypass-until"
 
 	// Operator-owned state annotations written by the webhook and phased Deployment controller.
 	RolloutDependencyPhaseAnnotationKey    = "grafana.com/rollout-dependency-phase"
 	RolloutDependencyRevisionAnnotationKey = "grafana.com/rollout-dependency-revision"
 	RolloutDependencyReasonAnnotationKey   = "grafana.com/rollout-dependency-reason"
-	RolloutSoakStartedAtAnnotationKey      = "grafana.com/rollout-soak-started-at"
-	RolloutRestartBaselineAnnotationKey    = "grafana.com/rollout-restart-baseline"
 	RolloutHadPausedAnnotationKey          = "grafana.com/rollout-had-paused"
 
 	// Dependency phase values.
 	RolloutDependencyPhaseWaiting  = "waiting"
-	RolloutDependencyPhaseSoaking  = "soaking"
-	RolloutDependencyPhaseBlocked  = "blocked"
 	RolloutDependencyPhaseComplete = "complete"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,4 +61,41 @@ const (
 	// StatefulSets in the same rollout group to continue rolling out.
 	RolloutPausedAnnotationKey   = "grafana.com/rollout-paused"
 	RolloutPausedAnnotationValue = "true"
+
+	// RolloutPhasedLabelKey opts a Deployment into phased (dependency-chained) rollouts.
+	RolloutPhasedLabelKey   = "grafana.com/rollout-phased"
+	RolloutPhasedLabelValue = "true"
+
+	// RolloutDependsOnAnnotationKey names the upstream Deployment that must finish and soak
+	// before this Deployment is allowed to roll.
+	RolloutDependsOnAnnotationKey = "grafana.com/rollout-depends-on"
+
+	// RolloutRevisionAnnotationKey is a shared revision stamp set by Git/jsonnet. The operator
+	// only gates when this value changes, so zone-local template differences are ignored.
+	RolloutRevisionAnnotationKey = "grafana.com/rollout-revision"
+
+	// RolloutSoakDurationAnnotationKey overrides the default soak duration (Prometheus duration, e.g. "5m").
+	RolloutSoakDurationAnnotationKey = "grafana.com/rollout-soak-duration"
+
+	// RolloutRestartThresholdAnnotationKey overrides the default restart ratio threshold
+	// (e.g. "10%" or "0.1") evaluated at the end of the soak.
+	RolloutRestartThresholdAnnotationKey = "grafana.com/rollout-restart-threshold"
+
+	// RolloutResumeAnnotationKey, when set to the gated revision, bypasses a failed soak gate
+	// and immediately unpauses the Deployment.
+	RolloutResumeAnnotationKey = "grafana.com/rollout-resume"
+
+	// Operator-owned state annotations written by the webhook and phased Deployment controller.
+	RolloutDependencyPhaseAnnotationKey    = "grafana.com/rollout-dependency-phase"
+	RolloutDependencyRevisionAnnotationKey = "grafana.com/rollout-dependency-revision"
+	RolloutDependencyReasonAnnotationKey   = "grafana.com/rollout-dependency-reason"
+	RolloutSoakStartedAtAnnotationKey      = "grafana.com/rollout-soak-started-at"
+	RolloutRestartBaselineAnnotationKey    = "grafana.com/rollout-restart-baseline"
+	RolloutHadPausedAnnotationKey          = "grafana.com/rollout-had-paused"
+
+	// Dependency phase values.
+	RolloutDependencyPhaseWaiting  = "waiting"
+	RolloutDependencyPhaseSoaking  = "soaking"
+	RolloutDependencyPhaseBlocked  = "blocked"
+	RolloutDependencyPhaseComplete = "complete"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -70,4 +70,41 @@ const (
 	// the operator first observed pods needing an update for that revision. Used as the baseline
 	// evaluation timestamp (T0) for health checks.
 	RolloutHealthCheckStartedAtAnnotationKey = "grafana.com/rollout-health-check-started-at"
+
+	// RolloutPhasedLabelKey opts a Deployment into phased (dependency-chained) rollouts.
+	RolloutPhasedLabelKey   = "grafana.com/rollout-phased"
+	RolloutPhasedLabelValue = "true"
+
+	// RolloutDependsOnAnnotationKey names the upstream Deployment that must finish and soak
+	// before this Deployment is allowed to roll.
+	RolloutDependsOnAnnotationKey = "grafana.com/rollout-depends-on"
+
+	// RolloutRevisionAnnotationKey is a shared revision stamp set by Git/jsonnet. The operator
+	// only gates when this value changes, so zone-local template differences are ignored.
+	RolloutRevisionAnnotationKey = "grafana.com/rollout-revision"
+
+	// RolloutSoakDurationAnnotationKey overrides the default soak duration (Prometheus duration, e.g. "5m").
+	RolloutSoakDurationAnnotationKey = "grafana.com/rollout-soak-duration"
+
+	// RolloutRestartThresholdAnnotationKey overrides the default restart ratio threshold
+	// (e.g. "10%" or "0.1") evaluated at the end of the soak.
+	RolloutRestartThresholdAnnotationKey = "grafana.com/rollout-restart-threshold"
+
+	// RolloutResumeAnnotationKey, when set to the gated revision, bypasses a failed soak gate
+	// and immediately unpauses the Deployment.
+	RolloutResumeAnnotationKey = "grafana.com/rollout-resume"
+
+	// Operator-owned state annotations written by the webhook and phased Deployment controller.
+	RolloutDependencyPhaseAnnotationKey    = "grafana.com/rollout-dependency-phase"
+	RolloutDependencyRevisionAnnotationKey = "grafana.com/rollout-dependency-revision"
+	RolloutDependencyReasonAnnotationKey   = "grafana.com/rollout-dependency-reason"
+	RolloutSoakStartedAtAnnotationKey      = "grafana.com/rollout-soak-started-at"
+	RolloutRestartBaselineAnnotationKey    = "grafana.com/rollout-restart-baseline"
+	RolloutHadPausedAnnotationKey          = "grafana.com/rollout-had-paused"
+
+	// Dependency phase values.
+	RolloutDependencyPhaseWaiting  = "waiting"
+	RolloutDependencyPhaseSoaking  = "soaking"
+	RolloutDependencyPhaseBlocked  = "blocked"
+	RolloutDependencyPhaseComplete = "complete"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,10 +79,11 @@ const (
 	RolloutBypassUntilAnnotationKey = "grafana.com/rollout-bypass-until"
 
 	// Operator-owned state annotations written by the webhook and phased Deployment controller.
-	RolloutDependencyPhaseAnnotationKey    = "grafana.com/rollout-dependency-phase"
-	RolloutDependencyRevisionAnnotationKey = "grafana.com/rollout-dependency-revision"
-	RolloutDependencyReasonAnnotationKey   = "grafana.com/rollout-dependency-reason"
-	RolloutHadPausedAnnotationKey          = "grafana.com/rollout-had-paused"
+	RolloutDependencyPhaseAnnotationKey       = "grafana.com/rollout-dependency-phase"
+	RolloutDependencyRevisionAnnotationKey    = "grafana.com/rollout-dependency-revision"
+	RolloutDependencyReasonAnnotationKey      = "grafana.com/rollout-dependency-reason"
+	RolloutHadPausedAnnotationKey             = "grafana.com/rollout-had-paused"
+	RolloutCanariesReadyRevisionAnnotationKey = "grafana.com/rollout-canaries-ready-revision"
 
 	// Dependency phase values.
 	RolloutDependencyPhaseWaiting  = "waiting"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,4 +61,13 @@ const (
 	// StatefulSets in the same rollout group to continue rolling out.
 	RolloutPausedAnnotationKey   = "grafana.com/rollout-paused"
 	RolloutPausedAnnotationValue = "true"
+
+	// RolloutHealthCheckAnnotationKey references a namespaced RolloutHealthCheck CR used to gate
+	// progression between zones after the first zone has rolled.
+	RolloutHealthCheckAnnotationKey = "grafana.com/rollout-health-check"
+
+	// RolloutHealthCheckStartedAtAnnotationKey stores "<updateRevision>=<RFC3339>" marking when
+	// the operator first observed pods needing an update for that revision. Used as the baseline
+	// evaluation timestamp (T0) for health checks.
+	RolloutHealthCheckStartedAtAnnotationKey = "grafana.com/rollout-health-check-started-at"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,40 +62,29 @@ const (
 	RolloutPausedAnnotationKey   = "grafana.com/rollout-paused"
 	RolloutPausedAnnotationValue = "true"
 
-	// RolloutPhasedLabelKey opts a Deployment into phased (dependency-chained) rollouts.
+	// RolloutPhasedLabelKey opts a Deployment into phased (canary-gated) rollouts.
 	RolloutPhasedLabelKey   = "grafana.com/rollout-phased"
 	RolloutPhasedLabelValue = "true"
 
-	// RolloutDependsOnAnnotationKey names the upstream Deployment that must finish and soak
-	// before this Deployment is allowed to roll.
-	RolloutDependsOnAnnotationKey = "grafana.com/rollout-depends-on"
+	// RolloutCanaryAnnotationKey names one or more canary Deployments (comma-separated) that must
+	// finish rolling before this Deployment is allowed to proceed.
+	RolloutCanaryAnnotationKey = "grafana.com/rollout-canary"
 
 	// RolloutRevisionAnnotationKey is a shared revision stamp set by Git/jsonnet. The operator
 	// only gates when this value changes, so zone-local template differences are ignored.
 	RolloutRevisionAnnotationKey = "grafana.com/rollout-revision"
 
-	// RolloutSoakDurationAnnotationKey overrides the default soak duration (Prometheus duration, e.g. "5m").
-	RolloutSoakDurationAnnotationKey = "grafana.com/rollout-soak-duration"
-
-	// RolloutRestartThresholdAnnotationKey overrides the default restart ratio threshold
-	// (e.g. "10%" or "0.1") evaluated at the end of the soak.
-	RolloutRestartThresholdAnnotationKey = "grafana.com/rollout-restart-threshold"
-
-	// RolloutResumeAnnotationKey, when set to the gated revision, bypasses a failed soak gate
-	// and immediately unpauses the Deployment.
-	RolloutResumeAnnotationKey = "grafana.com/rollout-resume"
+	// RolloutBypassUntilAnnotationKey is an RFC3339 timestamp. While now is before that time,
+	// the operator skips pausing and unpauses an already-gated Deployment.
+	RolloutBypassUntilAnnotationKey = "grafana.com/rollout-bypass-until"
 
 	// Operator-owned state annotations written by the webhook and phased Deployment controller.
 	RolloutDependencyPhaseAnnotationKey    = "grafana.com/rollout-dependency-phase"
 	RolloutDependencyRevisionAnnotationKey = "grafana.com/rollout-dependency-revision"
 	RolloutDependencyReasonAnnotationKey   = "grafana.com/rollout-dependency-reason"
-	RolloutSoakStartedAtAnnotationKey      = "grafana.com/rollout-soak-started-at"
-	RolloutRestartBaselineAnnotationKey    = "grafana.com/rollout-restart-baseline"
 	RolloutHadPausedAnnotationKey          = "grafana.com/rollout-had-paused"
 
 	// Dependency phase values.
 	RolloutDependencyPhaseWaiting  = "waiting"
-	RolloutDependencyPhaseSoaking  = "soaking"
-	RolloutDependencyPhaseBlocked  = "blocked"
 	RolloutDependencyPhaseComplete = "complete"
 )

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -70,6 +71,10 @@ type RolloutController struct {
 
 	healthGate    HealthGate
 	healthMetrics *healthcheck.Metrics
+	healthTimerMu sync.Mutex
+	healthTimer   *time.Timer
+	healthTimerAt time.Time
+	healthWakeCh  chan struct{}
 
 	// This bool is true if we should trigger a reconcile.
 	shouldReconcile atomic.Bool
@@ -128,6 +133,7 @@ func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTM
 		zpdbController:       zpdbController,
 		logger:               logger,
 		stopCh:               make(chan struct{}),
+		healthWakeCh:         make(chan struct{}, 1),
 		discoveredGroups:     map[string]struct{}{},
 		groupReconcileTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "rollout_operator_group_reconciles_total",
@@ -255,6 +261,8 @@ func (c *RolloutController) Run() {
 		select {
 		case <-c.stopCh:
 			return
+		case <-c.healthWakeCh:
+			// Health deadlines must not wait for unrelated informer events or the regular throttle.
 		case <-time.After(c.reconcileInterval):
 			// Throttle before checking again if we should reconcile.
 		}
@@ -263,6 +271,13 @@ func (c *RolloutController) Run() {
 
 // Stop the controller.
 func (c *RolloutController) Stop() {
+	c.healthTimerMu.Lock()
+	if c.healthTimer != nil {
+		c.healthTimer.Stop()
+		c.healthTimer = nil
+		c.healthTimerAt = time.Time{}
+	}
+	c.healthTimerMu.Unlock()
 	close(c.stopCh)
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/healthcheck"
 	"github.com/grafana/rollout-operator/pkg/instrumentation"
 	"github.com/grafana/rollout-operator/pkg/util"
 	"github.com/grafana/rollout-operator/pkg/zpdb"
@@ -66,6 +67,9 @@ type RolloutController struct {
 	logger               log.Logger
 
 	zpdbController ZPDBEvictionController
+
+	healthGate    HealthGate
+	healthMetrics *healthcheck.Metrics
 
 	// This bool is true if we should trigger a reconcile.
 	shouldReconcile atomic.Bool
@@ -366,7 +370,39 @@ func (c *RolloutController) reconcileStatefulSetsGroup(ctx context.Context, grou
 		sets = util.MoveStatefulSetToFront(sets, notReadySets[0])
 	}
 
+	// Stamp the pre-rollout baseline timestamp as soon as any StatefulSet in the group
+	// needs updates, so T0 is available before the first between-zone health evaluation.
+	if groupHasHealthCheckAnnotation(sets) {
+		needsStamp := false
+		for _, sts := range sets {
+			outdated, err := c.podsNotMatchingUpdateRevision(sts)
+			if err != nil {
+				return fmt.Errorf("unable to list outdated pods for StatefulSet %s: %w", sts.Name, err)
+			}
+			if len(outdated) > 0 {
+				needsStamp = true
+				break
+			}
+		}
+		if needsStamp {
+			if err := c.ensureHealthCheckStartedAt(ctx, sets); err != nil {
+				level.Warn(c.logger).Log("msg", "failed to ensure health-check started-at annotation", "group", groupName, "err", err)
+			}
+		}
+	}
+
 	for _, sts := range sets {
+		pause, err := c.maybeEvaluateHealthGate(ctx, groupName, sets, sts)
+		if err != nil {
+			return fmt.Errorf("failed to evaluate health check before StatefulSet %s: %w", sts.Name, err)
+		}
+		if pause {
+			// Skip this StatefulSet but continue the loop so a mid-roll zone that sorts
+			// later (all its pods Ready, so not reordered via notReadySets) can still progress.
+			level.Info(c.logger).Log("msg", "pausing rollout due to health check", "group", groupName, "statefulset", sts.Name)
+			continue
+		}
+
 		ongoing, err := c.updateStatefulSetPods(ctx, sts)
 		if err != nil {
 			// Do not continue with other StatefulSets because this StatefulSet
@@ -769,6 +805,9 @@ func (c *RolloutController) deleteMetricsForDecommissionedGroups(groups map[stri
 		c.groupReconcileFailed.DeleteLabelValues(name)
 		c.groupReconcileDuration.DeleteLabelValues(name)
 		c.groupReconcileLastSuccess.DeleteLabelValues(name)
+		if c.healthMetrics != nil {
+			c.healthMetrics.DeleteGroup(name)
+		}
 		delete(c.discoveredGroups, name)
 	}
 

--- a/pkg/controller/health.go
+++ b/pkg/controller/health.go
@@ -1,0 +1,214 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log/level"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/healthcheck"
+)
+
+// HealthGate evaluates cell-level health before progressing to the next zone.
+type HealthGate interface {
+	Evaluate(ctx context.Context, req healthcheck.Request) healthcheck.Decision
+}
+
+// SetHealthCheck wires optional health-check gating into the controller.
+func (c *RolloutController) SetHealthCheck(gate HealthGate, metrics *healthcheck.Metrics) {
+	c.healthGate = gate
+	c.healthMetrics = metrics
+}
+
+func (c *RolloutController) maybeEvaluateHealthGate(ctx context.Context, groupName string, sets []*v1.StatefulSet, next *v1.StatefulSet) (pause bool, err error) {
+	if c.healthGate == nil {
+		return false, nil
+	}
+	// Binding is per-StatefulSet: only gate when the zone about to roll references a check.
+	if strings.TrimSpace(next.Annotations[config.RolloutHealthCheckAnnotationKey]) == "" {
+		return false, nil
+	}
+
+	needsGate, err := c.shouldGateBeforeStatefulSet(sets, next)
+	if err != nil {
+		return false, err
+	}
+	if !needsGate {
+		return false, nil
+	}
+
+	// Skip PromQL evaluation when the next zone is paused; it will not roll anyway.
+	if next.Annotations[config.RolloutPausedAnnotationKey] == config.RolloutPausedAnnotationValue {
+		return false, nil
+	}
+
+	candidatePods, stablePods, err := c.listCandidateAndStablePods(sets)
+	if err != nil {
+		return false, err
+	}
+	baseline := earliestHealthCheckStartedAt(sets)
+	if baseline.IsZero() {
+		msg := fmt.Sprintf("health-check baseline timestamp missing for group %s; pausing before StatefulSet %s", groupName, next.Name)
+		level.Warn(c.logger).Log("msg", msg, "group", groupName, "statefulset", next.Name)
+		if c.healthMetrics != nil {
+			c.healthMetrics.Blocked.WithLabelValues(groupName).Set(1)
+		}
+		return true, nil
+	}
+
+	decision := c.healthGate.Evaluate(ctx, healthcheck.Request{
+		RolloutGroup:  groupName,
+		Namespace:     c.namespace,
+		Sets:          sets,
+		NextSTS:       next,
+		CandidatePods: candidatePods,
+		StablePods:    stablePods,
+		BaselineTime:  baseline,
+	})
+	return decision.ShouldPause, nil
+}
+
+func groupHasHealthCheckAnnotation(sets []*v1.StatefulSet) bool {
+	for _, sts := range sets {
+		if strings.TrimSpace(sts.Annotations[config.RolloutHealthCheckAnnotationKey]) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldGateBeforeStatefulSet is true when next still has pods to update, has not started
+// rolling yet, and at least one other StatefulSet in the group already has candidate pods.
+func (c *RolloutController) shouldGateBeforeStatefulSet(sets []*v1.StatefulSet, next *v1.StatefulSet) (bool, error) {
+	outdated, err := c.podsNotMatchingUpdateRevision(next)
+	if err != nil {
+		return false, err
+	}
+	if len(outdated) == 0 {
+		return false, nil
+	}
+
+	nextCandidates, err := c.podsMatchingUpdateRevision(next)
+	if err != nil {
+		return false, err
+	}
+	if len(nextCandidates) > 0 {
+		// Zone already mid-roll; do not re-gate.
+		return false, nil
+	}
+
+	for _, sts := range sets {
+		if sts.Name == next.Name {
+			continue
+		}
+		candidates, err := c.podsMatchingUpdateRevision(sts)
+		if err != nil {
+			return false, err
+		}
+		if len(candidates) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (c *RolloutController) podsMatchingUpdateRevision(sts *v1.StatefulSet) ([]*corev1.Pod, error) {
+	updateRev := sts.Status.UpdateRevision
+	if updateRev == "" {
+		return nil, fmt.Errorf("updateRevision is empty for StatefulSet %s", sts.Name)
+	}
+	pods, err := c.listPodsByStatefulSet(sts)
+	if err != nil {
+		return nil, err
+	}
+	var matching []*corev1.Pod
+	for _, pod := range pods {
+		if pod.Labels[v1.ControllerRevisionHashLabelKey] == updateRev {
+			matching = append(matching, pod)
+		}
+	}
+	return matching, nil
+}
+
+func (c *RolloutController) listCandidateAndStablePods(sets []*v1.StatefulSet) (candidates, stable []*corev1.Pod, err error) {
+	for _, sts := range sets {
+		pods, listErr := c.listPodsByStatefulSet(sts)
+		if listErr != nil {
+			return nil, nil, listErr
+		}
+		updateRev := sts.Status.UpdateRevision
+		for _, pod := range pods {
+			if pod.Labels[v1.ControllerRevisionHashLabelKey] == updateRev {
+				candidates = append(candidates, pod)
+			} else {
+				stable = append(stable, pod)
+			}
+		}
+	}
+	return candidates, stable, nil
+}
+
+func (c *RolloutController) ensureHealthCheckStartedAt(ctx context.Context, sets []*v1.StatefulSet) error {
+	now := time.Now().UTC()
+	for _, sts := range sets {
+		outdated, err := c.podsNotMatchingUpdateRevision(sts)
+		if err != nil {
+			return err
+		}
+		if len(outdated) == 0 {
+			continue
+		}
+		updateRev := sts.Status.UpdateRevision
+		existing := healthcheck.ParseStartedAtAnnotation(sts.Annotations[config.RolloutHealthCheckStartedAtAnnotationKey], updateRev)
+		if !existing.IsZero() {
+			continue
+		}
+		value := healthcheck.FormatStartedAtAnnotation(updateRev, now)
+		if err := c.patchStatefulSetAnnotation(ctx, sts, config.RolloutHealthCheckStartedAtAnnotationKey, value); err != nil {
+			return fmt.Errorf("failed to patch started-at on %s: %w", sts.Name, err)
+		}
+		if sts.Annotations == nil {
+			sts.Annotations = map[string]string{}
+		}
+		sts.Annotations[config.RolloutHealthCheckStartedAtAnnotationKey] = value
+	}
+	return nil
+}
+
+func earliestHealthCheckStartedAt(sets []*v1.StatefulSet) time.Time {
+	var earliest time.Time
+	for _, sts := range sets {
+		t := healthcheck.ParseStartedAtAnnotation(sts.Annotations[config.RolloutHealthCheckStartedAtAnnotationKey], sts.Status.UpdateRevision)
+		if t.IsZero() {
+			continue
+		}
+		if earliest.IsZero() || t.Before(earliest) {
+			earliest = t
+		}
+	}
+	return earliest
+}
+
+func (c *RolloutController) patchStatefulSetAnnotation(ctx context.Context, sts *v1.StatefulSet, key, value string) error {
+	patch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]string{
+				key: value,
+			},
+		},
+	}
+	data, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+	_, err = c.kubeClient.AppsV1().StatefulSets(c.namespace).Patch(ctx, sts.Name, types.MergePatchType, data, metav1.PatchOptions{})
+	return err
+}

--- a/pkg/controller/health.go
+++ b/pkg/controller/health.go
@@ -73,7 +73,57 @@ func (c *RolloutController) maybeEvaluateHealthGate(ctx context.Context, groupNa
 		StablePods:    stablePods,
 		BaselineTime:  baseline,
 	})
+	if decision.ShouldPause && decision.RequeueAfter > 0 {
+		c.scheduleHealthRequeue(decision.RequeueAfter, groupName, next.Name)
+	}
 	return decision.ShouldPause, nil
+}
+
+func (c *RolloutController) scheduleHealthRequeue(after time.Duration, groupName, statefulSet string) {
+	if after <= 0 {
+		return
+	}
+
+	due := time.Now().Add(after)
+	c.healthTimerMu.Lock()
+	defer c.healthTimerMu.Unlock()
+	if c.healthTimer != nil && !due.Before(c.healthTimerAt) {
+		return
+	}
+	if c.healthTimer != nil {
+		c.healthTimer.Stop()
+	}
+
+	var timer *time.Timer
+	timer = time.AfterFunc(after, func() {
+		c.healthTimerMu.Lock()
+		if c.healthTimer != timer {
+			c.healthTimerMu.Unlock()
+			return
+		}
+		c.healthTimer = nil
+		c.healthTimerAt = time.Time{}
+		c.healthTimerMu.Unlock()
+
+		select {
+		case <-c.stopCh:
+			return
+		default:
+			c.enqueueReconcile()
+			select {
+			case c.healthWakeCh <- struct{}{}:
+			default:
+			}
+		}
+	})
+	c.healthTimer = timer
+	c.healthTimerAt = due
+	level.Debug(c.logger).Log(
+		"msg", "scheduled health check reevaluation",
+		"group", groupName,
+		"statefulset", statefulSet,
+		"requeue_after", after,
+	)
 }
 
 func groupHasHealthCheckAnnotation(sets []*v1.StatefulSet) bool {

--- a/pkg/controller/health.go
+++ b/pkg/controller/health.go
@@ -65,13 +65,16 @@ func (c *RolloutController) maybeEvaluateHealthGate(ctx context.Context, groupNa
 	}
 
 	decision := c.healthGate.Evaluate(ctx, healthcheck.Request{
-		RolloutGroup:  groupName,
-		Namespace:     c.namespace,
-		Sets:          sets,
-		NextSTS:       next,
-		CandidatePods: candidatePods,
-		StablePods:    stablePods,
-		BaselineTime:  baseline,
+		RolloutGroup:      groupName,
+		Namespace:         c.namespace,
+		TargetName:        next.Name,
+		TargetKind:        "StatefulSet",
+		TargetLabels:      next.Labels,
+		TargetAnnotations: next.Annotations,
+		EventTarget:       next,
+		CandidatePods:     candidatePods,
+		StablePods:        stablePods,
+		BaselineTime:      baseline,
 	})
 	return decision.ShouldPause, nil
 }

--- a/pkg/controller/health_test.go
+++ b/pkg/controller/health_test.go
@@ -1,0 +1,217 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/healthcheck"
+)
+
+type mockHealthGate struct {
+	mu          sync.Mutex
+	calls       int
+	shouldPause bool
+	lastReq     healthcheck.Request
+}
+
+func (m *mockHealthGate) Evaluate(_ context.Context, req healthcheck.Request) healthcheck.Decision {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	m.lastReq = req
+	return healthcheck.Decision{ShouldPause: m.shouldPause, Reason: "mock"}
+}
+
+func (m *mockHealthGate) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+func TestRolloutController_HealthCheckGating(t *testing.T) {
+	withHealthCheck := func(sts *v1.StatefulSet) {
+		if sts.Annotations == nil {
+			sts.Annotations = map[string]string{}
+		}
+		sts.Annotations[config.RolloutHealthCheckAnnotationKey] = "ingester-cell-health"
+		sts.Annotations[config.RolloutMaxUnavailableAnnotationKey] = "2"
+	}
+
+	t.Run("first zone rolls without gate", func(t *testing.T) {
+		gate := &mockHealthGate{shouldPause: true}
+		objects := []runtime.Object{
+			mockStatefulSet("ingester-zone-a", withPrevRevision(), withHealthCheck),
+			mockStatefulSet("ingester-zone-b", withPrevRevision(), withHealthCheck),
+			mockStatefulSetPod("ingester-zone-a-0", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-2", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
+		}
+		c := newControllerWithHealthGate(t, objects, gate)
+		require.NoError(t, c.reconcile(context.Background()))
+		require.Equal(t, 0, gate.callCount(), "first zone must not evaluate health gate")
+
+		pods, err := c.kubeClient.CoreV1().Pods(testNamespace).List(context.Background(), metav1.ListOptions{})
+		require.NoError(t, err)
+		deleted := 0
+		for _, name := range []string{"ingester-zone-a-0", "ingester-zone-a-1", "ingester-zone-a-2"} {
+			found := false
+			for _, p := range pods.Items {
+				if p.Name == name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				deleted++
+			}
+		}
+		require.Equal(t, testMaxUnavailable, deleted)
+	})
+
+	t.Run("gate blocks next zone", func(t *testing.T) {
+		gate := &mockHealthGate{shouldPause: true}
+		objects := []runtime.Object{
+			mockStatefulSet("ingester-zone-a", withHealthCheck),
+			mockStatefulSet("ingester-zone-b", withPrevRevision(), withHealthCheck),
+			mockStatefulSetPod("ingester-zone-a-0", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-1", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-2", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
+		}
+		c := newControllerWithHealthGate(t, objects, gate)
+		require.NoError(t, c.reconcile(context.Background()))
+		require.Equal(t, 1, gate.callCount())
+		require.Equal(t, "ingester-zone-b", gate.lastReq.NextSTS.Name)
+
+		for _, name := range []string{"ingester-zone-b-0", "ingester-zone-b-1", "ingester-zone-b-2"} {
+			_, err := c.kubeClient.CoreV1().Pods(testNamespace).Get(context.Background(), name, metav1.GetOptions{})
+			require.NoError(t, err, name)
+		}
+	})
+
+	t.Run("pass allows next zone", func(t *testing.T) {
+		gate := &mockHealthGate{shouldPause: false}
+		objects := []runtime.Object{
+			mockStatefulSet("ingester-zone-a", withHealthCheck),
+			mockStatefulSet("ingester-zone-b", withPrevRevision(), withHealthCheck),
+			mockStatefulSetPod("ingester-zone-a-0", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-1", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-2", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
+		}
+		c := newControllerWithHealthGate(t, objects, gate)
+		require.NoError(t, c.reconcile(context.Background()))
+		require.Equal(t, 1, gate.callCount())
+
+		pods, err := c.kubeClient.CoreV1().Pods(testNamespace).List(context.Background(), metav1.ListOptions{})
+		require.NoError(t, err)
+		remainingB := 0
+		for _, p := range pods.Items {
+			if strings.HasPrefix(p.Name, "ingester-zone-b") {
+				remainingB++
+			}
+		}
+		require.Equal(t, 3-testMaxUnavailable, remainingB)
+	})
+
+	t.Run("mid-zone not gated again", func(t *testing.T) {
+		gate := &mockHealthGate{shouldPause: true}
+		objects := []runtime.Object{
+			mockStatefulSet("ingester-zone-a", withHealthCheck),
+			mockStatefulSet("ingester-zone-b", withPrevRevision(), withHealthCheck),
+			mockStatefulSetPod("ingester-zone-a-0", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-1", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-2", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-0", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
+		}
+		c := newControllerWithHealthGate(t, objects, gate)
+		require.NoError(t, c.reconcile(context.Background()))
+		require.Equal(t, 0, gate.callCount())
+	})
+
+	t.Run("no annotation skips gate", func(t *testing.T) {
+		gate := &mockHealthGate{shouldPause: true}
+		objects := []runtime.Object{
+			mockStatefulSet("ingester-zone-a"),
+			mockStatefulSet("ingester-zone-b", withPrevRevision()),
+			mockStatefulSetPod("ingester-zone-a-0", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-1", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-2", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
+		}
+		c := newControllerWithHealthGate(t, objects, gate)
+		require.NoError(t, c.reconcile(context.Background()))
+		require.Equal(t, 0, gate.callCount())
+	})
+
+	t.Run("pause continues mid-roll zone", func(t *testing.T) {
+		gate := &mockHealthGate{shouldPause: true}
+		objects := []runtime.Object{
+			mockStatefulSet("ingester-zone-a", withHealthCheck),
+			mockStatefulSet("ingester-zone-b", withPrevRevision(), withHealthCheck),
+			mockStatefulSet("ingester-zone-c", withPrevRevision(), withHealthCheck),
+			mockStatefulSetPod("ingester-zone-a-0", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-1", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-a-2", testLastRevisionHash),
+			// zone-b has not started — health gate pauses it.
+			mockStatefulSetPod("ingester-zone-b-0", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-b-2", testPrevRevisionHash),
+			// zone-c mid-roll (sorts after b): must still progress after b is paused.
+			mockStatefulSetPod("ingester-zone-c-0", testLastRevisionHash),
+			mockStatefulSetPod("ingester-zone-c-1", testPrevRevisionHash),
+			mockStatefulSetPod("ingester-zone-c-2", testPrevRevisionHash),
+		}
+		c := newControllerWithHealthGate(t, objects, gate)
+		require.NoError(t, c.reconcile(context.Background()))
+		require.GreaterOrEqual(t, gate.callCount(), 1)
+		pods, err := c.kubeClient.CoreV1().Pods(testNamespace).List(context.Background(), metav1.ListOptions{})
+		require.NoError(t, err)
+		remainingC := 0
+		for _, p := range pods.Items {
+			if strings.HasPrefix(p.Name, "ingester-zone-c") {
+				remainingC++
+			}
+		}
+		require.Less(t, remainingC, 3, "mid-roll zone-c should continue deleting pods despite zone-b pause")
+		// zone-b must remain untouched
+		for _, name := range []string{"ingester-zone-b-0", "ingester-zone-b-1", "ingester-zone-b-2"} {
+			_, err := c.kubeClient.CoreV1().Pods(testNamespace).Get(context.Background(), name, metav1.GetOptions{})
+			require.NoError(t, err, name)
+		}
+	})
+}
+
+func newControllerWithHealthGate(t *testing.T, objects []runtime.Object, gate HealthGate) *RolloutController {
+	t.Helper()
+	kubeClient := fake.NewClientset(objects...)
+	reg := prometheus.NewPedanticRegistry()
+	c := NewRolloutController(kubeClient, nil, nil, nil, testClusterDomain, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger(), &mockEvictionController{})
+	c.SetHealthCheck(gate, nil)
+	require.NoError(t, c.Init())
+	t.Cleanup(c.Stop)
+	return c
+}

--- a/pkg/controller/health_test.go
+++ b/pkg/controller/health_test.go
@@ -98,7 +98,7 @@ func TestRolloutController_HealthCheckGating(t *testing.T) {
 		c := newControllerWithHealthGate(t, objects, gate)
 		require.NoError(t, c.reconcile(context.Background()))
 		require.Equal(t, 1, gate.callCount())
-		require.Equal(t, "ingester-zone-b", gate.lastReq.NextSTS.Name)
+		require.Equal(t, "ingester-zone-b", gate.lastReq.TargetName)
 
 		for _, name := range []string{"ingester-zone-b-0", "ingester-zone-b-1", "ingester-zone-b-2"} {
 			_, err := c.kubeClient.CoreV1().Pods(testNamespace).Get(context.Background(), name, metav1.GetOptions{})

--- a/pkg/controller/health_test.go
+++ b/pkg/controller/health_test.go
@@ -209,7 +209,7 @@ func newControllerWithHealthGate(t *testing.T, objects []runtime.Object, gate He
 	t.Helper()
 	kubeClient := fake.NewClientset(objects...)
 	reg := prometheus.NewPedanticRegistry()
-	c := NewRolloutController(kubeClient, nil, nil, nil, testClusterDomain, testNamespace, nil, 5*time.Second, reg, log.NewNopLogger(), &mockEvictionController{})
+	c := NewRolloutController(kubeClient, nil, nil, nil, testClusterDomain, testNamespace, NewPodInformerFactory(kubeClient, testNamespace), nil, 5*time.Second, reg, log.NewNopLogger(), &mockEvictionController{})
 	c.SetHealthCheck(gate, nil)
 	require.NoError(t, c.Init())
 	t.Cleanup(c.Stop)

--- a/pkg/controller/health_test.go
+++ b/pkg/controller/health_test.go
@@ -20,10 +20,11 @@ import (
 )
 
 type mockHealthGate struct {
-	mu          sync.Mutex
-	calls       int
-	shouldPause bool
-	lastReq     healthcheck.Request
+	mu           sync.Mutex
+	calls        int
+	shouldPause  bool
+	requeueAfter time.Duration
+	lastReq      healthcheck.Request
 }
 
 func (m *mockHealthGate) Evaluate(_ context.Context, req healthcheck.Request) healthcheck.Decision {
@@ -31,7 +32,7 @@ func (m *mockHealthGate) Evaluate(_ context.Context, req healthcheck.Request) he
 	defer m.mu.Unlock()
 	m.calls++
 	m.lastReq = req
-	return healthcheck.Decision{ShouldPause: m.shouldPause, Reason: "mock"}
+	return healthcheck.Decision{ShouldPause: m.shouldPause, Reason: "mock", RequeueAfter: m.requeueAfter}
 }
 
 func (m *mockHealthGate) callCount() int {
@@ -84,7 +85,7 @@ func TestRolloutController_HealthCheckGating(t *testing.T) {
 	})
 
 	t.Run("gate blocks next zone", func(t *testing.T) {
-		gate := &mockHealthGate{shouldPause: true}
+		gate := &mockHealthGate{shouldPause: true, requeueAfter: time.Minute}
 		objects := []runtime.Object{
 			mockStatefulSet("ingester-zone-a", withHealthCheck),
 			mockStatefulSet("ingester-zone-b", withPrevRevision(), withHealthCheck),
@@ -99,6 +100,12 @@ func TestRolloutController_HealthCheckGating(t *testing.T) {
 		require.NoError(t, c.reconcile(context.Background()))
 		require.Equal(t, 1, gate.callCount())
 		require.Equal(t, "ingester-zone-b", gate.lastReq.NextSTS.Name)
+		c.healthTimerMu.Lock()
+		timerScheduled := c.healthTimer != nil
+		timerDelay := time.Until(c.healthTimerAt)
+		c.healthTimerMu.Unlock()
+		require.True(t, timerScheduled)
+		require.InDelta(t, time.Minute, timerDelay, float64(time.Second))
 
 		for _, name := range []string{"ingester-zone-b-0", "ingester-zone-b-1", "ingester-zone-b-2"} {
 			_, err := c.kubeClient.CoreV1().Pods(testNamespace).Get(context.Background(), name, metav1.GetOptions{})
@@ -203,6 +210,28 @@ func TestRolloutController_HealthCheckGating(t *testing.T) {
 			require.NoError(t, err, name)
 		}
 	})
+}
+
+func TestRolloutController_HealthRequeueTimerEnqueuesReconcile(t *testing.T) {
+	c := &RolloutController{
+		logger:       log.NewNopLogger(),
+		stopCh:       make(chan struct{}),
+		healthWakeCh: make(chan struct{}, 1),
+	}
+	t.Cleanup(c.Stop)
+
+	c.scheduleHealthRequeue(10*time.Millisecond, "ingester", "ingester-zone-b")
+
+	select {
+	case <-c.healthWakeCh:
+	case <-time.After(time.Second):
+		t.Fatal("health requeue timer did not wake the controller")
+	}
+	require.True(t, c.shouldReconcile.Load())
+	c.healthTimerMu.Lock()
+	defer c.healthTimerMu.Unlock()
+	require.Nil(t, c.healthTimer)
+	require.True(t, c.healthTimerAt.IsZero())
 }
 
 func newControllerWithHealthGate(t *testing.T, objects []runtime.Object, gate HealthGate) *RolloutController {

--- a/pkg/controller/phased_deployment.go
+++ b/pkg/controller/phased_deployment.go
@@ -471,18 +471,6 @@ func (c *PhasedDeploymentController) ensurePaused(ctx context.Context, dep *apps
 	})
 }
 
-func (c *PhasedDeploymentController) patchAnnotations(ctx context.Context, name string, annotations map[string]string) error {
-	payload := make(map[string]interface{}, len(annotations))
-	for k, v := range annotations {
-		payload[k] = v
-	}
-	return c.patchDeployment(ctx, name, map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"annotations": payload,
-		},
-	})
-}
-
 func (c *PhasedDeploymentController) patchDeployment(ctx context.Context, name string, patch map[string]interface{}) error {
 	b, err := json.Marshal(patch)
 	if err != nil {

--- a/pkg/controller/phased_deployment.go
+++ b/pkg/controller/phased_deployment.go
@@ -1,0 +1,560 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/hashicorp/go-multierror"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/atomic"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	listersv1 "k8s.io/client-go/listers/apps/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/phased"
+	"github.com/grafana/rollout-operator/pkg/util"
+)
+
+// PhasedDeploymentController sequences opted-in Deployments that declare a depends-on relationship.
+type PhasedDeploymentController struct {
+	kubeClient          kubernetes.Interface
+	namespace           string
+	reconcileInterval   time.Duration
+	deploymentsFactory  informers.SharedInformerFactory
+	deploymentLister    listersv1.DeploymentLister
+	deploymentsInformer cache.SharedIndexInformer
+	podsFactory         informers.SharedInformerFactory
+	podLister           corelisters.PodLister
+	podsInformer        cache.SharedIndexInformer
+	logger              log.Logger
+
+	shouldReconcile atomic.Bool
+	stopCh          chan struct{}
+
+	phase             *prometheus.GaugeVec
+	blocked           *prometheus.GaugeVec
+	restartRatio      *prometheus.GaugeVec
+	soakRemaining     *prometheus.GaugeVec
+	reconcileTotal    prometheus.Counter
+	reconcileFailed   prometheus.Counter
+	reconcileDuration prometheus.Histogram
+}
+
+func NewPhasedDeploymentController(kubeClient kubernetes.Interface, namespace string, reconcileInterval time.Duration, reg prometheus.Registerer, logger log.Logger) *PhasedDeploymentController {
+	namespaceOpt := informers.WithNamespace(namespace)
+	deploymentsSel := labels.NewSelector().Add(util.MustNewLabelsRequirement(config.RolloutPhasedLabelKey, selection.Equals, []string{config.RolloutPhasedLabelValue})).String()
+	deploymentsSelOpt := informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+		options.LabelSelector = deploymentsSel
+	})
+
+	deploymentsFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, informerSyncInterval, namespaceOpt, deploymentsSelOpt)
+	deploymentsInformer := deploymentsFactory.Apps().V1().Deployments()
+	podsFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, informerSyncInterval, namespaceOpt)
+	podsInformer := podsFactory.Core().V1().Pods()
+
+	c := &PhasedDeploymentController{
+		kubeClient:          kubeClient,
+		namespace:           namespace,
+		reconcileInterval:   reconcileInterval,
+		deploymentsFactory:  deploymentsFactory,
+		deploymentLister:    deploymentsInformer.Lister(),
+		deploymentsInformer: deploymentsInformer.Informer(),
+		podsFactory:         podsFactory,
+		podLister:           podsInformer.Lister(),
+		podsInformer:        podsInformer.Informer(),
+		logger:              logger,
+		stopCh:              make(chan struct{}),
+		phase: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_phased_deployment_phase",
+			Help: "Current phased Deployment gate phase (1=active for labeled phase).",
+		}, []string{"deployment", "phase"}),
+		blocked: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_phased_deployment_blocked",
+			Help: "Whether a phased Deployment is blocked (1) awaiting resume.",
+		}, []string{"deployment", "reason"}),
+		restartRatio: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_phased_deployment_restart_ratio",
+			Help: "Measured container-restart ratio at the end of the last soak evaluation.",
+		}, []string{"deployment"}),
+		soakRemaining: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_phased_deployment_soak_remaining_seconds",
+			Help: "Seconds remaining in the current soak window, if soaking.",
+		}, []string{"deployment"}),
+		reconcileTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "rollout_operator_phased_deployment_reconciles_total",
+			Help: "Total number of phased Deployment reconciles started.",
+		}),
+		reconcileFailed: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "rollout_operator_phased_deployment_reconciles_failed_total",
+			Help: "Total number of phased Deployment reconciles that failed.",
+		}),
+		reconcileDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:    "rollout_operator_phased_deployment_reconcile_duration_seconds",
+			Help:    "Time spent reconciling phased Deployments.",
+			Buckets: prometheus.DefBuckets,
+		}),
+	}
+	return c
+}
+
+func (c *PhasedDeploymentController) Init() error {
+	_, err := c.deploymentsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.enqueueReconcile() },
+		UpdateFunc: func(old, new interface{}) { c.enqueueReconcile() },
+		DeleteFunc: func(obj interface{}) { c.enqueueReconcile() },
+	})
+	if err != nil {
+		return err
+	}
+	_, err = c.podsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(old, new interface{}) { c.enqueueReconcile() },
+		AddFunc:    func(obj interface{}) { c.enqueueReconcile() },
+		DeleteFunc: func(obj interface{}) { c.enqueueReconcile() },
+	})
+	if err != nil {
+		return err
+	}
+
+	go c.deploymentsFactory.Start(c.stopCh)
+	go c.podsFactory.Start(c.stopCh)
+
+	level.Info(c.logger).Log("msg", "phased deployment informer caches are syncing")
+	if ok := cache.WaitForCacheSync(c.stopCh, c.deploymentsInformer.HasSynced, c.podsInformer.HasSynced); !ok {
+		return errors.New("phased deployment informer caches failed to sync")
+	}
+	level.Info(c.logger).Log("msg", "phased deployment informer caches have synced")
+	return nil
+}
+
+func (c *PhasedDeploymentController) Run() {
+	ctx := context.Background()
+	for {
+		if c.shouldReconcile.CompareAndSwap(true, false) {
+			if err := c.reconcile(ctx); err != nil {
+				level.Warn(c.logger).Log("msg", "phased deployment reconcile failed", "err", err)
+				c.shouldReconcile.Store(true)
+			}
+		}
+		select {
+		case <-c.stopCh:
+			return
+		case <-time.After(c.reconcileInterval):
+		}
+	}
+}
+
+func (c *PhasedDeploymentController) Stop() {
+	close(c.stopCh)
+}
+
+func (c *PhasedDeploymentController) enqueueReconcile() {
+	c.shouldReconcile.Store(true)
+}
+
+func (c *PhasedDeploymentController) reconcile(ctx context.Context) error {
+	c.reconcileTotal.Inc()
+	timer := prometheus.NewTimer(c.reconcileDuration)
+	defer timer.ObserveDuration()
+
+	deps, err := c.deploymentLister.Deployments(c.namespace).List(labels.Everything())
+	if err != nil {
+		c.reconcileFailed.Inc()
+		return err
+	}
+
+	byName := make(map[string]*appsv1.Deployment, len(deps))
+	for _, d := range deps {
+		byName[d.Name] = d
+	}
+
+	var errs error
+	for _, d := range deps {
+		if err := c.reconcileDeployment(ctx, d, byName); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+	if errs != nil {
+		c.reconcileFailed.Inc()
+	}
+	return errs
+}
+
+func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, dep *appsv1.Deployment, byName map[string]*appsv1.Deployment) error {
+	dependsOn := phased.DependsOn(dep)
+	if dependsOn == "" {
+		c.clearMetrics(dep.Name)
+		return nil
+	}
+
+	revision := phased.Revision(dep)
+	if revision == "" {
+		c.setPhaseMetric(dep.Name, "missing_revision")
+		return nil
+	}
+
+	// Explicit resume for a blocked revision bypasses the failed soak immediately.
+	if phased.ResumeRevision(dep) == revision && phased.Phase(dep) == config.RolloutDependencyPhaseBlocked {
+		level.Info(c.logger).Log("msg", "resuming phased deployment after explicit resume annotation", "deployment", dep.Name, "revision", revision)
+		return c.completeGate(ctx, dep, "resumed by annotation")
+	}
+
+	if phased.Phase(dep) == config.RolloutDependencyPhaseComplete && phased.DependencyRevision(dep) == revision {
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
+		c.blocked.DeleteLabelValues(dep.Name, "restarts")
+		c.blocked.DeleteLabelValues(dep.Name, "config")
+		c.soakRemaining.DeleteLabelValues(dep.Name)
+		return nil
+	}
+
+	// Ensure gate annotations exist (webhook may not have run yet on CREATE-before-label cases).
+	if phased.NeedsNewGate(dep) || phased.Phase(dep) == "" {
+		hadPaused := phased.HadPausedAnnotationFalse
+		prevHad := annotationOrEmpty(dep, config.RolloutHadPausedAnnotationKey)
+		prevPhase := phased.Phase(dep)
+		if prevPhase != "" && prevPhase != config.RolloutDependencyPhaseComplete {
+			// Carry forward pause intent across revision changes while a gate was active.
+			if prevHad != "" {
+				hadPaused = prevHad
+			}
+		} else if dep.Spec.Paused {
+			hadPaused = phased.HadPausedAnnotationTrue
+		}
+		if err := c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseWaiting,
+					config.RolloutDependencyRevisionAnnotationKey: revision,
+					config.RolloutDependencyReasonAnnotationKey:   "waiting for upstream deployment",
+					config.RolloutHadPausedAnnotationKey:          hadPaused,
+				},
+			},
+			"spec": map[string]interface{}{
+				"paused": true,
+			},
+		}); err != nil {
+			return err
+		}
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
+		return nil
+	}
+
+	if phased.DetectDependencyCycle(dep.Name, byName) {
+		c.setPhaseMetric(dep.Name, "config_error")
+		c.blocked.WithLabelValues(dep.Name, "config").Set(1)
+		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, "dependency cycle detected")
+	}
+
+	upstream, ok := byName[dependsOn]
+	if !ok {
+		// Upstream may lack the phased label; fetch directly.
+		u, err := c.kubeClient.AppsV1().Deployments(c.namespace).Get(ctx, dependsOn, metav1.GetOptions{})
+		if err != nil {
+			c.setPhaseMetric(dep.Name, "config_error")
+			c.blocked.WithLabelValues(dep.Name, "config").Set(1)
+			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("upstream deployment %q not found", dependsOn))
+		}
+		upstream = u
+	}
+
+	if phased.Revision(upstream) != revision {
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
+		c.soakRemaining.WithLabelValues(dep.Name).Set(0)
+		c.blocked.DeleteLabelValues(dep.Name, "config")
+		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for upstream %q to reach revision %s", dependsOn, revision))
+	}
+
+	if !phased.IsFullyRolledOut(upstream) {
+		// Upstream became unhealthy during soak — reset soak when we next see it healthy.
+		if phased.Phase(dep) == config.RolloutDependencyPhaseSoaking {
+			level.Info(c.logger).Log("msg", "upstream no longer fully rolled out during soak; resetting soak", "deployment", dep.Name, "upstream", dependsOn)
+			return c.resetSoak(ctx, dep, fmt.Sprintf("waiting for upstream %q to become fully rolled out", dependsOn))
+		}
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
+		c.blocked.DeleteLabelValues(dep.Name, "config")
+		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for upstream %q to become fully rolled out", dependsOn))
+	}
+
+	soakDuration, err := phased.ParseSoakDuration(dep.Annotations)
+	if err != nil {
+		c.setPhaseMetric(dep.Name, "config_error")
+		c.blocked.WithLabelValues(dep.Name, "config").Set(1)
+		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, err.Error())
+	}
+	threshold, err := phased.ParseRestartThreshold(dep.Annotations)
+	if err != nil {
+		c.setPhaseMetric(dep.Name, "config_error")
+		c.blocked.WithLabelValues(dep.Name, "config").Set(1)
+		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, err.Error())
+	}
+
+	// Restart failures stay blocked until an explicit resume for this revision.
+	if phased.Phase(dep) == config.RolloutDependencyPhaseBlocked {
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseBlocked)
+		c.blocked.WithLabelValues(dep.Name, "restarts").Set(1)
+		c.blocked.DeleteLabelValues(dep.Name, "config")
+		c.soakRemaining.WithLabelValues(dep.Name).Set(0)
+		return c.ensurePaused(ctx, dep)
+	}
+
+	soakStartedAt, hasSoak := parseSoakStartedAt(dep)
+	if !hasSoak || phased.Phase(dep) != config.RolloutDependencyPhaseSoaking {
+		return c.startSoak(ctx, dep, upstream)
+	}
+
+	remaining := soakDuration - time.Since(soakStartedAt)
+	if remaining > 0 {
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseSoaking)
+		c.soakRemaining.WithLabelValues(dep.Name).Set(remaining.Seconds())
+		return c.ensurePaused(ctx, dep)
+	}
+	c.soakRemaining.WithLabelValues(dep.Name).Set(0)
+
+	// Soak finished: evaluate restart ratio once.
+	pods, err := c.listDeploymentPods(upstream)
+	if err != nil {
+		return err
+	}
+	baseline, err := phased.DecodeRestartBaseline(annotationOrEmpty(dep, config.RolloutRestartBaselineAnnotationKey))
+	if err != nil {
+		return fmt.Errorf("decode restart baseline for %s: %w", dep.Name, err)
+	}
+	ratio := phased.RestartRatio(pods, baseline)
+	c.restartRatio.WithLabelValues(dep.Name).Set(ratio)
+
+	if phased.ExceedsRestartThreshold(ratio, threshold) {
+		level.Warn(c.logger).Log(
+			"msg", "phased deployment blocked by restart threshold",
+			"deployment", dep.Name,
+			"upstream", dependsOn,
+			"restart_ratio", ratio,
+			"threshold", threshold,
+		)
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseBlocked)
+		c.blocked.WithLabelValues(dep.Name, "restarts").Set(1)
+		return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					config.RolloutDependencyPhaseAnnotationKey:  config.RolloutDependencyPhaseBlocked,
+					config.RolloutDependencyReasonAnnotationKey: fmt.Sprintf("restart ratio %.4f >= threshold %.4f", ratio, threshold),
+				},
+			},
+			"spec": map[string]interface{}{
+				"paused": true,
+			},
+		})
+	}
+
+	level.Info(c.logger).Log(
+		"msg", "phased deployment soak passed",
+		"deployment", dep.Name,
+		"upstream", dependsOn,
+		"restart_ratio", ratio,
+		"threshold", threshold,
+	)
+	c.blocked.DeleteLabelValues(dep.Name, "restarts")
+	return c.completeGate(ctx, dep, fmt.Sprintf("soak passed (restart ratio %.4f)", ratio))
+}
+
+func (c *PhasedDeploymentController) startSoak(ctx context.Context, dep, upstream *appsv1.Deployment) error {
+	pods, err := c.listDeploymentPods(upstream)
+	if err != nil {
+		return err
+	}
+	baseline, err := phased.EncodeRestartBaseline(phased.BuildRestartBaseline(pods))
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	level.Info(c.logger).Log("msg", "starting phased deployment soak", "deployment", dep.Name, "upstream", upstream.Name, "pods", len(pods))
+	c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseSoaking)
+	c.blocked.DeleteLabelValues(dep.Name, "config")
+	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				config.RolloutDependencyPhaseAnnotationKey:  config.RolloutDependencyPhaseSoaking,
+				config.RolloutDependencyReasonAnnotationKey: fmt.Sprintf("soaking upstream %q", upstream.Name),
+				config.RolloutSoakStartedAtAnnotationKey:    now,
+				config.RolloutRestartBaselineAnnotationKey:  baseline,
+			},
+		},
+		"spec": map[string]interface{}{
+			"paused": true,
+		},
+	})
+}
+
+func (c *PhasedDeploymentController) resetSoak(ctx context.Context, dep *appsv1.Deployment, reason string) error {
+	c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
+	c.soakRemaining.WithLabelValues(dep.Name).Set(0)
+	annotations := map[string]interface{}{
+		config.RolloutDependencyPhaseAnnotationKey:  config.RolloutDependencyPhaseWaiting,
+		config.RolloutDependencyReasonAnnotationKey: reason,
+		config.RolloutSoakStartedAtAnnotationKey:    nil,
+		config.RolloutRestartBaselineAnnotationKey:  nil,
+	}
+	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": annotations,
+		},
+		"spec": map[string]interface{}{
+			"paused": true,
+		},
+	})
+}
+
+func (c *PhasedDeploymentController) completeGate(ctx context.Context, dep *appsv1.Deployment, reason string) error {
+	hadPaused := annotationOrEmpty(dep, config.RolloutHadPausedAnnotationKey) == phased.HadPausedAnnotationTrue
+	paused := hadPaused
+	c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
+	c.blocked.DeleteLabelValues(dep.Name, "restarts")
+	c.blocked.DeleteLabelValues(dep.Name, "config")
+	c.soakRemaining.WithLabelValues(dep.Name).Set(0)
+
+	annotations := map[string]interface{}{
+		config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseComplete,
+		config.RolloutDependencyRevisionAnnotationKey: phased.Revision(dep),
+		config.RolloutDependencyReasonAnnotationKey:   reason,
+		config.RolloutSoakStartedAtAnnotationKey:      nil,
+		config.RolloutRestartBaselineAnnotationKey:    nil,
+		config.RolloutResumeAnnotationKey:             nil,
+	}
+	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": annotations,
+		},
+		"spec": map[string]interface{}{
+			"paused": paused,
+		},
+	})
+}
+
+func (c *PhasedDeploymentController) ensurePhase(ctx context.Context, dep *appsv1.Deployment, phase, reason string) error {
+	if phased.Phase(dep) == phase && annotationOrEmpty(dep, config.RolloutDependencyReasonAnnotationKey) == reason && dep.Spec.Paused {
+		return nil
+	}
+	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				config.RolloutDependencyPhaseAnnotationKey:  phase,
+				config.RolloutDependencyReasonAnnotationKey: reason,
+			},
+		},
+		"spec": map[string]interface{}{
+			"paused": true,
+		},
+	})
+}
+
+func (c *PhasedDeploymentController) ensurePaused(ctx context.Context, dep *appsv1.Deployment) error {
+	if dep.Spec.Paused {
+		return nil
+	}
+	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+		"spec": map[string]interface{}{
+			"paused": true,
+		},
+	})
+}
+
+func (c *PhasedDeploymentController) patchAnnotations(ctx context.Context, name string, annotations map[string]string) error {
+	payload := make(map[string]interface{}, len(annotations))
+	for k, v := range annotations {
+		payload[k] = v
+	}
+	return c.patchDeployment(ctx, name, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": payload,
+		},
+	})
+}
+
+func (c *PhasedDeploymentController) patchDeployment(ctx context.Context, name string, patch map[string]interface{}) error {
+	b, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+	_, err = c.kubeClient.AppsV1().Deployments(c.namespace).Patch(ctx, name, types.MergePatchType, b, metav1.PatchOptions{
+		FieldManager: "rollout-operator",
+	})
+	return err
+}
+
+func (c *PhasedDeploymentController) listDeploymentPods(dep *appsv1.Deployment) ([]*corev1.Pod, error) {
+	if dep.Spec.Selector == nil {
+		return nil, nil
+	}
+	selector, err := metav1.LabelSelectorAsSelector(dep.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+	pods, err := c.podLister.Pods(c.namespace).List(selector)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*corev1.Pod, 0, len(pods))
+	for _, p := range pods {
+		if p.DeletionTimestamp != nil {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+func (c *PhasedDeploymentController) setPhaseMetric(name, phase string) {
+	for _, p := range []string{
+		config.RolloutDependencyPhaseWaiting,
+		config.RolloutDependencyPhaseSoaking,
+		config.RolloutDependencyPhaseBlocked,
+		config.RolloutDependencyPhaseComplete,
+		"config_error",
+		"missing_revision",
+	} {
+		if p == phase {
+			c.phase.WithLabelValues(name, p).Set(1)
+		} else {
+			c.phase.WithLabelValues(name, p).Set(0)
+		}
+	}
+}
+
+func (c *PhasedDeploymentController) clearMetrics(name string) {
+	c.phase.DeletePartialMatch(prometheus.Labels{"deployment": name})
+	c.blocked.DeletePartialMatch(prometheus.Labels{"deployment": name})
+	c.restartRatio.DeleteLabelValues(name)
+	c.soakRemaining.DeleteLabelValues(name)
+}
+
+func annotationOrEmpty(dep *appsv1.Deployment, key string) string {
+	if dep.Annotations == nil {
+		return ""
+	}
+	return dep.Annotations[key]
+}
+
+func parseSoakStartedAt(dep *appsv1.Deployment) (time.Time, bool) {
+	raw := annotationOrEmpty(dep, config.RolloutSoakStartedAtAnnotationKey)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}

--- a/pkg/controller/phased_deployment.go
+++ b/pkg/controller/phased_deployment.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log"
@@ -22,7 +23,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/apps/v1"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/grafana/rollout-operator/pkg/config"
@@ -30,7 +30,12 @@ import (
 	"github.com/grafana/rollout-operator/pkg/util"
 )
 
-// PhasedDeploymentController sequences opted-in Deployments that declare a depends-on relationship.
+const (
+	bypassEventReason = "RolloutBypass"
+	bypassEventSource = "rollout-operator"
+)
+
+// PhasedDeploymentController sequences opted-in Deployments that declare canary dependencies.
 type PhasedDeploymentController struct {
 	kubeClient          kubernetes.Interface
 	namespace           string
@@ -38,18 +43,16 @@ type PhasedDeploymentController struct {
 	deploymentsFactory  informers.SharedInformerFactory
 	deploymentLister    listersv1.DeploymentLister
 	deploymentsInformer cache.SharedIndexInformer
-	podsFactory         informers.SharedInformerFactory
-	podLister           corelisters.PodLister
-	podsInformer        cache.SharedIndexInformer
 	logger              log.Logger
+	now                 func() time.Time
 
 	shouldReconcile atomic.Bool
 	stopCh          chan struct{}
 
 	phase             *prometheus.GaugeVec
 	blocked           *prometheus.GaugeVec
-	restartRatio      *prometheus.GaugeVec
-	soakRemaining     *prometheus.GaugeVec
+	bypassActive      *prometheus.GaugeVec
+	bypassTotal       *prometheus.CounterVec
 	reconcileTotal    prometheus.Counter
 	reconcileFailed   prometheus.Counter
 	reconcileDuration prometheus.Histogram
@@ -64,8 +67,6 @@ func NewPhasedDeploymentController(kubeClient kubernetes.Interface, namespace st
 
 	deploymentsFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, informerSyncInterval, namespaceOpt, deploymentsSelOpt)
 	deploymentsInformer := deploymentsFactory.Apps().V1().Deployments()
-	podsFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, informerSyncInterval, namespaceOpt)
-	podsInformer := podsFactory.Core().V1().Pods()
 
 	c := &PhasedDeploymentController{
 		kubeClient:          kubeClient,
@@ -74,10 +75,8 @@ func NewPhasedDeploymentController(kubeClient kubernetes.Interface, namespace st
 		deploymentsFactory:  deploymentsFactory,
 		deploymentLister:    deploymentsInformer.Lister(),
 		deploymentsInformer: deploymentsInformer.Informer(),
-		podsFactory:         podsFactory,
-		podLister:           podsInformer.Lister(),
-		podsInformer:        podsInformer.Informer(),
 		logger:              logger,
+		now:                 time.Now,
 		stopCh:              make(chan struct{}),
 		phase: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "rollout_operator_phased_deployment_phase",
@@ -85,15 +84,15 @@ func NewPhasedDeploymentController(kubeClient kubernetes.Interface, namespace st
 		}, []string{"deployment", "phase"}),
 		blocked: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "rollout_operator_phased_deployment_blocked",
-			Help: "Whether a phased Deployment is blocked (1) awaiting resume.",
+			Help: "Whether a phased Deployment is blocked (1) due to a config error.",
 		}, []string{"deployment", "reason"}),
-		restartRatio: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "rollout_operator_phased_deployment_restart_ratio",
-			Help: "Measured container-restart ratio at the end of the last soak evaluation.",
+		bypassActive: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_phased_deployment_bypass_active",
+			Help: "Whether a time-limited rollout bypass is currently active (1).",
 		}, []string{"deployment"}),
-		soakRemaining: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "rollout_operator_phased_deployment_soak_remaining_seconds",
-			Help: "Seconds remaining in the current soak window, if soaking.",
+		bypassTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "rollout_operator_phased_deployment_bypass_total",
+			Help: "Total number of times a phased Deployment used a time-limited rollout bypass.",
 		}, []string{"deployment"}),
 		reconcileTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "rollout_operator_phased_deployment_reconciles_total",
@@ -121,20 +120,11 @@ func (c *PhasedDeploymentController) Init() error {
 	if err != nil {
 		return err
 	}
-	_, err = c.podsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(old, new interface{}) { c.enqueueReconcile() },
-		AddFunc:    func(obj interface{}) { c.enqueueReconcile() },
-		DeleteFunc: func(obj interface{}) { c.enqueueReconcile() },
-	})
-	if err != nil {
-		return err
-	}
 
 	go c.deploymentsFactory.Start(c.stopCh)
-	go c.podsFactory.Start(c.stopCh)
 
 	level.Info(c.logger).Log("msg", "phased deployment informer caches are syncing")
-	if ok := cache.WaitForCacheSync(c.stopCh, c.deploymentsInformer.HasSynced, c.podsInformer.HasSynced); !ok {
+	if ok := cache.WaitForCacheSync(c.stopCh, c.deploymentsInformer.HasSynced); !ok {
 		return errors.New("phased deployment informer caches failed to sync")
 	}
 	level.Info(c.logger).Log("msg", "phased deployment informer caches have synced")
@@ -195,8 +185,8 @@ func (c *PhasedDeploymentController) reconcile(ctx context.Context) error {
 }
 
 func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, dep *appsv1.Deployment, byName map[string]*appsv1.Deployment) error {
-	dependsOn := phased.DependsOn(dep)
-	if dependsOn == "" {
+	canaries := phased.Canaries(dep)
+	if len(canaries) == 0 {
 		c.clearMetrics(dep.Name)
 		return nil
 	}
@@ -204,20 +194,37 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 	revision := phased.Revision(dep)
 	if revision == "" {
 		c.setPhaseMetric(dep.Name, "missing_revision")
+		c.bypassActive.WithLabelValues(dep.Name).Set(0)
 		return nil
 	}
 
-	// Explicit resume for a blocked revision bypasses the failed soak immediately.
-	if phased.ResumeRevision(dep) == revision && phased.Phase(dep) == config.RolloutDependencyPhaseBlocked {
-		level.Info(c.logger).Log("msg", "resuming phased deployment after explicit resume annotation", "deployment", dep.Name, "revision", revision)
-		return c.completeGate(ctx, dep, "resumed by annotation")
+	now := c.now()
+	if _, _, err := phased.BypassUntil(dep); err != nil {
+		level.Warn(c.logger).Log("msg", "invalid rollout-bypass-until, ignoring", "deployment", dep.Name, "err", err)
 	}
+	if phased.BypassActive(dep, now) {
+		c.bypassActive.WithLabelValues(dep.Name).Set(1)
+		needsBypassApply := phased.Phase(dep) != config.RolloutDependencyPhaseComplete ||
+			phased.DependencyRevision(dep) != revision ||
+			(dep.Spec.Paused && annotationOrEmpty(dep, config.RolloutHadPausedAnnotationKey) != phased.HadPausedAnnotationTrue)
+		if needsBypassApply {
+			level.Info(c.logger).Log("msg", "applying phased deployment bypass", "deployment", dep.Name, "revision", revision)
+			if err := c.completeGate(ctx, dep, fmt.Sprintf("bypassed until %s", annotationOrEmpty(dep, config.RolloutBypassUntilAnnotationKey))); err != nil {
+				return err
+			}
+			c.bypassTotal.WithLabelValues(dep.Name).Inc()
+			c.emitBypassEvent(ctx, dep, revision)
+			return nil
+		}
+		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
+		c.blocked.DeleteLabelValues(dep.Name, "config")
+		return nil
+	}
+	c.bypassActive.WithLabelValues(dep.Name).Set(0)
 
 	if phased.Phase(dep) == config.RolloutDependencyPhaseComplete && phased.DependencyRevision(dep) == revision {
 		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
-		c.blocked.DeleteLabelValues(dep.Name, "restarts")
 		c.blocked.DeleteLabelValues(dep.Name, "config")
-		c.soakRemaining.DeleteLabelValues(dep.Name)
 		return nil
 	}
 
@@ -239,7 +246,7 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 				"annotations": map[string]interface{}{
 					config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseWaiting,
 					config.RolloutDependencyRevisionAnnotationKey: revision,
-					config.RolloutDependencyReasonAnnotationKey:   "waiting for upstream deployment",
+					config.RolloutDependencyReasonAnnotationKey:   "waiting for canary deployment(s)",
 					config.RolloutHadPausedAnnotationKey:          hadPaused,
 				},
 			},
@@ -259,179 +266,57 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, "dependency cycle detected")
 	}
 
-	upstream, ok := byName[dependsOn]
-	if !ok {
-		// Upstream may lack the phased label; fetch directly.
-		u, err := c.kubeClient.AppsV1().Deployments(c.namespace).Get(ctx, dependsOn, metav1.GetOptions{})
+	for _, canaryName := range canaries {
+		canary, err := c.getCanary(ctx, canaryName, byName)
 		if err != nil {
 			c.setPhaseMetric(dep.Name, "config_error")
 			c.blocked.WithLabelValues(dep.Name, "config").Set(1)
-			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("upstream deployment %q not found", dependsOn))
+			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, err.Error())
 		}
-		upstream = u
-	}
-
-	if phased.Revision(upstream) != revision {
-		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
-		c.soakRemaining.WithLabelValues(dep.Name).Set(0)
-		c.blocked.DeleteLabelValues(dep.Name, "config")
-		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for upstream %q to reach revision %s", dependsOn, revision))
-	}
-
-	if !phased.IsFullyRolledOut(upstream) {
-		// Upstream became unhealthy during soak — reset soak when we next see it healthy.
-		if phased.Phase(dep) == config.RolloutDependencyPhaseSoaking {
-			level.Info(c.logger).Log("msg", "upstream no longer fully rolled out during soak; resetting soak", "deployment", dep.Name, "upstream", dependsOn)
-			return c.resetSoak(ctx, dep, fmt.Sprintf("waiting for upstream %q to become fully rolled out", dependsOn))
+		if phased.Revision(canary) != revision {
+			c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
+			c.blocked.DeleteLabelValues(dep.Name, "config")
+			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for canary %q to reach revision %s", canaryName, revision))
 		}
-		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
-		c.blocked.DeleteLabelValues(dep.Name, "config")
-		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for upstream %q to become fully rolled out", dependsOn))
-	}
-
-	soakDuration, err := phased.ParseSoakDuration(dep.Annotations)
-	if err != nil {
-		c.setPhaseMetric(dep.Name, "config_error")
-		c.blocked.WithLabelValues(dep.Name, "config").Set(1)
-		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, err.Error())
-	}
-	threshold, err := phased.ParseRestartThreshold(dep.Annotations)
-	if err != nil {
-		c.setPhaseMetric(dep.Name, "config_error")
-		c.blocked.WithLabelValues(dep.Name, "config").Set(1)
-		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, err.Error())
-	}
-
-	// Restart failures stay blocked until an explicit resume for this revision.
-	if phased.Phase(dep) == config.RolloutDependencyPhaseBlocked {
-		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseBlocked)
-		c.blocked.WithLabelValues(dep.Name, "restarts").Set(1)
-		c.blocked.DeleteLabelValues(dep.Name, "config")
-		c.soakRemaining.WithLabelValues(dep.Name).Set(0)
-		return c.ensurePaused(ctx, dep)
-	}
-
-	soakStartedAt, hasSoak := parseSoakStartedAt(dep)
-	if !hasSoak || phased.Phase(dep) != config.RolloutDependencyPhaseSoaking {
-		return c.startSoak(ctx, dep, upstream)
-	}
-
-	remaining := soakDuration - time.Since(soakStartedAt)
-	if remaining > 0 {
-		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseSoaking)
-		c.soakRemaining.WithLabelValues(dep.Name).Set(remaining.Seconds())
-		return c.ensurePaused(ctx, dep)
-	}
-	c.soakRemaining.WithLabelValues(dep.Name).Set(0)
-
-	// Soak finished: evaluate restart ratio once.
-	pods, err := c.listDeploymentPods(upstream)
-	if err != nil {
-		return err
-	}
-	baseline, err := phased.DecodeRestartBaseline(annotationOrEmpty(dep, config.RolloutRestartBaselineAnnotationKey))
-	if err != nil {
-		return fmt.Errorf("decode restart baseline for %s: %w", dep.Name, err)
-	}
-	ratio := phased.RestartRatio(pods, baseline)
-	c.restartRatio.WithLabelValues(dep.Name).Set(ratio)
-
-	if phased.ExceedsRestartThreshold(ratio, threshold) {
-		level.Warn(c.logger).Log(
-			"msg", "phased deployment blocked by restart threshold",
-			"deployment", dep.Name,
-			"upstream", dependsOn,
-			"restart_ratio", ratio,
-			"threshold", threshold,
-		)
-		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseBlocked)
-		c.blocked.WithLabelValues(dep.Name, "restarts").Set(1)
-		return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"annotations": map[string]interface{}{
-					config.RolloutDependencyPhaseAnnotationKey:  config.RolloutDependencyPhaseBlocked,
-					config.RolloutDependencyReasonAnnotationKey: fmt.Sprintf("restart ratio %.4f >= threshold %.4f", ratio, threshold),
-				},
-			},
-			"spec": map[string]interface{}{
-				"paused": true,
-			},
-		})
+		if !phased.IsFullyRolledOut(canary) {
+			c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
+			c.blocked.DeleteLabelValues(dep.Name, "config")
+			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for canary %q to become fully rolled out", canaryName))
+		}
 	}
 
 	level.Info(c.logger).Log(
-		"msg", "phased deployment soak passed",
+		"msg", "phased deployment canaries ready",
 		"deployment", dep.Name,
-		"upstream", dependsOn,
-		"restart_ratio", ratio,
-		"threshold", threshold,
+		"canaries", strings.Join(canaries, ","),
+		"revision", revision,
 	)
-	c.blocked.DeleteLabelValues(dep.Name, "restarts")
-	return c.completeGate(ctx, dep, fmt.Sprintf("soak passed (restart ratio %.4f)", ratio))
-}
-
-func (c *PhasedDeploymentController) startSoak(ctx context.Context, dep, upstream *appsv1.Deployment) error {
-	pods, err := c.listDeploymentPods(upstream)
-	if err != nil {
-		return err
-	}
-	baseline, err := phased.EncodeRestartBaseline(phased.BuildRestartBaseline(pods))
-	if err != nil {
-		return err
-	}
-	now := time.Now().UTC().Format(time.RFC3339)
-	level.Info(c.logger).Log("msg", "starting phased deployment soak", "deployment", dep.Name, "upstream", upstream.Name, "pods", len(pods))
-	c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseSoaking)
 	c.blocked.DeleteLabelValues(dep.Name, "config")
-	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"annotations": map[string]interface{}{
-				config.RolloutDependencyPhaseAnnotationKey:  config.RolloutDependencyPhaseSoaking,
-				config.RolloutDependencyReasonAnnotationKey: fmt.Sprintf("soaking upstream %q", upstream.Name),
-				config.RolloutSoakStartedAtAnnotationKey:    now,
-				config.RolloutRestartBaselineAnnotationKey:  baseline,
-			},
-		},
-		"spec": map[string]interface{}{
-			"paused": true,
-		},
-	})
+	return c.completeGate(ctx, dep, fmt.Sprintf("canaries ready: %s", strings.Join(canaries, ",")))
 }
 
-func (c *PhasedDeploymentController) resetSoak(ctx context.Context, dep *appsv1.Deployment, reason string) error {
-	c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
-	c.soakRemaining.WithLabelValues(dep.Name).Set(0)
-	annotations := map[string]interface{}{
-		config.RolloutDependencyPhaseAnnotationKey:  config.RolloutDependencyPhaseWaiting,
-		config.RolloutDependencyReasonAnnotationKey: reason,
-		config.RolloutSoakStartedAtAnnotationKey:    nil,
-		config.RolloutRestartBaselineAnnotationKey:  nil,
+func (c *PhasedDeploymentController) getCanary(ctx context.Context, name string, byName map[string]*appsv1.Deployment) (*appsv1.Deployment, error) {
+	if d, ok := byName[name]; ok {
+		return d, nil
 	}
-	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"annotations": annotations,
-		},
-		"spec": map[string]interface{}{
-			"paused": true,
-		},
-	})
+	// Canary may lack the phased label; fetch directly.
+	d, err := c.kubeClient.AppsV1().Deployments(c.namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("canary deployment %q not found: %w", name, err)
+	}
+	return d, nil
 }
 
 func (c *PhasedDeploymentController) completeGate(ctx context.Context, dep *appsv1.Deployment, reason string) error {
 	hadPaused := annotationOrEmpty(dep, config.RolloutHadPausedAnnotationKey) == phased.HadPausedAnnotationTrue
 	paused := hadPaused
 	c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
-	c.blocked.DeleteLabelValues(dep.Name, "restarts")
 	c.blocked.DeleteLabelValues(dep.Name, "config")
-	c.soakRemaining.WithLabelValues(dep.Name).Set(0)
 
 	annotations := map[string]interface{}{
 		config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseComplete,
 		config.RolloutDependencyRevisionAnnotationKey: phased.Revision(dep),
 		config.RolloutDependencyReasonAnnotationKey:   reason,
-		config.RolloutSoakStartedAtAnnotationKey:      nil,
-		config.RolloutRestartBaselineAnnotationKey:    nil,
-		config.RolloutResumeAnnotationKey:             nil,
 	}
 	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
 		"metadata": map[string]interface{}{
@@ -460,17 +345,6 @@ func (c *PhasedDeploymentController) ensurePhase(ctx context.Context, dep *appsv
 	})
 }
 
-func (c *PhasedDeploymentController) ensurePaused(ctx context.Context, dep *appsv1.Deployment) error {
-	if dep.Spec.Paused {
-		return nil
-	}
-	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
-		"spec": map[string]interface{}{
-			"paused": true,
-		},
-	})
-}
-
 func (c *PhasedDeploymentController) patchDeployment(ctx context.Context, name string, patch map[string]interface{}) error {
 	b, err := json.Marshal(patch)
 	if err != nil {
@@ -482,33 +356,42 @@ func (c *PhasedDeploymentController) patchDeployment(ctx context.Context, name s
 	return err
 }
 
-func (c *PhasedDeploymentController) listDeploymentPods(dep *appsv1.Deployment) ([]*corev1.Pod, error) {
-	if dep.Spec.Selector == nil {
-		return nil, nil
+func (c *PhasedDeploymentController) emitBypassEvent(ctx context.Context, dep *appsv1.Deployment, revision string) {
+	until := annotationOrEmpty(dep, config.RolloutBypassUntilAnnotationKey)
+	msg := fmt.Sprintf("phased rollout bypassed for revision %s until %s", revision, until)
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s.bypass.%d", dep.Name, c.now().UnixNano()),
+			Namespace: c.namespace,
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:            "Deployment",
+			Namespace:       dep.Namespace,
+			Name:            dep.Name,
+			UID:             dep.UID,
+			APIVersion:      "apps/v1",
+			ResourceVersion: dep.ResourceVersion,
+		},
+		Reason:  bypassEventReason,
+		Message: msg,
+		Source:  corev1.EventSource{Component: bypassEventSource},
+		Type:    corev1.EventTypeWarning,
+		Count:   1,
+		FirstTimestamp: metav1.Time{
+			Time: c.now(),
+		},
+		LastTimestamp: metav1.Time{
+			Time: c.now(),
+		},
 	}
-	selector, err := metav1.LabelSelectorAsSelector(dep.Spec.Selector)
-	if err != nil {
-		return nil, err
+	if _, err := c.kubeClient.CoreV1().Events(c.namespace).Create(ctx, event, metav1.CreateOptions{}); err != nil {
+		level.Warn(c.logger).Log("msg", "failed to emit phased rollout bypass event", "deployment", dep.Name, "err", err)
 	}
-	pods, err := c.podLister.Pods(c.namespace).List(selector)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]*corev1.Pod, 0, len(pods))
-	for _, p := range pods {
-		if p.DeletionTimestamp != nil {
-			continue
-		}
-		out = append(out, p)
-	}
-	return out, nil
 }
 
 func (c *PhasedDeploymentController) setPhaseMetric(name, phase string) {
 	for _, p := range []string{
 		config.RolloutDependencyPhaseWaiting,
-		config.RolloutDependencyPhaseSoaking,
-		config.RolloutDependencyPhaseBlocked,
 		config.RolloutDependencyPhaseComplete,
 		"config_error",
 		"missing_revision",
@@ -524,8 +407,7 @@ func (c *PhasedDeploymentController) setPhaseMetric(name, phase string) {
 func (c *PhasedDeploymentController) clearMetrics(name string) {
 	c.phase.DeletePartialMatch(prometheus.Labels{"deployment": name})
 	c.blocked.DeletePartialMatch(prometheus.Labels{"deployment": name})
-	c.restartRatio.DeleteLabelValues(name)
-	c.soakRemaining.DeleteLabelValues(name)
+	c.bypassActive.DeleteLabelValues(name)
 }
 
 func annotationOrEmpty(dep *appsv1.Deployment, key string) string {
@@ -533,16 +415,4 @@ func annotationOrEmpty(dep *appsv1.Deployment, key string) string {
 		return ""
 	}
 	return dep.Annotations[key]
-}
-
-func parseSoakStartedAt(dep *appsv1.Deployment) (time.Time, bool) {
-	raw := annotationOrEmpty(dep, config.RolloutSoakStartedAtAnnotationKey)
-	if raw == "" {
-		return time.Time{}, false
-	}
-	t, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		return time.Time{}, false
-	}
-	return t, true
 }

--- a/pkg/controller/phased_deployment.go
+++ b/pkg/controller/phased_deployment.go
@@ -192,15 +192,26 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 	}
 
 	revision := phased.Revision(dep)
+	level.Debug(c.logger).Log(
+		"msg", "reconciling phased deployment",
+		"deployment", dep.Name,
+		"revision", revision,
+		"gated_revision", phased.DependencyRevision(dep),
+		"phase", phased.Phase(dep),
+		"paused", dep.Spec.Paused,
+		"canaries", strings.Join(canaries, ","),
+	)
 	if revision == "" {
 		c.setPhaseMetric(dep.Name, "missing_revision")
 		c.bypassActive.WithLabelValues(dep.Name).Set(0)
+		level.Debug(c.logger).Log("msg", "phased deployment cannot be gated without rollout revision", "deployment", dep.Name)
 		return nil
 	}
 
 	now := c.now()
-	if _, _, err := phased.BypassUntil(dep); err != nil {
-		level.Warn(c.logger).Log("msg", "invalid rollout-bypass-until, ignoring", "deployment", dep.Name, "err", err)
+	bypassUntil, bypassSet, bypassErr := phased.BypassUntil(dep)
+	if bypassErr != nil {
+		level.Warn(c.logger).Log("msg", "invalid rollout-bypass-until, ignoring", "deployment", dep.Name, "err", bypassErr)
 	}
 	if phased.BypassActive(dep, now) {
 		c.bypassActive.WithLabelValues(dep.Name).Set(1)
@@ -208,7 +219,14 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 			phased.DependencyRevision(dep) != revision ||
 			(dep.Spec.Paused && annotationOrEmpty(dep, config.RolloutHadPausedAnnotationKey) != phased.HadPausedAnnotationTrue)
 		if needsBypassApply {
-			level.Info(c.logger).Log("msg", "applying phased deployment bypass", "deployment", dep.Name, "revision", revision)
+			level.Warn(c.logger).Log(
+				"msg", "applying phased deployment bypass",
+				"deployment", dep.Name,
+				"revision", revision,
+				"bypass_until", bypassUntil.Format(time.RFC3339),
+				"phase", phased.Phase(dep),
+				"paused", dep.Spec.Paused,
+			)
 			if err := c.completeGate(ctx, dep, fmt.Sprintf("bypassed until %s", annotationOrEmpty(dep, config.RolloutBypassUntilAnnotationKey))); err != nil {
 				return err
 			}
@@ -218,13 +236,28 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 		}
 		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
 		c.blocked.DeleteLabelValues(dep.Name, "config")
+		level.Debug(c.logger).Log(
+			"msg", "phased deployment bypass remains active",
+			"deployment", dep.Name,
+			"revision", revision,
+			"bypass_until", bypassUntil.Format(time.RFC3339),
+		)
 		return nil
 	}
 	c.bypassActive.WithLabelValues(dep.Name).Set(0)
+	if bypassSet && bypassErr == nil {
+		level.Debug(c.logger).Log(
+			"msg", "phased deployment bypass is expired",
+			"deployment", dep.Name,
+			"revision", revision,
+			"bypass_until", bypassUntil.Format(time.RFC3339),
+		)
+	}
 
 	if phased.Phase(dep) == config.RolloutDependencyPhaseComplete && phased.DependencyRevision(dep) == revision {
 		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
 		c.blocked.DeleteLabelValues(dep.Name, "config")
+		level.Debug(c.logger).Log("msg", "phased deployment may proceed", "deployment", dep.Name, "revision", revision, "paused", dep.Spec.Paused)
 		return nil
 	}
 
@@ -241,6 +274,15 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 		} else if dep.Spec.Paused {
 			hadPaused = phased.HadPausedAnnotationTrue
 		}
+		level.Info(c.logger).Log(
+			"msg", "starting phased deployment gate",
+			"deployment", dep.Name,
+			"previous_revision", phased.DependencyRevision(dep),
+			"target_revision", revision,
+			"previous_phase", prevPhase,
+			"canaries", strings.Join(canaries, ","),
+			"had_paused", hadPaused,
+		)
 		if err := c.patchDeployment(ctx, dep.Name, map[string]interface{}{
 			"metadata": map[string]interface{}{
 				"annotations": map[string]interface{}{
@@ -273,12 +315,29 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 			c.blocked.WithLabelValues(dep.Name, "config").Set(1)
 			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, err.Error())
 		}
-		if phased.Revision(canary) != revision {
+		canaryRevision := phased.Revision(canary)
+		canaryReady := phased.IsFullyRolledOut(canary)
+		level.Debug(c.logger).Log(
+			"msg", "checking phased deployment canary",
+			"deployment", dep.Name,
+			"canary", canaryName,
+			"current_revision", canaryRevision,
+			"target_revision", revision,
+			"ready", canaryReady,
+			"paused", canary.Spec.Paused,
+			"generation", canary.Generation,
+			"observed_generation", canary.Status.ObservedGeneration,
+			"replicas", valueOrDefault(canary.Spec.Replicas, 1),
+			"updated_replicas", canary.Status.UpdatedReplicas,
+			"ready_replicas", canary.Status.ReadyReplicas,
+			"available_replicas", canary.Status.AvailableReplicas,
+		)
+		if canaryRevision != revision {
 			c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
 			c.blocked.DeleteLabelValues(dep.Name, "config")
 			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for canary %q to reach revision %s", canaryName, revision))
 		}
-		if !phased.IsFullyRolledOut(canary) {
+		if !canaryReady {
 			c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
 			c.blocked.DeleteLabelValues(dep.Name, "config")
 			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for canary %q to become fully rolled out", canaryName))
@@ -318,6 +377,17 @@ func (c *PhasedDeploymentController) completeGate(ctx context.Context, dep *apps
 		config.RolloutDependencyRevisionAnnotationKey: phased.Revision(dep),
 		config.RolloutDependencyReasonAnnotationKey:   reason,
 	}
+	action := "unpause-and-proceed"
+	if hadPaused {
+		action = "preserve-pause"
+	}
+	level.Info(c.logger).Log(
+		"msg", "completing phased deployment gate",
+		"deployment", dep.Name,
+		"revision", phased.Revision(dep),
+		"reason", reason,
+		"action", action,
+	)
 	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"annotations": annotations,
@@ -330,8 +400,22 @@ func (c *PhasedDeploymentController) completeGate(ctx context.Context, dep *apps
 
 func (c *PhasedDeploymentController) ensurePhase(ctx context.Context, dep *appsv1.Deployment, phase, reason string) error {
 	if phased.Phase(dep) == phase && annotationOrEmpty(dep, config.RolloutDependencyReasonAnnotationKey) == reason && dep.Spec.Paused {
+		level.Debug(c.logger).Log(
+			"msg", "phased deployment remains on hold",
+			"deployment", dep.Name,
+			"revision", phased.Revision(dep),
+			"phase", phase,
+			"reason", reason,
+		)
 		return nil
 	}
+	level.Info(c.logger).Log(
+		"msg", "holding phased deployment",
+		"deployment", dep.Name,
+		"revision", phased.Revision(dep),
+		"phase", phase,
+		"reason", reason,
+	)
 	return c.patchDeployment(ctx, dep.Name, map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"annotations": map[string]interface{}{
@@ -415,4 +499,11 @@ func annotationOrEmpty(dep *appsv1.Deployment, key string) string {
 		return ""
 	}
 	return dep.Annotations[key]
+}
+
+func valueOrDefault(value *int32, fallback int32) int32 {
+	if value == nil {
+		return fallback
+	}
+	return *value
 }

--- a/pkg/controller/phased_deployment.go
+++ b/pkg/controller/phased_deployment.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/healthcheck"
 	"github.com/grafana/rollout-operator/pkg/phased"
 	"github.com/grafana/rollout-operator/pkg/util"
 )
@@ -45,6 +46,8 @@ type PhasedDeploymentController struct {
 	deploymentsInformer cache.SharedIndexInformer
 	logger              log.Logger
 	now                 func() time.Time
+	healthGate          HealthGate
+	healthMetrics       *healthcheck.Metrics
 
 	shouldReconcile atomic.Bool
 	stopCh          chan struct{}
@@ -109,6 +112,12 @@ func NewPhasedDeploymentController(kubeClient kubernetes.Interface, namespace st
 		}),
 	}
 	return c
+}
+
+// SetHealthCheck wires optional health-check gating into phased Deployment rollouts.
+func (c *PhasedDeploymentController) SetHealthCheck(gate HealthGate, metrics *healthcheck.Metrics) {
+	c.healthGate = gate
+	c.healthMetrics = metrics
 }
 
 func (c *PhasedDeploymentController) Init() error {
@@ -187,6 +196,9 @@ func (c *PhasedDeploymentController) reconcile(ctx context.Context) error {
 func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, dep *appsv1.Deployment, byName map[string]*appsv1.Deployment) error {
 	canaries := phased.Canaries(dep)
 	if len(canaries) == 0 {
+		if phased.Phase(dep) != "" || strings.TrimSpace(annotationOrEmpty(dep, config.RolloutHealthCheckAnnotationKey)) != "" {
+			c.clearDeploymentHealthGate(ctx, dep)
+		}
 		c.clearMetrics(dep.Name)
 		return nil
 	}
@@ -203,6 +215,7 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 		level.Warn(c.logger).Log("msg", "invalid rollout-bypass-until, ignoring", "deployment", dep.Name, "err", err)
 	}
 	if phased.BypassActive(dep, now) {
+		c.clearDeploymentHealthGate(ctx, dep)
 		c.bypassActive.WithLabelValues(dep.Name).Set(1)
 		needsBypassApply := phased.Phase(dep) != config.RolloutDependencyPhaseComplete ||
 			phased.DependencyRevision(dep) != revision ||
@@ -221,6 +234,9 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 		return nil
 	}
 	c.bypassActive.WithLabelValues(dep.Name).Set(0)
+	if !c.shouldEvaluateHealth(dep) {
+		c.clearDeploymentHealthGate(ctx, dep)
+	}
 
 	if phased.Phase(dep) == config.RolloutDependencyPhaseComplete && phased.DependencyRevision(dep) == revision {
 		c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseComplete)
@@ -266,6 +282,8 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, "dependency cycle detected")
 	}
 
+	canaryDeployments := make([]*appsv1.Deployment, 0, len(canaries))
+	var healthBaseline time.Time
 	for _, canaryName := range canaries {
 		canary, err := c.getCanary(ctx, canaryName, byName)
 		if err != nil {
@@ -277,6 +295,16 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 			c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
 			c.blocked.DeleteLabelValues(dep.Name, "config")
 			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for canary %q to reach revision %s", canaryName, revision))
+		}
+		canaryDeployments = append(canaryDeployments, canary)
+		if c.shouldEvaluateHealth(dep) {
+			startedAt, err := c.ensureDeploymentHealthCheckStartedAt(ctx, canary, revision)
+			if err != nil {
+				return err
+			}
+			if healthBaseline.IsZero() || startedAt.Before(healthBaseline) {
+				healthBaseline = startedAt
+			}
 		}
 		if !phased.IsFullyRolledOut(canary) {
 			c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
@@ -292,7 +320,125 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 		"revision", revision,
 	)
 	c.blocked.DeleteLabelValues(dep.Name, "config")
+	if c.shouldEvaluateHealth(dep) {
+		pause, reason, err := c.evaluateDeploymentHealthGate(ctx, dep, canaryDeployments, healthBaseline)
+		if err != nil {
+			return err
+		}
+		if pause {
+			c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
+			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, reason)
+		}
+	}
 	return c.completeGate(ctx, dep, fmt.Sprintf("canaries ready: %s", strings.Join(canaries, ",")))
+}
+
+func (c *PhasedDeploymentController) shouldEvaluateHealth(dep *appsv1.Deployment) bool {
+	return c.healthGate != nil && strings.TrimSpace(annotationOrEmpty(dep, config.RolloutHealthCheckAnnotationKey)) != ""
+}
+
+func (c *PhasedDeploymentController) clearDeploymentHealthGate(ctx context.Context, dep *appsv1.Deployment) {
+	if c.healthGate == nil {
+		return
+	}
+	groupName := deploymentHealthGroup(dep)
+	c.healthGate.Evaluate(ctx, healthcheck.Request{
+		RolloutGroup:      groupName,
+		StateKey:          deploymentHealthStateKey(groupName, dep.Name),
+		Namespace:         c.namespace,
+		TargetName:        dep.Name,
+		TargetKind:        "Deployment",
+		TargetLabels:      dep.Labels,
+		TargetAnnotations: nil,
+		EventTarget:       dep,
+	})
+}
+
+func (c *PhasedDeploymentController) ensureDeploymentHealthCheckStartedAt(ctx context.Context, dep *appsv1.Deployment, revision string) (time.Time, error) {
+	existing := healthcheck.ParseStartedAtAnnotation(annotationOrEmpty(dep, config.RolloutHealthCheckStartedAtAnnotationKey), revision)
+	if !existing.IsZero() {
+		return existing, nil
+	}
+	startedAt := c.now().UTC()
+	value := healthcheck.FormatStartedAtAnnotation(revision, startedAt)
+	if err := c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				config.RolloutHealthCheckStartedAtAnnotationKey: value,
+			},
+		},
+	}); err != nil {
+		return time.Time{}, fmt.Errorf("failed to patch health-check started-at on Deployment %s: %w", dep.Name, err)
+	}
+	return startedAt, nil
+}
+
+func (c *PhasedDeploymentController) evaluateDeploymentHealthGate(ctx context.Context, dep *appsv1.Deployment, canaries []*appsv1.Deployment, baseline time.Time) (bool, string, error) {
+	groupName := deploymentHealthGroup(dep)
+	if baseline.IsZero() {
+		reason := fmt.Sprintf("health-check baseline timestamp missing for Deployment %s", dep.Name)
+		level.Warn(c.logger).Log("msg", reason, "deployment", dep.Name)
+		if c.healthMetrics != nil {
+			c.healthMetrics.Blocked.WithLabelValues(groupName).Set(1)
+		}
+		return true, reason, nil
+	}
+
+	var candidatePods []*corev1.Pod
+	for _, canary := range canaries {
+		pods, err := c.listDeploymentPods(ctx, canary)
+		if err != nil {
+			return false, "", err
+		}
+		candidatePods = append(candidatePods, pods...)
+	}
+	stablePods, err := c.listDeploymentPods(ctx, dep)
+	if err != nil {
+		return false, "", err
+	}
+
+	decision := c.healthGate.Evaluate(ctx, healthcheck.Request{
+		RolloutGroup:      groupName,
+		StateKey:          deploymentHealthStateKey(groupName, dep.Name),
+		Namespace:         c.namespace,
+		TargetName:        dep.Name,
+		TargetKind:        "Deployment",
+		TargetLabels:      dep.Labels,
+		TargetAnnotations: dep.Annotations,
+		EventTarget:       dep,
+		CandidatePods:     candidatePods,
+		StablePods:        stablePods,
+		BaselineTime:      baseline,
+		Now:               c.now(),
+	})
+	return decision.ShouldPause, decision.Reason, nil
+}
+
+func deploymentHealthGroup(dep *appsv1.Deployment) string {
+	if groupName := dep.Labels[config.RolloutGroupLabelKey]; groupName != "" {
+		return groupName
+	}
+	return dep.Name
+}
+
+func deploymentHealthStateKey(groupName, deploymentName string) string {
+	return groupName + "/Deployment/" + deploymentName
+}
+
+func (c *PhasedDeploymentController) listDeploymentPods(ctx context.Context, dep *appsv1.Deployment) ([]*corev1.Pod, error) {
+	selector, err := metav1.LabelSelectorAsSelector(dep.Spec.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("invalid pod selector for Deployment %s: %w", dep.Name, err)
+	}
+	podList, err := c.kubeClient.CoreV1().Pods(c.namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods for Deployment %s: %w", dep.Name, err)
+	}
+	pods := make([]*corev1.Pod, 0, len(podList.Items))
+	for i := range podList.Items {
+		pods = append(pods, &podList.Items[i])
+	}
+	return pods, nil
 }
 
 func (c *PhasedDeploymentController) getCanary(ctx context.Context, name string, byName map[string]*appsv1.Deployment) (*appsv1.Deployment, error) {

--- a/pkg/controller/phased_deployment.go
+++ b/pkg/controller/phased_deployment.go
@@ -308,6 +308,7 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 		return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, "dependency cycle detected")
 	}
 
+	canariesReady := phased.CanariesReadyRevision(dep) == revision
 	for _, canaryName := range canaries {
 		canary, err := c.getCanary(ctx, canaryName, byName)
 		if err != nil {
@@ -324,6 +325,7 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 			"current_revision", canaryRevision,
 			"target_revision", revision,
 			"ready", canaryReady,
+			"ready_latched", canariesReady,
 			"paused", canary.Spec.Paused,
 			"generation", canary.Generation,
 			"observed_generation", canary.Status.ObservedGeneration,
@@ -337,10 +339,28 @@ func (c *PhasedDeploymentController) reconcileDeployment(ctx context.Context, de
 			c.blocked.DeleteLabelValues(dep.Name, "config")
 			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for canary %q to reach revision %s", canaryName, revision))
 		}
-		if !canaryReady {
+		if !canariesReady && !canaryReady {
 			c.setPhaseMetric(dep.Name, config.RolloutDependencyPhaseWaiting)
 			c.blocked.DeleteLabelValues(dep.Name, "config")
 			return c.ensurePhase(ctx, dep, config.RolloutDependencyPhaseWaiting, fmt.Sprintf("waiting for canary %q to become fully rolled out", canaryName))
+		}
+	}
+
+	if !canariesReady {
+		level.Info(c.logger).Log(
+			"msg", "latching phased deployment canaries ready",
+			"deployment", dep.Name,
+			"canaries", strings.Join(canaries, ","),
+			"revision", revision,
+		)
+		if err := c.patchDeployment(ctx, dep.Name, map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					config.RolloutCanariesReadyRevisionAnnotationKey: revision,
+				},
+			},
+		}); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/controller/phased_deployment.go
+++ b/pkg/controller/phased_deployment.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -51,6 +52,11 @@ type PhasedDeploymentController struct {
 
 	shouldReconcile atomic.Bool
 	stopCh          chan struct{}
+	stopOnce        sync.Once
+	healthTimerMu   sync.Mutex
+	healthTimer     *time.Timer
+	healthTimerAt   time.Time
+	healthWakeCh    chan struct{}
 
 	phase             *prometheus.GaugeVec
 	blocked           *prometheus.GaugeVec
@@ -81,6 +87,7 @@ func NewPhasedDeploymentController(kubeClient kubernetes.Interface, namespace st
 		logger:              logger,
 		now:                 time.Now,
 		stopCh:              make(chan struct{}),
+		healthWakeCh:        make(chan struct{}, 1),
 		phase: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "rollout_operator_phased_deployment_phase",
 			Help: "Current phased Deployment gate phase (1=active for labeled phase).",
@@ -152,13 +159,24 @@ func (c *PhasedDeploymentController) Run() {
 		select {
 		case <-c.stopCh:
 			return
+		case <-c.healthWakeCh:
+			// Health deadlines must not wait for unrelated informer events or the regular throttle.
 		case <-time.After(c.reconcileInterval):
 		}
 	}
 }
 
 func (c *PhasedDeploymentController) Stop() {
-	close(c.stopCh)
+	c.stopOnce.Do(func() {
+		c.healthTimerMu.Lock()
+		if c.healthTimer != nil {
+			c.healthTimer.Stop()
+			c.healthTimer = nil
+			c.healthTimerAt = time.Time{}
+		}
+		c.healthTimerMu.Unlock()
+		close(c.stopCh)
+	})
 }
 
 func (c *PhasedDeploymentController) enqueueReconcile() {
@@ -169,6 +187,7 @@ func (c *PhasedDeploymentController) reconcile(ctx context.Context) error {
 	c.reconcileTotal.Inc()
 	timer := prometheus.NewTimer(c.reconcileDuration)
 	defer timer.ObserveDuration()
+	c.resetHealthRequeue()
 
 	deps, err := c.deploymentLister.Deployments(c.namespace).List(labels.Everything())
 	if err != nil {
@@ -470,7 +489,67 @@ func (c *PhasedDeploymentController) evaluateDeploymentHealthGate(ctx context.Co
 		BaselineTime:      baseline,
 		Now:               c.now(),
 	})
+	if decision.ShouldPause && decision.RequeueAfter > 0 {
+		c.scheduleHealthRequeue(decision.RequeueAfter, dep.Name, annotationOrEmpty(dep, config.RolloutHealthCheckAnnotationKey))
+	}
 	return decision.ShouldPause, decision.Reason, nil
+}
+
+func (c *PhasedDeploymentController) resetHealthRequeue() {
+	c.healthTimerMu.Lock()
+	defer c.healthTimerMu.Unlock()
+	if c.healthTimer != nil {
+		c.healthTimer.Stop()
+		c.healthTimer = nil
+		c.healthTimerAt = time.Time{}
+	}
+}
+
+func (c *PhasedDeploymentController) scheduleHealthRequeue(after time.Duration, deployment, policy string) {
+	if after <= 0 {
+		return
+	}
+
+	due := time.Now().Add(after)
+	c.healthTimerMu.Lock()
+	defer c.healthTimerMu.Unlock()
+	if c.healthTimer != nil && !due.Before(c.healthTimerAt) {
+		return
+	}
+	if c.healthTimer != nil {
+		c.healthTimer.Stop()
+	}
+
+	var timer *time.Timer
+	timer = time.AfterFunc(after, func() {
+		c.healthTimerMu.Lock()
+		if c.healthTimer != timer {
+			c.healthTimerMu.Unlock()
+			return
+		}
+		c.healthTimer = nil
+		c.healthTimerAt = time.Time{}
+		c.healthTimerMu.Unlock()
+
+		select {
+		case <-c.stopCh:
+			return
+		default:
+			c.enqueueReconcile()
+			select {
+			case c.healthWakeCh <- struct{}{}:
+			default:
+			}
+		}
+	})
+	c.healthTimer = timer
+	c.healthTimerAt = due
+	level.Debug(c.logger).Log(
+		"msg", "scheduled phased deployment health check reevaluation",
+		"deployment", deployment,
+		"policy", policy,
+		"requeue_after", after,
+	)
 }
 
 func deploymentHealthGroup(dep *appsv1.Deployment) string {

--- a/pkg/controller/phased_deployment_test.go
+++ b/pkg/controller/phased_deployment_test.go
@@ -1,0 +1,208 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/phased"
+)
+
+func TestPhasedDeploymentController_WaitsForUpstreamThenSoaks(t *testing.T) {
+	replicas := int32(2)
+	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
+	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+
+	pods := []runtime.Object{
+		mockDeploymentPod("zone-a", "zone-a-0", "uid-a0", 0),
+		mockDeploymentPod("zone-a", "zone-a-1", "uid-a1", 0),
+	}
+
+	api := fake.NewSimpleClientset(append([]runtime.Object{upstream, follower}, pods...)...)
+	c := newTestPhasedController(t, api)
+	require.NoError(t, c.reconcile(context.Background()))
+
+	follower, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseSoaking, phased.Phase(follower))
+	require.True(t, follower.Spec.Paused)
+	require.NotEmpty(t, follower.Annotations[config.RolloutSoakStartedAtAnnotationKey])
+	require.NotEmpty(t, follower.Annotations[config.RolloutRestartBaselineAnnotationKey])
+}
+
+func TestPhasedDeploymentController_CompletesAfterSoakWithLowRestarts(t *testing.T) {
+	replicas := int32(2)
+	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
+	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseSoaking
+	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	follower.Annotations[config.RolloutSoakStartedAtAnnotationKey] = time.Now().UTC().Add(-6 * time.Minute).Format(time.RFC3339)
+	baseline, err := phased.EncodeRestartBaseline(phased.RestartBaseline{"uid-a0/app": 0, "uid-a1/app": 0})
+	require.NoError(t, err)
+	follower.Annotations[config.RolloutRestartBaselineAnnotationKey] = baseline
+	follower.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
+
+	pods := []runtime.Object{
+		mockDeploymentPod("zone-a", "zone-a-0", "uid-a0", 0),
+		mockDeploymentPod("zone-a", "zone-a-1", "uid-a1", 0),
+	}
+	api := fake.NewSimpleClientset(append([]runtime.Object{upstream, follower}, pods...)...)
+	c := newTestPhasedController(t, api)
+	require.NoError(t, c.reconcile(context.Background()))
+
+	follower, err = api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(follower))
+	require.False(t, follower.Spec.Paused)
+}
+
+func TestPhasedDeploymentController_BlocksOnHighRestartRatio(t *testing.T) {
+	replicas := int32(2)
+	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
+	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseSoaking
+	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	follower.Annotations[config.RolloutSoakStartedAtAnnotationKey] = time.Now().UTC().Add(-6 * time.Minute).Format(time.RFC3339)
+	baseline, err := phased.EncodeRestartBaseline(phased.RestartBaseline{"uid-a0/app": 0, "uid-a1/app": 0})
+	require.NoError(t, err)
+	follower.Annotations[config.RolloutRestartBaselineAnnotationKey] = baseline
+
+	// 1 restart across 2 pods => ratio 0.5 >= 0.1
+	pods := []runtime.Object{
+		mockDeploymentPod("zone-a", "zone-a-0", "uid-a0", 1),
+		mockDeploymentPod("zone-a", "zone-a-1", "uid-a1", 0),
+	}
+	api := fake.NewSimpleClientset(append([]runtime.Object{upstream, follower}, pods...)...)
+	c := newTestPhasedController(t, api)
+	require.NoError(t, c.reconcile(context.Background()))
+
+	follower, err = api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseBlocked, phased.Phase(follower))
+	require.True(t, follower.Spec.Paused)
+}
+
+func TestPhasedDeploymentController_ResumeUnpausesImmediately(t *testing.T) {
+	replicas := int32(1)
+	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
+	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseBlocked
+	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	follower.Annotations[config.RolloutResumeAnnotationKey] = "r1"
+	follower.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
+
+	api := fake.NewSimpleClientset(upstream, follower)
+	c := newTestPhasedController(t, api)
+	require.NoError(t, c.reconcile(context.Background()))
+
+	follower, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(follower))
+	require.False(t, follower.Spec.Paused)
+	require.Empty(t, follower.Annotations[config.RolloutResumeAnnotationKey])
+}
+
+func TestPhasedDeploymentController_ResetsSoakWhenUpstreamUnhealthy(t *testing.T) {
+	replicas := int32(2)
+	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, false) // not fully rolled out
+	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseSoaking
+	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	follower.Annotations[config.RolloutSoakStartedAtAnnotationKey] = time.Now().UTC().Add(-1 * time.Minute).Format(time.RFC3339)
+	follower.Annotations[config.RolloutRestartBaselineAnnotationKey] = `{}`
+
+	api := fake.NewSimpleClientset(upstream, follower)
+	c := newTestPhasedController(t, api)
+	require.NoError(t, c.reconcile(context.Background()))
+
+	follower, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseWaiting, phased.Phase(follower))
+	require.Empty(t, follower.Annotations[config.RolloutSoakStartedAtAnnotationKey])
+}
+
+func newTestPhasedController(t *testing.T, api *fake.Clientset) *PhasedDeploymentController {
+	t.Helper()
+	c := NewPhasedDeploymentController(api, testNamespace, time.Second, prometheus.NewRegistry(), log.NewNopLogger())
+	require.NoError(t, c.Init())
+	t.Cleanup(c.Stop)
+	return c
+}
+
+func mockPhasedDeployment(name, dependsOn, revision string, paused bool, replicas int32, fullyRolledOut bool) *appsv1.Deployment {
+	labels := map[string]string{
+		config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue,
+		"name":                       name,
+	}
+	ann := map[string]string{
+		config.RolloutRevisionAnnotationKey: revision,
+	}
+	if dependsOn != "" {
+		ann[config.RolloutDependsOnAnnotationKey] = dependsOn
+	}
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   testNamespace,
+			Labels:      labels,
+			Annotations: ann,
+			Generation:  1,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Paused:   paused,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": name}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"name": name}},
+			},
+		},
+	}
+	if fullyRolledOut {
+		d.Status = appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			Replicas:           replicas,
+			UpdatedReplicas:    replicas,
+			ReadyReplicas:      replicas,
+			AvailableReplicas:  replicas,
+		}
+	} else {
+		d.Status = appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			Replicas:           replicas,
+			UpdatedReplicas:    replicas - 1,
+			ReadyReplicas:      replicas - 1,
+			AvailableReplicas:  replicas - 1,
+		}
+	}
+	return d
+}
+
+func mockDeploymentPod(deployName, podName, uid string, restarts int32) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: testNamespace,
+			UID:       types.UID(uid),
+			Labels:    map[string]string{"name": deployName},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", Ready: true, RestartCount: restarts, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+			},
+		},
+	}
+}

--- a/pkg/controller/phased_deployment_test.go
+++ b/pkg/controller/phased_deployment_test.go
@@ -60,9 +60,33 @@ func TestPhasedDeploymentController_CompletesWhenCanaryReady(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(main))
 	require.False(t, main.Spec.Paused)
+	require.Equal(t, "r1", phased.CanariesReadyRevision(main))
 	require.Contains(t, logs.String(), `msg="phased deployment canaries ready"`)
 	require.Contains(t, logs.String(), `msg="completing phased deployment gate"`)
 	require.Contains(t, logs.String(), "action=unpause-and-proceed")
+}
+
+func TestPhasedDeploymentController_LatchedCanaryReadinessDoesNotRegress(t *testing.T) {
+	replicas := int32(2)
+	canary := mockPhasedDeployment("zone-a", "", "r1", false, replicas, false)
+	canary.Status.UpdatedReplicas = replicas
+	main := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	main.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	main.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
+	main.Annotations[config.RolloutCanariesReadyRevisionAnnotationKey] = "r1"
+
+	api := fake.NewSimpleClientset(canary, main)
+	var logs bytes.Buffer
+	c := newTestPhasedControllerWithLogger(t, api, log.NewLogfmtLogger(&logs))
+	require.NoError(t, c.reconcile(context.Background()))
+
+	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(main))
+	require.False(t, main.Spec.Paused)
+	require.Contains(t, logs.String(), "ready=false")
+	require.Contains(t, logs.String(), "ready_latched=true")
 }
 
 func TestPhasedDeploymentController_WaitsForAllCanaries(t *testing.T) {

--- a/pkg/controller/phased_deployment_test.go
+++ b/pkg/controller/phased_deployment_test.go
@@ -1,7 +1,9 @@
 package controller
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,7 +27,8 @@ func TestPhasedDeploymentController_WaitsForCanary(t *testing.T) {
 	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
 
 	api := fake.NewSimpleClientset(canary, main)
-	c := newTestPhasedController(t, api)
+	var logs bytes.Buffer
+	c := newTestPhasedControllerWithLogger(t, api, log.NewLogfmtLogger(&logs))
 	require.NoError(t, c.reconcile(context.Background()))
 
 	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
@@ -33,6 +36,11 @@ func TestPhasedDeploymentController_WaitsForCanary(t *testing.T) {
 	require.Equal(t, config.RolloutDependencyPhaseWaiting, phased.Phase(main))
 	require.True(t, main.Spec.Paused)
 	require.Contains(t, main.Annotations[config.RolloutDependencyReasonAnnotationKey], "fully rolled out")
+	require.Contains(t, logs.String(), `msg="checking phased deployment canary"`)
+	require.Contains(t, logs.String(), "current_revision=r1")
+	require.Contains(t, logs.String(), "target_revision=r1")
+	require.Contains(t, logs.String(), "ready=false")
+	require.True(t, strings.Contains(logs.String(), `msg="holding phased deployment"`))
 }
 
 func TestPhasedDeploymentController_CompletesWhenCanaryReady(t *testing.T) {
@@ -44,13 +52,17 @@ func TestPhasedDeploymentController_CompletesWhenCanaryReady(t *testing.T) {
 	main.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
 
 	api := fake.NewSimpleClientset(canary, main)
-	c := newTestPhasedController(t, api)
+	var logs bytes.Buffer
+	c := newTestPhasedControllerWithLogger(t, api, log.NewLogfmtLogger(&logs))
 	require.NoError(t, c.reconcile(context.Background()))
 
 	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(main))
 	require.False(t, main.Spec.Paused)
+	require.Contains(t, logs.String(), `msg="phased deployment canaries ready"`)
+	require.Contains(t, logs.String(), `msg="completing phased deployment gate"`)
+	require.Contains(t, logs.String(), "action=unpause-and-proceed")
 }
 
 func TestPhasedDeploymentController_WaitsForAllCanaries(t *testing.T) {
@@ -147,8 +159,12 @@ func TestPhasedDeploymentController_BypassHonorsPreExistingPause(t *testing.T) {
 }
 
 func newTestPhasedController(t *testing.T, api *fake.Clientset) *PhasedDeploymentController {
+	return newTestPhasedControllerWithLogger(t, api, log.NewNopLogger())
+}
+
+func newTestPhasedControllerWithLogger(t *testing.T, api *fake.Clientset, logger log.Logger) *PhasedDeploymentController {
 	t.Helper()
-	c := NewPhasedDeploymentController(api, testNamespace, time.Second, prometheus.NewRegistry(), log.NewNopLogger())
+	c := NewPhasedDeploymentController(api, testNamespace, time.Second, prometheus.NewRegistry(), logger)
 	require.NoError(t, c.Init())
 	t.Cleanup(c.Stop)
 	return c

--- a/pkg/controller/phased_deployment_test.go
+++ b/pkg/controller/phased_deployment_test.go
@@ -11,127 +11,137 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/grafana/rollout-operator/pkg/config"
 	"github.com/grafana/rollout-operator/pkg/phased"
 )
 
-func TestPhasedDeploymentController_WaitsForUpstreamThenSoaks(t *testing.T) {
+func TestPhasedDeploymentController_WaitsForCanary(t *testing.T) {
 	replicas := int32(2)
-	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
-	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
-	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
-	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	canary := mockPhasedDeployment("zone-a", "", "r1", false, replicas, false)
+	main := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	main.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
 
-	pods := []runtime.Object{
-		mockDeploymentPod("zone-a", "zone-a-0", "uid-a0", 0),
-		mockDeploymentPod("zone-a", "zone-a-1", "uid-a1", 0),
-	}
-
-	api := fake.NewSimpleClientset(append([]runtime.Object{upstream, follower}, pods...)...)
+	api := fake.NewSimpleClientset(canary, main)
 	c := newTestPhasedController(t, api)
 	require.NoError(t, c.reconcile(context.Background()))
 
-	follower, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, config.RolloutDependencyPhaseSoaking, phased.Phase(follower))
-	require.True(t, follower.Spec.Paused)
-	require.NotEmpty(t, follower.Annotations[config.RolloutSoakStartedAtAnnotationKey])
-	require.NotEmpty(t, follower.Annotations[config.RolloutRestartBaselineAnnotationKey])
+	require.Equal(t, config.RolloutDependencyPhaseWaiting, phased.Phase(main))
+	require.True(t, main.Spec.Paused)
+	require.Contains(t, main.Annotations[config.RolloutDependencyReasonAnnotationKey], "fully rolled out")
 }
 
-func TestPhasedDeploymentController_CompletesAfterSoakWithLowRestarts(t *testing.T) {
+func TestPhasedDeploymentController_CompletesWhenCanaryReady(t *testing.T) {
 	replicas := int32(2)
-	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
-	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
-	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseSoaking
-	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
-	follower.Annotations[config.RolloutSoakStartedAtAnnotationKey] = time.Now().UTC().Add(-6 * time.Minute).Format(time.RFC3339)
-	baseline, err := phased.EncodeRestartBaseline(phased.RestartBaseline{"uid-a0/app": 0, "uid-a1/app": 0})
-	require.NoError(t, err)
-	follower.Annotations[config.RolloutRestartBaselineAnnotationKey] = baseline
-	follower.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
+	canary := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
+	main := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	main.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	main.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
 
-	pods := []runtime.Object{
-		mockDeploymentPod("zone-a", "zone-a-0", "uid-a0", 0),
-		mockDeploymentPod("zone-a", "zone-a-1", "uid-a1", 0),
-	}
-	api := fake.NewSimpleClientset(append([]runtime.Object{upstream, follower}, pods...)...)
+	api := fake.NewSimpleClientset(canary, main)
 	c := newTestPhasedController(t, api)
 	require.NoError(t, c.reconcile(context.Background()))
 
-	follower, err = api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(follower))
-	require.False(t, follower.Spec.Paused)
+	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(main))
+	require.False(t, main.Spec.Paused)
 }
 
-func TestPhasedDeploymentController_BlocksOnHighRestartRatio(t *testing.T) {
-	replicas := int32(2)
-	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
-	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
-	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseSoaking
-	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
-	follower.Annotations[config.RolloutSoakStartedAtAnnotationKey] = time.Now().UTC().Add(-6 * time.Minute).Format(time.RFC3339)
-	baseline, err := phased.EncodeRestartBaseline(phased.RestartBaseline{"uid-a0/app": 0, "uid-a1/app": 0})
-	require.NoError(t, err)
-	follower.Annotations[config.RolloutRestartBaselineAnnotationKey] = baseline
-
-	// 1 restart across 2 pods => ratio 0.5 >= 0.1
-	pods := []runtime.Object{
-		mockDeploymentPod("zone-a", "zone-a-0", "uid-a0", 1),
-		mockDeploymentPod("zone-a", "zone-a-1", "uid-a1", 0),
-	}
-	api := fake.NewSimpleClientset(append([]runtime.Object{upstream, follower}, pods...)...)
-	c := newTestPhasedController(t, api)
-	require.NoError(t, c.reconcile(context.Background()))
-
-	follower, err = api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
-	require.NoError(t, err)
-	require.Equal(t, config.RolloutDependencyPhaseBlocked, phased.Phase(follower))
-	require.True(t, follower.Spec.Paused)
-}
-
-func TestPhasedDeploymentController_ResumeUnpausesImmediately(t *testing.T) {
+func TestPhasedDeploymentController_WaitsForAllCanaries(t *testing.T) {
 	replicas := int32(1)
-	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
-	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
-	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseBlocked
-	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
-	follower.Annotations[config.RolloutResumeAnnotationKey] = "r1"
-	follower.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
+	qf := mockPhasedDeployment("query-frontend-zone-a", "", "r1", false, replicas, true)
+	querier := mockPhasedDeployment("querier-zone-a", "", "r1", false, replicas, false)
+	main := mockPhasedDeployment("querier-zone-b", "querier-zone-a,query-frontend-zone-a", "r1", true, replicas, false)
+	main.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
 
-	api := fake.NewSimpleClientset(upstream, follower)
+	api := fake.NewSimpleClientset(qf, querier, main)
 	c := newTestPhasedController(t, api)
 	require.NoError(t, c.reconcile(context.Background()))
 
-	follower, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "querier-zone-b", metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(follower))
-	require.False(t, follower.Spec.Paused)
-	require.Empty(t, follower.Annotations[config.RolloutResumeAnnotationKey])
+	require.Equal(t, config.RolloutDependencyPhaseWaiting, phased.Phase(main))
+	require.Contains(t, main.Annotations[config.RolloutDependencyReasonAnnotationKey], "querier-zone-a")
+
+	querier.Status.UpdatedReplicas = replicas
+	querier.Status.ReadyReplicas = replicas
+	querier.Status.AvailableReplicas = replicas
+	_, err = api.AppsV1().Deployments(testNamespace).Update(context.Background(), querier, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	// Refresh informer by waiting briefly and re-init is heavy; reconcile uses lister which may be stale.
+	// Force a fresh controller against updated API.
+	c = newTestPhasedController(t, api)
+	require.NoError(t, c.reconcile(context.Background()))
+
+	main, err = api.AppsV1().Deployments(testNamespace).Get(context.Background(), "querier-zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(main))
+	require.False(t, main.Spec.Paused)
 }
 
-func TestPhasedDeploymentController_ResetsSoakWhenUpstreamUnhealthy(t *testing.T) {
-	replicas := int32(2)
-	upstream := mockPhasedDeployment("zone-a", "", "r1", false, replicas, false) // not fully rolled out
-	follower := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
-	follower.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseSoaking
-	follower.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
-	follower.Annotations[config.RolloutSoakStartedAtAnnotationKey] = time.Now().UTC().Add(-1 * time.Minute).Format(time.RFC3339)
-	follower.Annotations[config.RolloutRestartBaselineAnnotationKey] = `{}`
+func TestPhasedDeploymentController_BypassUnpauses(t *testing.T) {
+	replicas := int32(1)
+	canary := mockPhasedDeployment("zone-a", "", "r1", false, replicas, false)
+	main := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	main.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	main.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
+	main.Annotations[config.RolloutBypassUntilAnnotationKey] = time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
 
-	api := fake.NewSimpleClientset(upstream, follower)
+	api := fake.NewSimpleClientset(canary, main)
 	c := newTestPhasedController(t, api)
 	require.NoError(t, c.reconcile(context.Background()))
 
-	follower, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, config.RolloutDependencyPhaseWaiting, phased.Phase(follower))
-	require.Empty(t, follower.Annotations[config.RolloutSoakStartedAtAnnotationKey])
+	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(main))
+	require.False(t, main.Spec.Paused)
+
+	events, err := api.CoreV1().Events(testNamespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, events.Items, 1)
+	require.Equal(t, bypassEventReason, events.Items[0].Reason)
+
+	// Second reconcile must not re-emit bypass telemetry.
+	require.NoError(t, c.reconcile(context.Background()))
+	events, err = api.CoreV1().Events(testNamespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, events.Items, 1)
+}
+
+func TestPhasedDeploymentController_BypassHonorsPreExistingPause(t *testing.T) {
+	replicas := int32(1)
+	canary := mockPhasedDeployment("zone-a", "", "r1", false, replicas, false)
+	main := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	main.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	main.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationTrue
+	main.Annotations[config.RolloutBypassUntilAnnotationKey] = time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+
+	api := fake.NewSimpleClientset(canary, main)
+	c := newTestPhasedController(t, api)
+	require.NoError(t, c.reconcile(context.Background()))
+
+	main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, config.RolloutDependencyPhaseComplete, phased.Phase(main))
+	require.True(t, main.Spec.Paused)
+
+	events, err := api.CoreV1().Events(testNamespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, events.Items, 1)
+
+	require.NoError(t, c.reconcile(context.Background()))
+	events, err = api.CoreV1().Events(testNamespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, events.Items, 1)
 }
 
 func newTestPhasedController(t *testing.T, api *fake.Clientset) *PhasedDeploymentController {
@@ -142,7 +152,7 @@ func newTestPhasedController(t *testing.T, api *fake.Clientset) *PhasedDeploymen
 	return c
 }
 
-func mockPhasedDeployment(name, dependsOn, revision string, paused bool, replicas int32, fullyRolledOut bool) *appsv1.Deployment {
+func mockPhasedDeployment(name, canaries, revision string, paused bool, replicas int32, fullyRolledOut bool) *appsv1.Deployment {
 	labels := map[string]string{
 		config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue,
 		"name":                       name,
@@ -150,8 +160,8 @@ func mockPhasedDeployment(name, dependsOn, revision string, paused bool, replica
 	ann := map[string]string{
 		config.RolloutRevisionAnnotationKey: revision,
 	}
-	if dependsOn != "" {
-		ann[config.RolloutDependsOnAnnotationKey] = dependsOn
+	if canaries != "" {
+		ann[config.RolloutCanaryAnnotationKey] = canaries
 	}
 	d := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -188,21 +198,4 @@ func mockPhasedDeployment(name, dependsOn, revision string, paused bool, replica
 		}
 	}
 	return d
-}
-
-func mockDeploymentPod(deployName, podName, uid string, restarts int32) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: testNamespace,
-			UID:       types.UID(uid),
-			Labels:    map[string]string{"name": deployName},
-		},
-		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
-			ContainerStatuses: []corev1.ContainerStatus{
-				{Name: "app", Ready: true, RestartCount: restarts, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
-			},
-		},
-	}
 }

--- a/pkg/controller/phased_deployment_test.go
+++ b/pkg/controller/phased_deployment_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,8 +17,35 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/healthcheck"
 	"github.com/grafana/rollout-operator/pkg/phased"
 )
+
+type phasedRequeueGate struct {
+	mu        sync.Mutex
+	decisions []healthcheck.Decision
+	calls     int
+	called    chan struct{}
+}
+
+func (g *phasedRequeueGate) Evaluate(_ context.Context, _ healthcheck.Request) healthcheck.Decision {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	index := min(g.calls, len(g.decisions)-1)
+	decision := g.decisions[index]
+	g.calls++
+	select {
+	case g.called <- struct{}{}:
+	default:
+	}
+	return decision
+}
+
+func (g *phasedRequeueGate) callCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.calls
+}
 
 func TestPhasedDeploymentController_WaitsForCanary(t *testing.T) {
 	replicas := int32(2)
@@ -108,6 +136,91 @@ func TestPhasedDeploymentController_HealthCheckGatesReadyCanary(t *testing.T) {
 			require.NotEmpty(t, canary.Annotations[config.RolloutHealthCheckStartedAtAnnotationKey])
 		})
 	}
+}
+
+func TestPhasedDeploymentController_HealthDeadlineTriggersReconcile(t *testing.T) {
+	replicas := int32(1)
+	canary := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
+	canary.Annotations[config.RolloutHealthCheckStartedAtAnnotationKey] = healthcheck.FormatStartedAtAnnotation("r1", time.Now().Add(-time.Minute))
+	main := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+	main.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+	main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+	main.Annotations[config.RolloutDependencyReasonAnnotationKey] = "blocked by health"
+	main.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
+	main.Annotations[config.RolloutHealthCheckAnnotationKey] = "deployment-health"
+
+	candidatePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "zone-a-0", Namespace: testNamespace, Labels: map[string]string{"name": "zone-a"}}}
+	stablePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "zone-b-0", Namespace: testNamespace, Labels: map[string]string{"name": "zone-b"}}}
+	api := fake.NewSimpleClientset(canary, main, candidatePod, stablePod)
+	var logs bytes.Buffer
+	c := newTestPhasedControllerWithLogger(t, api, log.NewLogfmtLogger(&logs))
+	c.reconcileInterval = time.Hour
+	gate := &phasedRequeueGate{
+		decisions: []healthcheck.Decision{
+			{ShouldPause: true, Reason: "blocked by health", RequeueAfter: 25 * time.Millisecond},
+			{},
+		},
+		called: make(chan struct{}, 2),
+	}
+	c.SetHealthCheck(gate, nil)
+
+	require.NoError(t, c.reconcile(context.Background()))
+	require.Equal(t, 1, gate.callCount())
+	c.shouldReconcile.Store(false)
+
+	runDone := make(chan struct{})
+	go func() {
+		c.Run()
+		close(runDone)
+	}()
+
+	select {
+	case <-gate.called:
+	case <-time.After(time.Second):
+		t.Fatal("health deadline did not trigger a phased Deployment reconcile")
+	}
+	if gate.callCount() < 2 {
+		select {
+		case <-gate.called:
+		case <-time.After(time.Second):
+			t.Fatal("health deadline did not trigger a second gate evaluation")
+		}
+	}
+	require.GreaterOrEqual(t, gate.callCount(), 2)
+
+	c.Stop()
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatal("phased Deployment controller did not stop")
+	}
+	require.Contains(t, logs.String(), `msg="scheduled phased deployment health check reevaluation"`)
+	require.Contains(t, logs.String(), "deployment=zone-b")
+	require.Contains(t, logs.String(), "policy=deployment-health")
+}
+
+func TestPhasedDeploymentController_HealthRequeueKeepsEarliestDeadline(t *testing.T) {
+	var logs bytes.Buffer
+	c := &PhasedDeploymentController{
+		logger:       log.NewLogfmtLogger(&logs),
+		stopCh:       make(chan struct{}),
+		healthWakeCh: make(chan struct{}, 1),
+	}
+	t.Cleanup(c.Stop)
+
+	c.scheduleHealthRequeue(2*time.Second, "zone-b", "slow")
+	c.scheduleHealthRequeue(5*time.Second, "zone-c", "later")
+	c.scheduleHealthRequeue(500*time.Millisecond, "zone-d", "fast")
+
+	c.healthTimerMu.Lock()
+	timerScheduled := c.healthTimer != nil
+	timerDelay := time.Until(c.healthTimerAt)
+	c.healthTimerMu.Unlock()
+	require.True(t, timerScheduled)
+	require.InDelta(t, 500*time.Millisecond, timerDelay, float64(100*time.Millisecond))
+	require.Contains(t, logs.String(), "deployment=zone-d")
+	require.Contains(t, logs.String(), "policy=fast")
+	require.NotContains(t, logs.String(), "policy=later")
 }
 
 func TestPhasedDeploymentController_ClearsHealthStateWhenCanaryRemoved(t *testing.T) {

--- a/pkg/controller/phased_deployment_test.go
+++ b/pkg/controller/phased_deployment_test.go
@@ -110,6 +110,7 @@ func TestPhasedDeploymentController_BypassUnpauses(t *testing.T) {
 	require.Equal(t, bypassEventReason, events.Items[0].Reason)
 
 	// Second reconcile must not re-emit bypass telemetry.
+	c = newTestPhasedController(t, api)
 	require.NoError(t, c.reconcile(context.Background()))
 	events, err = api.CoreV1().Events(testNamespace).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
@@ -138,6 +139,7 @@ func TestPhasedDeploymentController_BypassHonorsPreExistingPause(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, events.Items, 1)
 
+	c = newTestPhasedController(t, api)
 	require.NoError(t, c.reconcile(context.Background()))
 	events, err = api.CoreV1().Events(testNamespace).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)

--- a/pkg/controller/phased_deployment_test.go
+++ b/pkg/controller/phased_deployment_test.go
@@ -53,6 +53,67 @@ func TestPhasedDeploymentController_CompletesWhenCanaryReady(t *testing.T) {
 	require.False(t, main.Spec.Paused)
 }
 
+func TestPhasedDeploymentController_HealthCheckGatesReadyCanary(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		shouldPause bool
+		wantPhase   string
+		wantPaused  bool
+	}{
+		{name: "blocked", shouldPause: true, wantPhase: config.RolloutDependencyPhaseWaiting, wantPaused: true},
+		{name: "passing", shouldPause: false, wantPhase: config.RolloutDependencyPhaseComplete, wantPaused: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			replicas := int32(1)
+			canary := mockPhasedDeployment("zone-a", "", "r1", false, replicas, true)
+			main := mockPhasedDeployment("zone-b", "zone-a", "r1", true, replicas, false)
+			main.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseWaiting
+			main.Annotations[config.RolloutDependencyRevisionAnnotationKey] = "r1"
+			main.Annotations[config.RolloutHadPausedAnnotationKey] = phased.HadPausedAnnotationFalse
+			main.Annotations[config.RolloutHealthCheckAnnotationKey] = "deployment-health"
+
+			candidatePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "zone-a-0", Namespace: testNamespace, Labels: map[string]string{"name": "zone-a"}}}
+			stablePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "zone-b-0", Namespace: testNamespace, Labels: map[string]string{"name": "zone-b"}}}
+			api := fake.NewSimpleClientset(canary, main, candidatePod, stablePod)
+			c := newTestPhasedController(t, api)
+			gate := &mockHealthGate{shouldPause: tc.shouldPause}
+			c.SetHealthCheck(gate, nil)
+
+			require.NoError(t, c.reconcile(context.Background()))
+
+			main, err := api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-b", metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Equal(t, tc.wantPhase, phased.Phase(main))
+			require.Equal(t, tc.wantPaused, main.Spec.Paused)
+			require.Equal(t, 1, gate.callCount())
+			require.Equal(t, "zone-b", gate.lastReq.TargetName)
+			require.Equal(t, "Deployment", gate.lastReq.TargetKind)
+			require.Len(t, gate.lastReq.CandidatePods, 1)
+			require.Len(t, gate.lastReq.StablePods, 1)
+
+			canary, err = api.AppsV1().Deployments(testNamespace).Get(context.Background(), "zone-a", metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotEmpty(t, canary.Annotations[config.RolloutHealthCheckStartedAtAnnotationKey])
+		})
+	}
+}
+
+func TestPhasedDeploymentController_ClearsHealthStateWhenCanaryRemoved(t *testing.T) {
+	replicas := int32(1)
+	dep := mockPhasedDeployment("zone-b", "", "r1", false, replicas, true)
+	dep.Annotations[config.RolloutHealthCheckAnnotationKey] = "deployment-health"
+
+	api := fake.NewSimpleClientset(dep)
+	c := newTestPhasedController(t, api)
+	gate := &mockHealthGate{}
+	c.SetHealthCheck(gate, nil)
+
+	require.NoError(t, c.reconcile(context.Background()))
+	require.Equal(t, 1, gate.callCount())
+	require.Empty(t, gate.lastReq.TargetAnnotations)
+	require.Equal(t, "zone-b/Deployment/zone-b", gate.lastReq.StateKey)
+}
+
 func TestPhasedDeploymentController_WaitsForAllCanaries(t *testing.T) {
 	replicas := int32(1)
 	qf := mockPhasedDeployment("query-frontend-zone-a", "", "r1", false, replicas, true)

--- a/pkg/healthcheck/cache.go
+++ b/pkg/healthcheck/cache.go
@@ -1,0 +1,72 @@
+package healthcheck
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// configCache holds RolloutHealthCheck configs keyed by name.
+type configCache struct {
+	entries map[string]*Config
+	lock    sync.RWMutex
+}
+
+func newConfigCache() *configCache {
+	return &configCache{
+		entries: map[string]*Config{},
+	}
+}
+
+func (c *configCache) addOrUpdateRaw(obj *unstructured.Unstructured) (bool, int64, error) {
+	cfg, err := ParseAndValidate(obj)
+	if err != nil {
+		return false, -1, err
+	}
+	updated, generation := c.addOrUpdate(cfg)
+	return updated, generation, nil
+}
+
+func (c *configCache) addOrUpdate(cfg *Config) (bool, int64) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	oldCfg, found := c.entries[cfg.Name]
+	if found && oldCfg.Generation >= cfg.Generation {
+		return false, oldCfg.Generation
+	}
+	c.entries[cfg.Name] = cfg
+	return true, cfg.Generation
+}
+
+func (c *configCache) delete(generation int64, name string) (bool, int64) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	oldCfg, found := c.entries[name]
+	if !found {
+		return false, -1
+	}
+	if oldCfg.Generation > generation {
+		return false, oldCfg.Generation
+	}
+	delete(c.entries, name)
+	return true, oldCfg.Generation
+}
+
+// Get returns the cached config for name, or nil if missing.
+func (c *configCache) Get(name string) *Config {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.entries[name]
+}
+
+func (c *configCache) invalidate(name string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	delete(c.entries, name)
+}
+
+func (c *configCache) size() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return len(c.entries)
+}

--- a/pkg/healthcheck/cache.go
+++ b/pkg/healthcheck/cache.go
@@ -64,9 +64,3 @@ func (c *configCache) invalidate(name string) {
 	defer c.lock.Unlock()
 	delete(c.entries, name)
 }
-
-func (c *configCache) size() int {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-	return len(c.entries)
-}

--- a/pkg/healthcheck/config.go
+++ b/pkg/healthcheck/config.go
@@ -1,0 +1,270 @@
+package healthcheck
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	RolloutHealthCheckKind       = "RolloutHealthCheck"
+	RolloutHealthChecksPlural    = "rollouthealthchecks"
+	RolloutHealthChecksSpecGroup = "rollout-operator.grafana.com"
+	RolloutHealthChecksVersion   = "v1"
+
+	placeholderTargetMatchers = "${targetMatchers}"
+	placeholderRange          = "${range}"
+	placeholderCurrent        = "${current}"
+	placeholderBaseline       = "${baseline}"
+
+	defaultCurrentRange  = 5 * time.Minute
+	defaultBaselineRange = 10 * time.Minute
+	defaultQueryTimeout  = 10 * time.Second
+	defaultQueryRetries  = 3
+)
+
+// FailureAction controls how a failed or no-data check affects the rollout.
+type FailureAction string
+
+const (
+	ActionPause    FailureAction = "Pause"
+	ActionWarn     FailureAction = "Warn"
+	ActionDisabled FailureAction = "Disabled"
+)
+
+// Check is a single PromQL health check within a RolloutHealthCheck.
+type Check struct {
+	Name          string
+	CurrentRange  time.Duration
+	BaselineRange time.Duration
+	QueryTimeout  time.Duration
+	QueryRetries  int
+	OnFailure     FailureAction
+	OnNoData      FailureAction
+	Disabled      bool
+	Query         string
+	SuccessQuery  string
+}
+
+// Config is the parsed RolloutHealthCheck custom resource.
+type Config struct {
+	Name          string
+	Generation    int64
+	Selector      labels.Selector
+	PrometheusURL string
+	Checks        []Check
+}
+
+// MatchesLabels returns true if this Config's selector matches the given labels.
+func (c *Config) MatchesLabels(set labels.Set) bool {
+	if c.Selector == nil {
+		return false
+	}
+	return c.Selector.Matches(set)
+}
+
+// ParseAndValidate parses an unstructured RolloutHealthCheck into a Config.
+func ParseAndValidate(obj *unstructured.Unstructured) (*Config, error) {
+	if obj.GetKind() != RolloutHealthCheckKind {
+		return nil, fmt.Errorf("unexpected object kind - expecting %s", RolloutHealthCheckKind)
+	}
+
+	cfg := &Config{
+		Name:       obj.GetName(),
+		Generation: obj.GetGeneration(),
+	}
+
+	prometheusURL, found, err := unstructured.NestedString(obj.Object, "spec", "prometheusURL")
+	if err != nil {
+		return nil, fmt.Errorf("invalid prometheusURL: %w", err)
+	}
+	if !found || strings.TrimSpace(prometheusURL) == "" {
+		return nil, errors.New("invalid value: prometheusURL is required")
+	}
+	cfg.PrometheusURL = strings.TrimSpace(prometheusURL)
+	parsedURL, err := url.Parse(cfg.PrometheusURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid value: prometheusURL is not a valid URL: %w", err)
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return nil, errors.New("invalid value: prometheusURL scheme must be http or https")
+	}
+	if parsedURL.Host == "" {
+		return nil, errors.New("invalid value: prometheusURL must include a host")
+	}
+
+	if mlMap, found, err := unstructured.NestedStringMap(obj.Object, "spec", "selector", "matchLabels"); err != nil {
+		return nil, fmt.Errorf("invalid value: selector is not valid, got %v", err)
+	} else if !found || len(mlMap) == 0 {
+		return nil, errors.New("invalid value: selector.matchLabels is required")
+	} else {
+		cfg.Selector = labels.SelectorFromSet(mlMap)
+	}
+
+	rawChecks, found, err := unstructured.NestedSlice(obj.Object, "spec", "checks")
+	if err != nil {
+		return nil, fmt.Errorf("invalid checks: %w", err)
+	}
+	if !found || len(rawChecks) == 0 {
+		return nil, errors.New("invalid value: checks must contain at least one entry")
+	}
+
+	seenNames := map[string]struct{}{}
+	for i, raw := range rawChecks {
+		checkMap, ok := raw.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid value: checks[%d] must be an object", i)
+		}
+		check, err := parseCheck(checkMap, i)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := seenNames[check.Name]; exists {
+			return nil, fmt.Errorf("invalid value: duplicate check name %q", check.Name)
+		}
+		seenNames[check.Name] = struct{}{}
+		cfg.Checks = append(cfg.Checks, check)
+	}
+
+	return cfg, nil
+}
+
+func parseCheck(m map[string]interface{}, index int) (Check, error) {
+	check := Check{
+		CurrentRange:  defaultCurrentRange,
+		BaselineRange: defaultBaselineRange,
+		QueryTimeout:  defaultQueryTimeout,
+		QueryRetries:  defaultQueryRetries,
+		OnFailure:     ActionPause,
+		OnNoData:      ActionPause,
+	}
+
+	name, ok := m["name"].(string)
+	if !ok || strings.TrimSpace(name) == "" {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].name is required", index)
+	}
+	check.Name = strings.TrimSpace(name)
+
+	query, ok := m["query"].(string)
+	if !ok || strings.TrimSpace(query) == "" {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].query is required", index)
+	}
+	check.Query = query
+	if !strings.Contains(check.Query, placeholderTargetMatchers) {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].query must contain %s", index, placeholderTargetMatchers)
+	}
+	if !strings.Contains(check.Query, placeholderRange) {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].query must contain %s", index, placeholderRange)
+	}
+
+	successQuery, ok := m["successQuery"].(string)
+	if !ok || strings.TrimSpace(successQuery) == "" {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].successQuery is required", index)
+	}
+	check.SuccessQuery = successQuery
+	if !strings.Contains(check.SuccessQuery, placeholderCurrent) {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].successQuery must contain %s", index, placeholderCurrent)
+	}
+	if !strings.Contains(check.SuccessQuery, placeholderBaseline) {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].successQuery must contain %s", index, placeholderBaseline)
+	}
+
+	if v, found := m["currentRange"]; found {
+		d, err := parseDurationField(v, "currentRange", index)
+		if err != nil {
+			return Check{}, err
+		}
+		check.CurrentRange = d
+	}
+	if v, found := m["baselineRange"]; found {
+		d, err := parseDurationField(v, "baselineRange", index)
+		if err != nil {
+			return Check{}, err
+		}
+		check.BaselineRange = d
+	}
+	if v, found := m["queryTimeout"]; found {
+		d, err := parseDurationField(v, "queryTimeout", index)
+		if err != nil {
+			return Check{}, err
+		}
+		check.QueryTimeout = d
+	}
+	if v, found := m["queryRetries"]; found {
+		n, ok := asInt(v)
+		if !ok || n < 0 {
+			return Check{}, fmt.Errorf("invalid value: checks[%d].queryRetries must be >= 0", index)
+		}
+		check.QueryRetries = n
+	}
+	if v, found := m["onFailure"]; found {
+		action, err := parseFailureAction(v, "onFailure", index)
+		if err != nil {
+			return Check{}, err
+		}
+		check.OnFailure = action
+	}
+	if v, found := m["onNoData"]; found {
+		action, err := parseFailureAction(v, "onNoData", index)
+		if err != nil {
+			return Check{}, err
+		}
+		check.OnNoData = action
+	}
+	if v, found := m["disabled"]; found {
+		disabled, ok := v.(bool)
+		if !ok {
+			return Check{}, fmt.Errorf("invalid value: checks[%d].disabled must be a boolean", index)
+		}
+		check.Disabled = disabled
+	}
+
+	return check, nil
+}
+
+func parseDurationField(v interface{}, field string, index int) (time.Duration, error) {
+	s, ok := v.(string)
+	if !ok || strings.TrimSpace(s) == "" {
+		return 0, fmt.Errorf("invalid value: checks[%d].%s must be a duration string", index, field)
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid value: checks[%d].%s is not a valid duration: %w", index, field, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("invalid value: checks[%d].%s must be > 0", index, field)
+	}
+	return d, nil
+}
+
+func parseFailureAction(v interface{}, field string, index int) (FailureAction, error) {
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("invalid value: checks[%d].%s must be a string", index, field)
+	}
+	switch FailureAction(s) {
+	case ActionPause, ActionWarn, ActionDisabled:
+		return FailureAction(s), nil
+	default:
+		return "", fmt.Errorf("invalid value: checks[%d].%s must be Pause, Warn, or Disabled", index, field)
+	}
+}
+
+func asInt(v interface{}) (int, bool) {
+	switch n := v.(type) {
+	case int64:
+		return int(n), true
+	case int:
+		return n, true
+	case float64:
+		if n == float64(int(n)) {
+			return int(n), true
+		}
+	}
+	return 0, false
+}

--- a/pkg/healthcheck/config.go
+++ b/pkg/healthcheck/config.go
@@ -22,13 +22,19 @@ const (
 	placeholderCurrent        = "${current}"
 	placeholderBaseline       = "${baseline}"
 
-	defaultCurrentRange  = 5 * time.Minute
-	defaultBaselineRange = 10 * time.Minute
-	defaultQueryTimeout  = 10 * time.Second
-	defaultQueryRetries  = 3
+	defaultCurrentRange         = 5 * time.Minute
+	defaultBaselineRange        = 10 * time.Minute
+	defaultQueryTimeout         = 10 * time.Second
+	defaultErrorRetryInterval   = 10 * time.Second
+	defaultErrorMaxAttempts     = 3
+	defaultNoDataRetryInterval  = 30 * time.Second
+	defaultNoDataMaxAttempts    = 3
+	defaultReevaluationInterval = 2*time.Minute + 30*time.Second
+	defaultConsecutiveFailures  = 3
+	defaultConsecutiveSuccesses = 1
 )
 
-// FailureAction controls how a failed or no-data check affects the rollout.
+// FailureAction controls how a failed, no-data, or exhausted check affects the rollout.
 type FailureAction string
 
 const (
@@ -37,15 +43,30 @@ const (
 	ActionDisabled FailureAction = "Disabled"
 )
 
+// RetryPolicy controls retries for query errors or no-data responses.
+type RetryPolicy struct {
+	RetryInterval   time.Duration
+	MaxAttempts     int
+	ExhaustedAction FailureAction
+}
+
+// FailurePolicy controls how consecutive success/failure evaluations accumulate.
+type FailurePolicy struct {
+	ReevaluationInterval time.Duration
+	ConsecutiveFailures  int
+	ConsecutiveSuccesses int
+	ExceededAction       FailureAction
+}
+
 // Check is a single PromQL health check within a RolloutHealthCheck.
 type Check struct {
 	Name          string
 	CurrentRange  time.Duration
 	BaselineRange time.Duration
 	QueryTimeout  time.Duration
-	QueryRetries  int
-	OnFailure     FailureAction
-	OnNoData      FailureAction
+	ErrorPolicy   RetryPolicy
+	FailurePolicy FailurePolicy
+	NoDataPolicy  RetryPolicy
 	Disabled      bool
 	Query         string
 	SuccessQuery  string
@@ -139,9 +160,22 @@ func parseCheck(m map[string]interface{}, index int) (Check, error) {
 		CurrentRange:  defaultCurrentRange,
 		BaselineRange: defaultBaselineRange,
 		QueryTimeout:  defaultQueryTimeout,
-		QueryRetries:  defaultQueryRetries,
-		OnFailure:     ActionPause,
-		OnNoData:      ActionPause,
+		ErrorPolicy: RetryPolicy{
+			RetryInterval:   defaultErrorRetryInterval,
+			MaxAttempts:     defaultErrorMaxAttempts,
+			ExhaustedAction: ActionPause,
+		},
+		FailurePolicy: FailurePolicy{
+			ReevaluationInterval: defaultReevaluationInterval,
+			ConsecutiveFailures:  defaultConsecutiveFailures,
+			ConsecutiveSuccesses: defaultConsecutiveSuccesses,
+			ExceededAction:       ActionPause,
+		},
+		NoDataPolicy: RetryPolicy{
+			RetryInterval:   defaultNoDataRetryInterval,
+			MaxAttempts:     defaultNoDataMaxAttempts,
+			ExhaustedAction: ActionPause,
+		},
 	}
 
 	name, ok := m["name"].(string)
@@ -188,34 +222,6 @@ func parseCheck(m map[string]interface{}, index int) (Check, error) {
 		}
 		check.BaselineRange = d
 	}
-	if v, found := m["queryTimeout"]; found {
-		d, err := parseDurationField(v, "queryTimeout", index)
-		if err != nil {
-			return Check{}, err
-		}
-		check.QueryTimeout = d
-	}
-	if v, found := m["queryRetries"]; found {
-		n, ok := asInt(v)
-		if !ok || n < 0 {
-			return Check{}, fmt.Errorf("invalid value: checks[%d].queryRetries must be >= 0", index)
-		}
-		check.QueryRetries = n
-	}
-	if v, found := m["onFailure"]; found {
-		action, err := parseFailureAction(v, "onFailure", index)
-		if err != nil {
-			return Check{}, err
-		}
-		check.OnFailure = action
-	}
-	if v, found := m["onNoData"]; found {
-		action, err := parseFailureAction(v, "onNoData", index)
-		if err != nil {
-			return Check{}, err
-		}
-		check.OnNoData = action
-	}
 	if v, found := m["disabled"]; found {
 		disabled, ok := v.(bool)
 		if !ok {
@@ -223,8 +229,96 @@ func parseCheck(m map[string]interface{}, index int) (Check, error) {
 		}
 		check.Disabled = disabled
 	}
+	if v, found := m["errorPolicy"]; found {
+		policy, err := parseRetryPolicy(v, "errorPolicy", index, check.ErrorPolicy)
+		if err != nil {
+			return Check{}, err
+		}
+		check.ErrorPolicy = policy
+	}
+	if v, found := m["noDataPolicy"]; found {
+		policy, err := parseRetryPolicy(v, "noDataPolicy", index, check.NoDataPolicy)
+		if err != nil {
+			return Check{}, err
+		}
+		check.NoDataPolicy = policy
+	}
+	if v, found := m["failurePolicy"]; found {
+		policy, err := parseFailurePolicy(v, index, check.FailurePolicy)
+		if err != nil {
+			return Check{}, err
+		}
+		check.FailurePolicy = policy
+	}
 
 	return check, nil
+}
+
+func parseRetryPolicy(v interface{}, field string, index int, defaults RetryPolicy) (RetryPolicy, error) {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return RetryPolicy{}, fmt.Errorf("invalid value: checks[%d].%s must be an object", index, field)
+	}
+	policy := defaults
+	if raw, found := m["retryInterval"]; found {
+		d, err := parseDurationField(raw, field+".retryInterval", index)
+		if err != nil {
+			return RetryPolicy{}, err
+		}
+		policy.RetryInterval = d
+	}
+	if raw, found := m["maxAttempts"]; found {
+		n, ok := asInt(raw)
+		if !ok || n < 1 {
+			return RetryPolicy{}, fmt.Errorf("invalid value: checks[%d].%s.maxAttempts must be >= 1", index, field)
+		}
+		policy.MaxAttempts = n
+	}
+	if raw, found := m["exhaustedAction"]; found {
+		action, err := parseFailureAction(raw, field+".exhaustedAction", index)
+		if err != nil {
+			return RetryPolicy{}, err
+		}
+		policy.ExhaustedAction = action
+	}
+	return policy, nil
+}
+
+func parseFailurePolicy(v interface{}, index int, defaults FailurePolicy) (FailurePolicy, error) {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return FailurePolicy{}, fmt.Errorf("invalid value: checks[%d].failurePolicy must be an object", index)
+	}
+	policy := defaults
+	if raw, found := m["reevaluationInterval"]; found {
+		d, err := parseDurationField(raw, "failurePolicy.reevaluationInterval", index)
+		if err != nil {
+			return FailurePolicy{}, err
+		}
+		policy.ReevaluationInterval = d
+	}
+	if raw, found := m["consecutiveFailures"]; found {
+		n, ok := asInt(raw)
+		if !ok || n < 1 {
+			return FailurePolicy{}, fmt.Errorf("invalid value: checks[%d].failurePolicy.consecutiveFailures must be >= 1", index)
+		}
+		policy.ConsecutiveFailures = n
+	}
+	if raw, found := m["consecutiveSuccesses"]; found {
+		n, ok := asInt(raw)
+		if !ok || n < 1 {
+			return FailurePolicy{}, fmt.Errorf("invalid value: checks[%d].failurePolicy.consecutiveSuccesses must be >= 1", index)
+		}
+		policy.ConsecutiveSuccesses = n
+	}
+	if raw, found := m["exceededAction"]; found {
+		action, err := parseFailureAction(raw, "failurePolicy.exceededAction", index)
+		if err != nil {
+			return FailurePolicy{}, err
+		}
+		policy.ExceededAction = action
+	}
+	return policy, nil
 }
 
 func parseDurationField(v interface{}, field string, index int) (time.Duration, error) {
@@ -260,7 +354,7 @@ func asInt(v interface{}) (int, bool) {
 	case int64:
 		return int(n), true
 	case int:
-		return n, true
+		return int(n), true
 	case float64:
 		if n == float64(int(n)) {
 			return int(n), true

--- a/pkg/healthcheck/config_test.go
+++ b/pkg/healthcheck/config_test.go
@@ -1,0 +1,115 @@
+package healthcheck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestParseAndValidate(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name":         "errors",
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool 1) + (${current} < bool (2 * ${baseline})) > bool 0`,
+				},
+			},
+		})
+		cfg, err := ParseAndValidate(obj)
+		require.NoError(t, err)
+		require.Equal(t, "ingester-cell-health", cfg.Name)
+		require.Equal(t, "http://prometheus:9090", cfg.PrometheusURL)
+		require.Len(t, cfg.Checks, 1)
+		require.Equal(t, ActionPause, cfg.Checks[0].OnFailure)
+		require.Equal(t, defaultCurrentRange, cfg.Checks[0].CurrentRange)
+	})
+
+	t.Run("missing placeholders", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name":         "errors",
+					"query":        `scalar(1)`,
+					"successQuery": `${current} < bool 1`,
+				},
+			},
+		})
+		_, err := ParseAndValidate(obj)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), placeholderTargetMatchers)
+	})
+
+	t.Run("duplicate check names", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name":         "errors",
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool (${baseline}))`,
+				},
+				map[string]interface{}{
+					"name":         "errors",
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool (${baseline}))`,
+				},
+			},
+		})
+		_, err := ParseAndValidate(obj)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "duplicate")
+	})
+
+	t.Run("invalid onFailure", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name":         "errors",
+					"onFailure":    "Nope",
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool (${baseline}))`,
+				},
+			},
+		})
+		_, err := ParseAndValidate(obj)
+		require.Error(t, err)
+	})
+}
+
+func TestParseStartedAtAnnotation(t *testing.T) {
+	require.True(t, ParseStartedAtAnnotation("", "rev").IsZero())
+	require.True(t, ParseStartedAtAnnotation("other=2026-01-01T00:00:00Z", "rev").IsZero())
+	ts := ParseStartedAtAnnotation("rev=2026-01-02T03:04:05Z", "rev")
+	require.False(t, ts.IsZero())
+	require.Equal(t, "rev=2026-01-02T03:04:05Z", FormatStartedAtAnnotation("rev", ts))
+}
+
+func mockHealthCheckUnstructured(spec map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": RolloutHealthChecksSpecGroup + "/" + RolloutHealthChecksVersion,
+		"kind":       RolloutHealthCheckKind,
+		"metadata": map[string]interface{}{
+			"name":       "ingester-cell-health",
+			"generation": int64(1),
+		},
+		"spec": spec,
+	}}
+}

--- a/pkg/healthcheck/config_test.go
+++ b/pkg/healthcheck/config_test.go
@@ -2,13 +2,14 @@ package healthcheck
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestParseAndValidate(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
+	t.Run("valid defaults", func(t *testing.T) {
 		obj := mockHealthCheckUnstructured(map[string]interface{}{
 			"selector": map[string]interface{}{
 				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
@@ -27,8 +28,57 @@ func TestParseAndValidate(t *testing.T) {
 		require.Equal(t, "ingester-cell-health", cfg.Name)
 		require.Equal(t, "http://prometheus:9090", cfg.PrometheusURL)
 		require.Len(t, cfg.Checks, 1)
-		require.Equal(t, ActionPause, cfg.Checks[0].OnFailure)
+		require.Equal(t, ActionPause, cfg.Checks[0].FailurePolicy.ExceededAction)
+		require.Equal(t, ActionPause, cfg.Checks[0].ErrorPolicy.ExhaustedAction)
+		require.Equal(t, ActionPause, cfg.Checks[0].NoDataPolicy.ExhaustedAction)
 		require.Equal(t, defaultCurrentRange, cfg.Checks[0].CurrentRange)
+		require.Equal(t, defaultConsecutiveFailures, cfg.Checks[0].FailurePolicy.ConsecutiveFailures)
+		require.Equal(t, defaultErrorRetryInterval, cfg.Checks[0].ErrorPolicy.RetryInterval)
+		require.Equal(t, defaultNoDataRetryInterval, cfg.Checks[0].NoDataPolicy.RetryInterval)
+	})
+
+	t.Run("explicit policies", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name": "errors",
+					"errorPolicy": map[string]interface{}{
+						"retryInterval":   "5s",
+						"maxAttempts":     int64(2),
+						"exhaustedAction": "Warn",
+					},
+					"failurePolicy": map[string]interface{}{
+						"reevaluationInterval": "1m",
+						"consecutiveFailures":  int64(2),
+						"consecutiveSuccesses": int64(2),
+						"exceededAction":       "Pause",
+					},
+					"noDataPolicy": map[string]interface{}{
+						"retryInterval":   "15s",
+						"maxAttempts":     int64(4),
+						"exhaustedAction": "Disabled",
+					},
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool (${baseline}))`,
+				},
+			},
+		})
+		cfg, err := ParseAndValidate(obj)
+		require.NoError(t, err)
+		c := cfg.Checks[0]
+		require.Equal(t, 5*time.Second, c.ErrorPolicy.RetryInterval)
+		require.Equal(t, 2, c.ErrorPolicy.MaxAttempts)
+		require.Equal(t, ActionWarn, c.ErrorPolicy.ExhaustedAction)
+		require.Equal(t, time.Minute, c.FailurePolicy.ReevaluationInterval)
+		require.Equal(t, 2, c.FailurePolicy.ConsecutiveFailures)
+		require.Equal(t, 2, c.FailurePolicy.ConsecutiveSuccesses)
+		require.Equal(t, 15*time.Second, c.NoDataPolicy.RetryInterval)
+		require.Equal(t, 4, c.NoDataPolicy.MaxAttempts)
+		require.Equal(t, ActionDisabled, c.NoDataPolicy.ExhaustedAction)
 	})
 
 	t.Run("missing placeholders", func(t *testing.T) {
@@ -74,7 +124,7 @@ func TestParseAndValidate(t *testing.T) {
 		require.Contains(t, err.Error(), "duplicate")
 	})
 
-	t.Run("invalid onFailure", func(t *testing.T) {
+	t.Run("invalid exhaustedAction", func(t *testing.T) {
 		obj := mockHealthCheckUnstructured(map[string]interface{}{
 			"selector": map[string]interface{}{
 				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
@@ -82,8 +132,10 @@ func TestParseAndValidate(t *testing.T) {
 			"prometheusURL": "http://prometheus:9090",
 			"checks": []interface{}{
 				map[string]interface{}{
-					"name":         "errors",
-					"onFailure":    "Nope",
+					"name": "errors",
+					"errorPolicy": map[string]interface{}{
+						"exhaustedAction": "Nope",
+					},
 					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
 					"successQuery": `(${current} < bool (${baseline}))`,
 				},

--- a/pkg/healthcheck/evaluator.go
+++ b/pkg/healthcheck/evaluator.go
@@ -1,0 +1,323 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/api"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+// Querier abstracts the Prometheus instant-query API for tests.
+type Querier interface {
+	Query(ctx context.Context, query string, ts time.Time) (model.Value, v1.Warnings, error)
+}
+
+type prometheusQuerier struct {
+	api v1.API
+}
+
+func (q *prometheusQuerier) Query(ctx context.Context, query string, ts time.Time) (model.Value, v1.Warnings, error) {
+	return q.api.Query(ctx, query, ts)
+}
+
+// NewPrometheusQuerier builds a Querier against the given Prometheus base URL.
+func NewPrometheusQuerier(prometheusURL string) (Querier, error) {
+	client, err := api.NewClient(api.Config{Address: prometheusURL})
+	if err != nil {
+		return nil, err
+	}
+	return &prometheusQuerier{api: v1.NewAPI(client)}, nil
+}
+
+// QuerierFactory creates a Querier for a Prometheus URL. Overridable in tests.
+type QuerierFactory func(prometheusURL string) (Querier, error)
+
+// EvaluationResult is the raw outcome of evaluating a single check.
+type EvaluationResult string
+
+const (
+	ResultPass   EvaluationResult = "pass"
+	ResultFail   EvaluationResult = "fail"
+	ResultNoData EvaluationResult = "no_data"
+	ResultError  EvaluationResult = "error"
+)
+
+// CheckOutcome is the action taken after mapping an EvaluationResult through onFailure/onNoData.
+type CheckOutcome string
+
+const (
+	OutcomePass    CheckOutcome = "pass"
+	OutcomePause   CheckOutcome = "pause"
+	OutcomeWarn    CheckOutcome = "warn"
+	OutcomeSkipped CheckOutcome = "skipped"
+)
+
+// EvaluateRequest holds inputs for evaluating a RolloutHealthCheck against a rollout group.
+type EvaluateRequest struct {
+	Config          *Config
+	Namespace       string
+	RolloutGroup    string
+	CandidatePods   []string
+	StablePods      []string
+	BaselineTime    time.Time
+	Now             time.Time
+}
+
+// EvaluateResponse is the aggregate result of all checks.
+type EvaluateResponse struct {
+	Outcome      CheckOutcome
+	FailedCheck  string
+	Message      string
+	CheckResults map[string]EvaluationResult
+}
+
+// Evaluator runs PromQL health checks.
+type Evaluator struct {
+	factory QuerierFactory
+	metrics *Metrics
+	logger  log.Logger
+}
+
+// NewEvaluator creates an Evaluator. factory may be nil to use NewPrometheusQuerier.
+func NewEvaluator(factory QuerierFactory, metrics *Metrics, logger log.Logger) *Evaluator {
+	if factory == nil {
+		factory = NewPrometheusQuerier
+	}
+	return &Evaluator{factory: factory, metrics: metrics, logger: logger}
+}
+
+// Evaluate runs all enabled checks in cfg. Returns OutcomePause when any check requires pausing.
+func (e *Evaluator) Evaluate(ctx context.Context, req EvaluateRequest) EvaluateResponse {
+	resp := EvaluateResponse{
+		Outcome:      OutcomePass,
+		CheckResults: map[string]EvaluationResult{},
+	}
+	if req.Config == nil {
+		return resp
+	}
+	if req.Now.IsZero() {
+		req.Now = time.Now()
+	}
+
+	querier, err := e.factory(req.Config.PrometheusURL)
+	if err != nil {
+		msg := fmt.Sprintf("failed to create Prometheus client for %q: %v", req.Config.PrometheusURL, err)
+		level.Error(e.logger).Log("msg", msg, "rollout_group", req.RolloutGroup)
+		resp.Outcome = OutcomePause
+		resp.Message = msg
+		return resp
+	}
+
+	candidateMatchers := buildTargetMatchers(req.Namespace, req.CandidatePods)
+	stableMatchers := buildTargetMatchers(req.Namespace, req.StablePods)
+
+	for _, check := range req.Config.Checks {
+		if check.Disabled {
+			resp.CheckResults[check.Name] = ResultPass
+			e.observeEvaluation(req.RolloutGroup, check.Name, "skipped")
+			continue
+		}
+
+		result, msg := e.evaluateCheck(ctx, querier, check, candidateMatchers, stableMatchers, req)
+		resp.CheckResults[check.Name] = result
+		e.observeEvaluation(req.RolloutGroup, check.Name, string(result))
+
+		outcome := mapResultToOutcome(result, check)
+		if outcome == OutcomeSkipped || outcome == OutcomePass {
+			continue
+		}
+		if outcome == OutcomeWarn {
+			if resp.Outcome == OutcomePass {
+				resp.Outcome = OutcomeWarn
+				resp.FailedCheck = check.Name
+				resp.Message = msg
+			}
+			continue
+		}
+		// Pause wins over Warn.
+		resp.Outcome = OutcomePause
+		resp.FailedCheck = check.Name
+		resp.Message = msg
+		return resp
+	}
+
+	return resp
+}
+
+func mapResultToOutcome(result EvaluationResult, check Check) CheckOutcome {
+	switch result {
+	case ResultPass:
+		return OutcomePass
+	case ResultFail:
+		return actionToOutcome(check.OnFailure)
+	case ResultNoData:
+		return actionToOutcome(check.OnNoData)
+	case ResultError:
+		// Unreachable / query errors always pause unless the check is fully disabled (handled earlier).
+		return actionToOutcome(check.OnFailure)
+	default:
+		return OutcomePause
+	}
+}
+
+func actionToOutcome(action FailureAction) CheckOutcome {
+	switch action {
+	case ActionWarn:
+		return OutcomeWarn
+	case ActionDisabled:
+		return OutcomeSkipped
+	default:
+		return OutcomePause
+	}
+}
+
+func (e *Evaluator) evaluateCheck(ctx context.Context, querier Querier, check Check, candidateMatchers, stableMatchers string, req EvaluateRequest) (EvaluationResult, string) {
+	currentQuery := substituteQuery(check.Query, candidateMatchers, formatDuration(check.CurrentRange))
+	baselineQuery := substituteQuery(check.Query, stableMatchers, formatDuration(check.BaselineRange))
+
+	currentVal, err := e.queryScalar(ctx, querier, currentQuery, req.Now, req.RolloutGroup, check, "current")
+	if err != nil {
+		return ResultError, fmt.Sprintf("check %q current query failed: %v", check.Name, err)
+	}
+	if currentVal == nil {
+		return ResultNoData, fmt.Sprintf("check %q current query returned no data", check.Name)
+	}
+
+	baselineTS := req.BaselineTime
+	if baselineTS.IsZero() {
+		baselineTS = req.Now
+	}
+	baselineVal, err := e.queryScalar(ctx, querier, baselineQuery, baselineTS, req.RolloutGroup, check, "baseline")
+	if err != nil {
+		return ResultError, fmt.Sprintf("check %q baseline query failed: %v", check.Name, err)
+	}
+	if baselineVal == nil {
+		return ResultNoData, fmt.Sprintf("check %q baseline query returned no data", check.Name)
+	}
+
+	successQuery := substituteSuccessQuery(check.SuccessQuery, *currentVal, *baselineVal)
+	successVal, err := e.queryScalar(ctx, querier, successQuery, req.Now, req.RolloutGroup, check, "success")
+	if err != nil {
+		return ResultError, fmt.Sprintf("check %q success query failed: %v", check.Name, err)
+	}
+	if successVal == nil {
+		return ResultNoData, fmt.Sprintf("check %q success query returned no data", check.Name)
+	}
+	if *successVal == 1 {
+		return ResultPass, ""
+	}
+	if *successVal == 0 {
+		return ResultFail, fmt.Sprintf("check %q failed (current=%v baseline=%v)", check.Name, *currentVal, *baselineVal)
+	}
+	return ResultFail, fmt.Sprintf("check %q success query returned unexpected scalar %v (want 0 or 1)", check.Name, *successVal)
+}
+
+func (e *Evaluator) queryScalar(ctx context.Context, querier Querier, query string, ts time.Time, rolloutGroup string, check Check, queryType string) (*float64, error) {
+	var lastErr error
+	attempts := check.QueryRetries + 1
+	for attempt := 0; attempt < attempts; attempt++ {
+		qctx, cancel := context.WithTimeout(ctx, check.QueryTimeout)
+		start := time.Now()
+		value, warnings, err := querier.Query(qctx, query, ts)
+		cancel()
+		if e.metrics != nil {
+			e.metrics.QueryDuration.WithLabelValues(rolloutGroup, check.Name, queryType).Observe(time.Since(start).Seconds())
+		}
+		if len(warnings) > 0 {
+			level.Warn(e.logger).Log("msg", "prometheus query warnings", "check", check.Name, "query_type", queryType, "warnings", strings.Join(warnings, "; "))
+		}
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		scalar, err := valueToScalar(value)
+		if err != nil {
+			return nil, err
+		}
+		return scalar, nil
+	}
+	return nil, lastErr
+}
+
+func (e *Evaluator) observeEvaluation(rolloutGroup, check, result string) {
+	if e.metrics == nil {
+		return
+	}
+	e.metrics.EvaluationsTotal.WithLabelValues(rolloutGroup, check, result).Inc()
+}
+
+func valueToScalar(value model.Value) (*float64, error) {
+	if value == nil {
+		return nil, nil
+	}
+	switch v := value.(type) {
+	case *model.Scalar:
+		if v == nil {
+			return nil, nil
+		}
+		f := float64(v.Value)
+		return &f, nil
+	case model.Vector:
+		if len(v) == 0 {
+			return nil, nil
+		}
+		if len(v) != 1 {
+			return nil, fmt.Errorf("expected scalar or single-sample vector, got vector of length %d", len(v))
+		}
+		f := float64(v[0].Value)
+		return &f, nil
+	default:
+		return nil, fmt.Errorf("expected scalar result, got %s", value.Type())
+	}
+}
+
+func substituteQuery(query, targetMatchers, rangeStr string) string {
+	out := strings.ReplaceAll(query, placeholderTargetMatchers, targetMatchers)
+	out = strings.ReplaceAll(out, placeholderRange, rangeStr)
+	return out
+}
+
+func substituteSuccessQuery(query string, current, baseline float64) string {
+	out := strings.ReplaceAll(query, placeholderCurrent, formatFloat(current))
+	out = strings.ReplaceAll(out, placeholderBaseline, formatFloat(baseline))
+	return out
+}
+
+func formatFloat(f float64) string {
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+func formatDuration(d time.Duration) string {
+	// Prefer compact Prometheus-style durations for common values.
+	if d%time.Hour == 0 && d >= time.Hour {
+		return fmt.Sprintf("%dh", int(d/time.Hour))
+	}
+	if d%time.Minute == 0 && d >= time.Minute {
+		return fmt.Sprintf("%dm", int(d/time.Minute))
+	}
+	if d%time.Second == 0 && d >= time.Second {
+		return fmt.Sprintf("%ds", int(d/time.Second))
+	}
+	return d.String()
+}
+
+// buildTargetMatchers returns PromQL label matchers for namespace and pod names.
+func buildTargetMatchers(namespace string, podNames []string) string {
+	quotedNS := strconv.Quote(namespace)
+	if len(podNames) == 0 {
+		return fmt.Sprintf(`namespace=%s,pod=~"^$"`, quotedNS)
+	}
+	parts := make([]string, 0, len(podNames))
+	for _, name := range podNames {
+		parts = append(parts, regexp.QuoteMeta(name))
+	}
+	return fmt.Sprintf(`namespace=%s,pod=~"%s"`, quotedNS, strings.Join(parts, "|"))
+}

--- a/pkg/healthcheck/evaluator.go
+++ b/pkg/healthcheck/evaluator.go
@@ -62,13 +62,13 @@ const (
 
 // EvaluateRequest holds inputs for evaluating a RolloutHealthCheck against a rollout group.
 type EvaluateRequest struct {
-	Config          *Config
-	Namespace       string
-	RolloutGroup    string
-	CandidatePods   []string
-	StablePods      []string
-	BaselineTime    time.Time
-	Now             time.Time
+	Config        *Config
+	Namespace     string
+	RolloutGroup  string
+	CandidatePods []string
+	StablePods    []string
+	BaselineTime  time.Time
+	Now           time.Time
 }
 
 // EvaluateResponse is the aggregate result of all checks.

--- a/pkg/healthcheck/evaluator.go
+++ b/pkg/healthcheck/evaluator.go
@@ -81,9 +81,12 @@ type EvaluateRequest struct {
 
 // CheckEvaluation is the raw result of one check.
 type CheckEvaluation struct {
-	Name    string
-	Result  EvaluationResult
-	Message string
+	Name          string
+	Result        EvaluationResult
+	Message       string
+	CurrentValue  *float64
+	BaselineValue *float64
+	QueryType     string
 }
 
 // EvaluateResponse is the aggregate raw result of all checks.
@@ -121,11 +124,23 @@ func (e *Evaluator) Evaluate(ctx context.Context, req EvaluateRequest) EvaluateR
 	if req.Now.IsZero() {
 		req.Now = time.Now()
 	}
-
+	level.Info(e.logger).Log(
+		"msg", "health check evaluation started",
+		"rollout_group", req.RolloutGroup,
+		"policy", req.Config.Name,
+		"candidate_pods", len(req.CandidatePods.Names),
+		"stable_pods", len(req.StablePods.Names),
+		"checks", len(req.Config.Checks),
+	)
 	querier, err := e.factory(req.Config.PrometheusURL)
 	if err != nil {
-		msg := fmt.Sprintf("failed to create Prometheus client for %q: %v", req.Config.PrometheusURL, err)
-		level.Error(e.logger).Log("msg", msg, "rollout_group", req.RolloutGroup)
+		msg := fmt.Sprintf("failed to create Prometheus client: %v", err)
+		level.Error(e.logger).Log(
+			"msg", "prometheus client unavailable",
+			"rollout_group", req.RolloutGroup,
+			"policy", req.Config.Name,
+			"err", err,
+		)
 		resp.ClientError = msg
 		return resp
 	}
@@ -142,24 +157,28 @@ func (e *Evaluator) Evaluate(ctx context.Context, req EvaluateRequest) EvaluateR
 			continue
 		}
 
-		result, msg := e.evaluateCheck(ctx, querier, check, candidateMatchers, stableMatchers, req)
-		ev := CheckEvaluation{Name: check.Name, Result: result, Message: msg}
+		ev := e.evaluateCheck(ctx, querier, check, candidateMatchers, stableMatchers, req)
 		resp.Checks = append(resp.Checks, ev)
-		resp.Results[check.Name] = result
-		e.observeEvaluation(req.RolloutGroup, check.Name, string(result))
+		resp.Results[check.Name] = ev.Result
+		e.observeEvaluation(req.RolloutGroup, check.Name, string(ev.Result))
 	}
 
 	return resp
 }
 
-func (e *Evaluator) evaluateCheck(ctx context.Context, querier Querier, check Check, candidateMatchers, stableMatchers string, req EvaluateRequest) (EvaluationResult, string) {
+func (e *Evaluator) evaluateCheck(ctx context.Context, querier Querier, check Check, candidateMatchers, stableMatchers string, req EvaluateRequest) CheckEvaluation {
+	ev := CheckEvaluation{Name: check.Name}
 	currentQuery := substituteQuery(check.Query, candidateMatchers, formatDuration(check.CurrentRange))
 	baselineQuery := substituteQuery(check.Query, stableMatchers, formatDuration(check.BaselineRange))
 
 	currentVal, result, errMsg := e.queryScalarOnce(ctx, querier, currentQuery, req.Now, req.RolloutGroup, check, "current")
 	if result != ResultPass {
-		return result, fmt.Sprintf("check %q current query: %s", check.Name, errMsg)
+		ev.Result = result
+		ev.Message = fmt.Sprintf("check %q current query: %s", check.Name, errMsg)
+		ev.QueryType = "current"
+		return ev
 	}
+	ev.CurrentValue = currentVal
 
 	baselineTS := req.BaselineTime
 	if baselineTS.IsZero() {
@@ -167,21 +186,33 @@ func (e *Evaluator) evaluateCheck(ctx context.Context, querier Querier, check Ch
 	}
 	baselineVal, result, errMsg := e.queryScalarOnce(ctx, querier, baselineQuery, baselineTS, req.RolloutGroup, check, "baseline")
 	if result != ResultPass {
-		return result, fmt.Sprintf("check %q baseline query: %s", check.Name, errMsg)
+		ev.Result = result
+		ev.Message = fmt.Sprintf("check %q baseline query: %s", check.Name, errMsg)
+		ev.QueryType = "baseline"
+		return ev
 	}
+	ev.BaselineValue = baselineVal
 
 	successQuery := substituteSuccessQuery(check.SuccessQuery, *currentVal, *baselineVal)
 	successVal, result, errMsg := e.queryScalarOnce(ctx, querier, successQuery, req.Now, req.RolloutGroup, check, "success")
 	if result != ResultPass {
-		return result, fmt.Sprintf("check %q success query: %s", check.Name, errMsg)
+		ev.Result = result
+		ev.Message = fmt.Sprintf("check %q success query: %s", check.Name, errMsg)
+		ev.QueryType = "success"
+		return ev
 	}
 	if *successVal == 1 {
-		return ResultPass, ""
+		ev.Result = ResultPass
+		return ev
 	}
 	if *successVal == 0 {
-		return ResultFail, fmt.Sprintf("check %q failed (current=%v baseline=%v)", check.Name, *currentVal, *baselineVal)
+		ev.Result = ResultFail
+		ev.Message = fmt.Sprintf("check %q failed (current=%v baseline=%v)", check.Name, *currentVal, *baselineVal)
+		return ev
 	}
-	return ResultFail, fmt.Sprintf("check %q success query returned unexpected scalar %v (want 0 or 1)", check.Name, *successVal)
+	ev.Result = ResultFail
+	ev.Message = fmt.Sprintf("check %q success query returned unexpected scalar %v (want 0 or 1)", check.Name, *successVal)
+	return ev
 }
 
 // queryScalarOnce performs a single Prometheus query. Retries are applied by Gate across reconciles
@@ -201,6 +232,13 @@ func (e *Evaluator) queryScalarOnce(ctx context.Context, querier Querier, query 
 		if ctx.Err() != nil {
 			return nil, ResultError, fmt.Sprintf("interrupted: %v", err)
 		}
+		level.Warn(e.logger).Log(
+			"msg", "prometheus query failed",
+			"rollout_group", rolloutGroup,
+			"check", check.Name,
+			"query_type", queryType,
+			"err", err,
+		)
 		return nil, ResultError, err.Error()
 	}
 

--- a/pkg/healthcheck/evaluator.go
+++ b/pkg/healthcheck/evaluator.go
@@ -40,17 +40,18 @@ func NewPrometheusQuerier(prometheusURL string) (Querier, error) {
 // QuerierFactory creates a Querier for a Prometheus URL. Overridable in tests.
 type QuerierFactory func(prometheusURL string) (Querier, error)
 
-// EvaluationResult is the raw outcome of evaluating a single check.
+// EvaluationResult is the raw outcome of evaluating a single check before policy mapping.
 type EvaluationResult string
 
 const (
-	ResultPass   EvaluationResult = "pass"
-	ResultFail   EvaluationResult = "fail"
-	ResultNoData EvaluationResult = "no_data"
-	ResultError  EvaluationResult = "error"
+	ResultPass    EvaluationResult = "pass"
+	ResultFail    EvaluationResult = "fail"
+	ResultNoData  EvaluationResult = "no_data"
+	ResultError   EvaluationResult = "error"
+	ResultSkipped EvaluationResult = "skipped"
 )
 
-// CheckOutcome is the action taken after mapping an EvaluationResult through onFailure/onNoData.
+// CheckOutcome is the action taken after mapping an EvaluationResult through policies.
 type CheckOutcome string
 
 const (
@@ -60,23 +61,37 @@ const (
 	OutcomeSkipped CheckOutcome = "skipped"
 )
 
+// TargetPods describes pods for ${targetMatchers} substitution.
+type TargetPods struct {
+	Names []string
+	// Zones are StatefulSet / zone identifiers (typically the pod "name" label).
+	Zones []string
+}
+
 // EvaluateRequest holds inputs for evaluating a RolloutHealthCheck against a rollout group.
 type EvaluateRequest struct {
 	Config        *Config
 	Namespace     string
 	RolloutGroup  string
-	CandidatePods []string
-	StablePods    []string
+	CandidatePods TargetPods
+	StablePods    TargetPods
 	BaselineTime  time.Time
 	Now           time.Time
 }
 
-// EvaluateResponse is the aggregate result of all checks.
+// CheckEvaluation is the raw result of one check.
+type CheckEvaluation struct {
+	Name    string
+	Result  EvaluationResult
+	Message string
+}
+
+// EvaluateResponse is the aggregate raw result of all checks.
 type EvaluateResponse struct {
-	Outcome      CheckOutcome
-	FailedCheck  string
-	Message      string
-	CheckResults map[string]EvaluationResult
+	Checks  []CheckEvaluation
+	Results map[string]EvaluationResult
+	// ClientError is set when the Prometheus client could not be created.
+	ClientError string
 }
 
 // Evaluator runs PromQL health checks.
@@ -94,11 +109,11 @@ func NewEvaluator(factory QuerierFactory, metrics *Metrics, logger log.Logger) *
 	return &Evaluator{factory: factory, metrics: metrics, logger: logger}
 }
 
-// Evaluate runs all enabled checks in cfg. Returns OutcomePause when any check requires pausing.
+// Evaluate runs all enabled checks and returns raw results. Policy mapping and retries across
+// reconciles are handled by Gate so evaluation does not block the controller on sleep.
 func (e *Evaluator) Evaluate(ctx context.Context, req EvaluateRequest) EvaluateResponse {
 	resp := EvaluateResponse{
-		Outcome:      OutcomePass,
-		CheckResults: map[string]EvaluationResult{},
+		Results: map[string]EvaluationResult{},
 	}
 	if req.Config == nil {
 		return resp
@@ -111,8 +126,7 @@ func (e *Evaluator) Evaluate(ctx context.Context, req EvaluateRequest) EvaluateR
 	if err != nil {
 		msg := fmt.Sprintf("failed to create Prometheus client for %q: %v", req.Config.PrometheusURL, err)
 		level.Error(e.logger).Log("msg", msg, "rollout_group", req.RolloutGroup)
-		resp.Outcome = OutcomePause
-		resp.Message = msg
+		resp.ClientError = msg
 		return resp
 	}
 
@@ -121,95 +135,45 @@ func (e *Evaluator) Evaluate(ctx context.Context, req EvaluateRequest) EvaluateR
 
 	for _, check := range req.Config.Checks {
 		if check.Disabled {
-			resp.CheckResults[check.Name] = ResultPass
-			e.observeEvaluation(req.RolloutGroup, check.Name, "skipped")
+			ev := CheckEvaluation{Name: check.Name, Result: ResultSkipped}
+			resp.Checks = append(resp.Checks, ev)
+			resp.Results[check.Name] = ResultSkipped
+			e.observeEvaluation(req.RolloutGroup, check.Name, string(ResultSkipped))
 			continue
 		}
 
 		result, msg := e.evaluateCheck(ctx, querier, check, candidateMatchers, stableMatchers, req)
-		resp.CheckResults[check.Name] = result
+		ev := CheckEvaluation{Name: check.Name, Result: result, Message: msg}
+		resp.Checks = append(resp.Checks, ev)
+		resp.Results[check.Name] = result
 		e.observeEvaluation(req.RolloutGroup, check.Name, string(result))
-
-		outcome := mapResultToOutcome(result, check)
-		if outcome == OutcomeSkipped || outcome == OutcomePass {
-			continue
-		}
-		if outcome == OutcomeWarn {
-			if resp.Outcome == OutcomePass {
-				resp.Outcome = OutcomeWarn
-				resp.FailedCheck = check.Name
-				resp.Message = msg
-			}
-			continue
-		}
-		// Pause wins over Warn.
-		resp.Outcome = OutcomePause
-		resp.FailedCheck = check.Name
-		resp.Message = msg
-		return resp
 	}
 
 	return resp
-}
-
-func mapResultToOutcome(result EvaluationResult, check Check) CheckOutcome {
-	switch result {
-	case ResultPass:
-		return OutcomePass
-	case ResultFail:
-		return actionToOutcome(check.OnFailure)
-	case ResultNoData:
-		return actionToOutcome(check.OnNoData)
-	case ResultError:
-		// Unreachable / query errors always pause unless the check is fully disabled (handled earlier).
-		return actionToOutcome(check.OnFailure)
-	default:
-		return OutcomePause
-	}
-}
-
-func actionToOutcome(action FailureAction) CheckOutcome {
-	switch action {
-	case ActionWarn:
-		return OutcomeWarn
-	case ActionDisabled:
-		return OutcomeSkipped
-	default:
-		return OutcomePause
-	}
 }
 
 func (e *Evaluator) evaluateCheck(ctx context.Context, querier Querier, check Check, candidateMatchers, stableMatchers string, req EvaluateRequest) (EvaluationResult, string) {
 	currentQuery := substituteQuery(check.Query, candidateMatchers, formatDuration(check.CurrentRange))
 	baselineQuery := substituteQuery(check.Query, stableMatchers, formatDuration(check.BaselineRange))
 
-	currentVal, err := e.queryScalar(ctx, querier, currentQuery, req.Now, req.RolloutGroup, check, "current")
-	if err != nil {
-		return ResultError, fmt.Sprintf("check %q current query failed: %v", check.Name, err)
-	}
-	if currentVal == nil {
-		return ResultNoData, fmt.Sprintf("check %q current query returned no data", check.Name)
+	currentVal, result, errMsg := e.queryScalarOnce(ctx, querier, currentQuery, req.Now, req.RolloutGroup, check, "current")
+	if result != ResultPass {
+		return result, fmt.Sprintf("check %q current query: %s", check.Name, errMsg)
 	}
 
 	baselineTS := req.BaselineTime
 	if baselineTS.IsZero() {
 		baselineTS = req.Now
 	}
-	baselineVal, err := e.queryScalar(ctx, querier, baselineQuery, baselineTS, req.RolloutGroup, check, "baseline")
-	if err != nil {
-		return ResultError, fmt.Sprintf("check %q baseline query failed: %v", check.Name, err)
-	}
-	if baselineVal == nil {
-		return ResultNoData, fmt.Sprintf("check %q baseline query returned no data", check.Name)
+	baselineVal, result, errMsg := e.queryScalarOnce(ctx, querier, baselineQuery, baselineTS, req.RolloutGroup, check, "baseline")
+	if result != ResultPass {
+		return result, fmt.Sprintf("check %q baseline query: %s", check.Name, errMsg)
 	}
 
 	successQuery := substituteSuccessQuery(check.SuccessQuery, *currentVal, *baselineVal)
-	successVal, err := e.queryScalar(ctx, querier, successQuery, req.Now, req.RolloutGroup, check, "success")
-	if err != nil {
-		return ResultError, fmt.Sprintf("check %q success query failed: %v", check.Name, err)
-	}
-	if successVal == nil {
-		return ResultNoData, fmt.Sprintf("check %q success query returned no data", check.Name)
+	successVal, result, errMsg := e.queryScalarOnce(ctx, querier, successQuery, req.Now, req.RolloutGroup, check, "success")
+	if result != ResultPass {
+		return result, fmt.Sprintf("check %q success query: %s", check.Name, errMsg)
 	}
 	if *successVal == 1 {
 		return ResultPass, ""
@@ -220,31 +184,34 @@ func (e *Evaluator) evaluateCheck(ctx context.Context, querier Querier, check Ch
 	return ResultFail, fmt.Sprintf("check %q success query returned unexpected scalar %v (want 0 or 1)", check.Name, *successVal)
 }
 
-func (e *Evaluator) queryScalar(ctx context.Context, querier Querier, query string, ts time.Time, rolloutGroup string, check Check, queryType string) (*float64, error) {
-	var lastErr error
-	attempts := check.QueryRetries + 1
-	for attempt := 0; attempt < attempts; attempt++ {
-		qctx, cancel := context.WithTimeout(ctx, check.QueryTimeout)
-		start := time.Now()
-		value, warnings, err := querier.Query(qctx, query, ts)
-		cancel()
-		if e.metrics != nil {
-			e.metrics.QueryDuration.WithLabelValues(rolloutGroup, check.Name, queryType).Observe(time.Since(start).Seconds())
-		}
-		if len(warnings) > 0 {
-			level.Warn(e.logger).Log("msg", "prometheus query warnings", "check", check.Name, "query_type", queryType, "warnings", strings.Join(warnings, "; "))
-		}
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		scalar, err := valueToScalar(value)
-		if err != nil {
-			return nil, err
-		}
-		return scalar, nil
+// queryScalarOnce performs a single Prometheus query. Retries are applied by Gate across reconciles
+// using errorPolicy / noDataPolicy so the controller reconcile loop is not blocked on sleep.
+func (e *Evaluator) queryScalarOnce(ctx context.Context, querier Querier, query string, ts time.Time, rolloutGroup string, check Check, queryType string) (*float64, EvaluationResult, string) {
+	qctx, cancel := context.WithTimeout(ctx, check.QueryTimeout)
+	start := time.Now()
+	value, warnings, err := querier.Query(qctx, query, ts)
+	cancel()
+	if e.metrics != nil {
+		e.metrics.QueryDuration.WithLabelValues(rolloutGroup, check.Name, queryType).Observe(time.Since(start).Seconds())
 	}
-	return nil, lastErr
+	if len(warnings) > 0 {
+		level.Warn(e.logger).Log("msg", "prometheus query warnings", "check", check.Name, "query_type", queryType, "warnings", strings.Join(warnings, "; "))
+	}
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ResultError, fmt.Sprintf("interrupted: %v", err)
+		}
+		return nil, ResultError, err.Error()
+	}
+
+	scalar, err := valueToScalar(value)
+	if err != nil {
+		return nil, ResultError, err.Error()
+	}
+	if scalar == nil {
+		return nil, ResultNoData, "no data"
+	}
+	return scalar, ResultPass, ""
 }
 
 func (e *Evaluator) observeEvaluation(rolloutGroup, check, result string) {
@@ -309,15 +276,52 @@ func formatDuration(d time.Duration) string {
 	return d.String()
 }
 
-// buildTargetMatchers returns PromQL label matchers for namespace and pod names.
-func buildTargetMatchers(namespace string, podNames []string) string {
+// buildTargetMatchers returns PromQL label matchers for namespace, zone (name), and pods.
+func buildTargetMatchers(namespace string, targets TargetPods) string {
 	quotedNS := strconv.Quote(namespace)
-	if len(podNames) == 0 {
-		return fmt.Sprintf(`namespace=%s,pod=~"^$"`, quotedNS)
+	parts := []string{fmt.Sprintf("namespace=%s", quotedNS)}
+	if len(targets.Zones) > 0 {
+		parts = append(parts, fmt.Sprintf(`name=~"%s"`, joinRegex(targets.Zones)))
 	}
-	parts := make([]string, 0, len(podNames))
-	for _, name := range podNames {
-		parts = append(parts, regexp.QuoteMeta(name))
+	if len(targets.Names) == 0 {
+		parts = append(parts, `pod=~"^$"`)
+	} else {
+		parts = append(parts, fmt.Sprintf(`pod=~"%s"`, joinRegex(targets.Names)))
 	}
-	return fmt.Sprintf(`namespace=%s,pod=~"%s"`, quotedNS, strings.Join(parts, "|"))
+	return strings.Join(parts, ",")
+}
+
+func joinRegex(values []string) string {
+	parts := make([]string, 0, len(values))
+	for _, v := range values {
+		parts = append(parts, regexp.QuoteMeta(v))
+	}
+	return strings.Join(parts, "|")
+}
+
+func uniqueNonEmpty(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+func actionToOutcome(action FailureAction) CheckOutcome {
+	switch action {
+	case ActionWarn:
+		return OutcomeWarn
+	case ActionDisabled:
+		return OutcomeSkipped
+	default:
+		return OutcomePause
+	}
 }

--- a/pkg/healthcheck/evaluator.go
+++ b/pkg/healthcheck/evaluator.go
@@ -276,13 +276,12 @@ func formatDuration(d time.Duration) string {
 	return d.String()
 }
 
-// buildTargetMatchers returns PromQL label matchers for namespace, zone (name), and pods.
+// buildTargetMatchers returns matchers common to application and kube-state-metrics
+// series. Pod names already identify the candidate/stable workloads; adding the
+// application-specific "name" label would make kube-state-metrics checks return no data.
 func buildTargetMatchers(namespace string, targets TargetPods) string {
 	quotedNS := strconv.Quote(namespace)
 	parts := []string{fmt.Sprintf("namespace=%s", quotedNS)}
-	if len(targets.Zones) > 0 {
-		parts = append(parts, fmt.Sprintf(`name=~"%s"`, joinRegex(targets.Zones)))
-	}
 	if len(targets.Names) == 0 {
 		parts = append(parts, `pod=~"^$"`)
 	} else {

--- a/pkg/healthcheck/evaluator_test.go
+++ b/pkg/healthcheck/evaluator_test.go
@@ -1,0 +1,171 @@
+package healthcheck
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type fakeQuerier struct {
+	mu       sync.Mutex
+	calls    []string
+	sequence []func() (model.Value, error)
+	seqIdx   int
+}
+
+func (f *fakeQuerier) Query(_ context.Context, query string, _ time.Time) (model.Value, v1.Warnings, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, query)
+	if f.seqIdx >= len(f.sequence) {
+		return &model.Scalar{Value: 0}, nil, nil
+	}
+	fn := f.sequence[f.seqIdx]
+	f.seqIdx++
+	val, err := fn()
+	return val, nil, err
+}
+
+func scalar(v float64) model.Value {
+	return &model.Scalar{Value: model.SampleValue(v), Timestamp: model.Now()}
+}
+
+func TestEvaluator_PassFailNoDataError(t *testing.T) {
+	baseCfg := &Config{
+		Name:          "hc",
+		PrometheusURL: "http://prometheus",
+		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
+		Checks: []Check{{
+			Name:          "errors",
+			CurrentRange:  time.Minute,
+			BaselineRange: 2 * time.Minute,
+			QueryTimeout:  time.Second,
+			QueryRetries:  0,
+			OnFailure:     ActionPause,
+			OnNoData:      ActionPause,
+			Query:         `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+			SuccessQuery:  `(${current} < bool 1) or (${current} < bool (2 * ${baseline}))`,
+		}},
+	}
+
+	t.Run("pass", func(t *testing.T) {
+		q := &fakeQuerier{sequence: []func() (model.Value, error){
+			func() (model.Value, error) { return scalar(0.1), nil },
+			func() (model.Value, error) { return scalar(0.2), nil },
+			func() (model.Value, error) { return scalar(1), nil },
+		}}
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		resp := e.Evaluate(context.Background(), EvaluateRequest{
+			Config:        baseCfg,
+			Namespace:     "ns",
+			RolloutGroup:  "ingester",
+			CandidatePods: []string{"ingester-zone-a-0"},
+			StablePods:    []string{"ingester-zone-b-0"},
+			Now:           time.Now(),
+			BaselineTime:  time.Now().Add(-time.Hour),
+		})
+		require.Equal(t, OutcomePass, resp.Outcome)
+		require.Equal(t, ResultPass, resp.CheckResults["errors"])
+		require.Len(t, q.calls, 3)
+		require.True(t, strings.Contains(q.calls[0], `pod=~"ingester-zone-a-0"`))
+		require.True(t, strings.Contains(q.calls[0], `[1m]`))
+		require.True(t, strings.Contains(q.calls[1], `pod=~"ingester-zone-b-0"`))
+		require.True(t, strings.Contains(q.calls[1], `[2m]`))
+		require.True(t, strings.Contains(q.calls[2], "0.1"))
+		require.True(t, strings.Contains(q.calls[2], "0.2"))
+	})
+
+	t.Run("fail pauses", func(t *testing.T) {
+		q := &fakeQuerier{sequence: []func() (model.Value, error){
+			func() (model.Value, error) { return scalar(5), nil },
+			func() (model.Value, error) { return scalar(0.1), nil },
+			func() (model.Value, error) { return scalar(0), nil },
+		}}
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: baseCfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
+		require.Equal(t, OutcomePause, resp.Outcome)
+		require.Equal(t, ResultFail, resp.CheckResults["errors"])
+	})
+
+	t.Run("no data pauses", func(t *testing.T) {
+		q := &fakeQuerier{sequence: []func() (model.Value, error){
+			func() (model.Value, error) { return model.Vector{}, nil },
+		}}
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: baseCfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
+		require.Equal(t, OutcomePause, resp.Outcome)
+		require.Equal(t, ResultNoData, resp.CheckResults["errors"])
+	})
+
+	t.Run("error pauses", func(t *testing.T) {
+		q := &fakeQuerier{sequence: []func() (model.Value, error){
+			func() (model.Value, error) { return nil, errors.New("boom") },
+		}}
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: baseCfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
+		require.Equal(t, OutcomePause, resp.Outcome)
+		require.Equal(t, ResultError, resp.CheckResults["errors"])
+	})
+
+	t.Run("warn on failure", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Checks = append([]Check(nil), baseCfg.Checks...)
+		cfg.Checks[0].OnFailure = ActionWarn
+		q := &fakeQuerier{sequence: []func() (model.Value, error){
+			func() (model.Value, error) { return scalar(5), nil },
+			func() (model.Value, error) { return scalar(0.1), nil },
+			func() (model.Value, error) { return scalar(0), nil },
+		}}
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: &cfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
+		require.Equal(t, OutcomeWarn, resp.Outcome)
+	})
+
+	t.Run("retries then succeeds", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Checks = append([]Check(nil), baseCfg.Checks...)
+		cfg.Checks[0].QueryRetries = 2
+		attempts := 0
+		q := &fakeQuerier{sequence: []func() (model.Value, error){
+			func() (model.Value, error) {
+				attempts++
+				return nil, errors.New("transient")
+			},
+			func() (model.Value, error) {
+				attempts++
+				return scalar(0.1), nil
+			},
+			func() (model.Value, error) { return scalar(0.2), nil },
+			func() (model.Value, error) { return scalar(1), nil },
+		}}
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: &cfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
+		require.Equal(t, OutcomePass, resp.Outcome)
+		require.Equal(t, 2, attempts)
+	})
+
+	t.Run("disabled check skipped", func(t *testing.T) {
+		cfg := *baseCfg
+		cfg.Checks = append([]Check(nil), baseCfg.Checks...)
+		cfg.Checks[0].Disabled = true
+		q := &fakeQuerier{}
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: &cfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
+		require.Equal(t, OutcomePass, resp.Outcome)
+		require.Empty(t, q.calls)
+	})
+}
+
+func TestBuildTargetMatchers(t *testing.T) {
+	require.Equal(t, `namespace="ns",pod=~"^$"`, buildTargetMatchers("ns", nil))
+	require.Equal(t, `namespace="ns",pod=~"a-0|b-1"`, buildTargetMatchers("ns", []string{"a-0", "b-1"}))
+}

--- a/pkg/healthcheck/evaluator_test.go
+++ b/pkg/healthcheck/evaluator_test.go
@@ -1,6 +1,7 @@
 package healthcheck
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -125,9 +126,14 @@ func TestEvaluator_PassFailNoDataError(t *testing.T) {
 		q := &fakeQuerier{sequence: []func() (model.Value, error){
 			func() (model.Value, error) { return nil, errors.New("boom") },
 		}}
-		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
+		var logs bytes.Buffer
+		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewLogfmtLogger(&logs))
 		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: baseCfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
 		require.Equal(t, ResultError, resp.Results["errors"])
+		require.Contains(t, logs.String(), "msg=\"prometheus query failed\"")
+		require.Contains(t, logs.String(), "query_type=current")
+		require.Contains(t, logs.String(), "err=boom")
+		require.NotContains(t, logs.String(), baseCfg.Checks[0].Query)
 	})
 
 	t.Run("disabled check skipped", func(t *testing.T) {

--- a/pkg/healthcheck/evaluator_test.go
+++ b/pkg/healthcheck/evaluator_test.go
@@ -39,22 +39,39 @@ func scalar(v float64) model.Value {
 	return &model.Scalar{Value: model.SampleValue(v), Timestamp: model.Now()}
 }
 
+func testCheck() Check {
+	return Check{
+		Name:          "errors",
+		CurrentRange:  time.Minute,
+		BaselineRange: 2 * time.Minute,
+		QueryTimeout:  time.Second,
+		ErrorPolicy: RetryPolicy{
+			RetryInterval:   0,
+			MaxAttempts:     1,
+			ExhaustedAction: ActionPause,
+		},
+		NoDataPolicy: RetryPolicy{
+			RetryInterval:   0,
+			MaxAttempts:     1,
+			ExhaustedAction: ActionPause,
+		},
+		FailurePolicy: FailurePolicy{
+			ReevaluationInterval: time.Millisecond,
+			ConsecutiveFailures:  1,
+			ConsecutiveSuccesses: 1,
+			ExceededAction:       ActionPause,
+		},
+		Query:        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+		SuccessQuery: `(${current} < bool 1) or (${current} < bool (2 * ${baseline}))`,
+	}
+}
+
 func TestEvaluator_PassFailNoDataError(t *testing.T) {
 	baseCfg := &Config{
 		Name:          "hc",
 		PrometheusURL: "http://prometheus",
 		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
-		Checks: []Check{{
-			Name:          "errors",
-			CurrentRange:  time.Minute,
-			BaselineRange: 2 * time.Minute,
-			QueryTimeout:  time.Second,
-			QueryRetries:  0,
-			OnFailure:     ActionPause,
-			OnNoData:      ActionPause,
-			Query:         `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
-			SuccessQuery:  `(${current} < bool 1) or (${current} < bool (2 * ${baseline}))`,
-		}},
+		Checks:        []Check{testCheck()},
 	}
 
 	t.Run("pass", func(t *testing.T) {
@@ -68,15 +85,15 @@ func TestEvaluator_PassFailNoDataError(t *testing.T) {
 			Config:        baseCfg,
 			Namespace:     "ns",
 			RolloutGroup:  "ingester",
-			CandidatePods: []string{"ingester-zone-a-0"},
-			StablePods:    []string{"ingester-zone-b-0"},
+			CandidatePods: TargetPods{Names: []string{"ingester-zone-a-0"}, Zones: []string{"ingester-zone-a"}},
+			StablePods:    TargetPods{Names: []string{"ingester-zone-b-0"}, Zones: []string{"ingester-zone-b"}},
 			Now:           time.Now(),
 			BaselineTime:  time.Now().Add(-time.Hour),
 		})
-		require.Equal(t, OutcomePass, resp.Outcome)
-		require.Equal(t, ResultPass, resp.CheckResults["errors"])
+		require.Equal(t, ResultPass, resp.Results["errors"])
 		require.Len(t, q.calls, 3)
 		require.True(t, strings.Contains(q.calls[0], `pod=~"ingester-zone-a-0"`))
+		require.True(t, strings.Contains(q.calls[0], `name=~"ingester-zone-a"`))
 		require.True(t, strings.Contains(q.calls[0], `[1m]`))
 		require.True(t, strings.Contains(q.calls[1], `pod=~"ingester-zone-b-0"`))
 		require.True(t, strings.Contains(q.calls[1], `[2m]`))
@@ -84,7 +101,7 @@ func TestEvaluator_PassFailNoDataError(t *testing.T) {
 		require.True(t, strings.Contains(q.calls[2], "0.2"))
 	})
 
-	t.Run("fail pauses", func(t *testing.T) {
+	t.Run("fail", func(t *testing.T) {
 		q := &fakeQuerier{sequence: []func() (model.Value, error){
 			func() (model.Value, error) { return scalar(5), nil },
 			func() (model.Value, error) { return scalar(0.1), nil },
@@ -92,65 +109,25 @@ func TestEvaluator_PassFailNoDataError(t *testing.T) {
 		}}
 		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
 		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: baseCfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
-		require.Equal(t, OutcomePause, resp.Outcome)
-		require.Equal(t, ResultFail, resp.CheckResults["errors"])
+		require.Equal(t, ResultFail, resp.Results["errors"])
 	})
 
-	t.Run("no data pauses", func(t *testing.T) {
+	t.Run("no data", func(t *testing.T) {
 		q := &fakeQuerier{sequence: []func() (model.Value, error){
 			func() (model.Value, error) { return model.Vector{}, nil },
 		}}
 		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
 		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: baseCfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
-		require.Equal(t, OutcomePause, resp.Outcome)
-		require.Equal(t, ResultNoData, resp.CheckResults["errors"])
+		require.Equal(t, ResultNoData, resp.Results["errors"])
 	})
 
-	t.Run("error pauses", func(t *testing.T) {
+	t.Run("error", func(t *testing.T) {
 		q := &fakeQuerier{sequence: []func() (model.Value, error){
 			func() (model.Value, error) { return nil, errors.New("boom") },
 		}}
 		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
 		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: baseCfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
-		require.Equal(t, OutcomePause, resp.Outcome)
-		require.Equal(t, ResultError, resp.CheckResults["errors"])
-	})
-
-	t.Run("warn on failure", func(t *testing.T) {
-		cfg := *baseCfg
-		cfg.Checks = append([]Check(nil), baseCfg.Checks...)
-		cfg.Checks[0].OnFailure = ActionWarn
-		q := &fakeQuerier{sequence: []func() (model.Value, error){
-			func() (model.Value, error) { return scalar(5), nil },
-			func() (model.Value, error) { return scalar(0.1), nil },
-			func() (model.Value, error) { return scalar(0), nil },
-		}}
-		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
-		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: &cfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
-		require.Equal(t, OutcomeWarn, resp.Outcome)
-	})
-
-	t.Run("retries then succeeds", func(t *testing.T) {
-		cfg := *baseCfg
-		cfg.Checks = append([]Check(nil), baseCfg.Checks...)
-		cfg.Checks[0].QueryRetries = 2
-		attempts := 0
-		q := &fakeQuerier{sequence: []func() (model.Value, error){
-			func() (model.Value, error) {
-				attempts++
-				return nil, errors.New("transient")
-			},
-			func() (model.Value, error) {
-				attempts++
-				return scalar(0.1), nil
-			},
-			func() (model.Value, error) { return scalar(0.2), nil },
-			func() (model.Value, error) { return scalar(1), nil },
-		}}
-		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
-		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: &cfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
-		require.Equal(t, OutcomePass, resp.Outcome)
-		require.Equal(t, 2, attempts)
+		require.Equal(t, ResultError, resp.Results["errors"])
 	})
 
 	t.Run("disabled check skipped", func(t *testing.T) {
@@ -160,12 +137,15 @@ func TestEvaluator_PassFailNoDataError(t *testing.T) {
 		q := &fakeQuerier{}
 		e := NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger())
 		resp := e.Evaluate(context.Background(), EvaluateRequest{Config: &cfg, Namespace: "ns", RolloutGroup: "ingester", Now: time.Now()})
-		require.Equal(t, OutcomePass, resp.Outcome)
+		require.Equal(t, ResultSkipped, resp.Results["errors"])
 		require.Empty(t, q.calls)
 	})
 }
 
 func TestBuildTargetMatchers(t *testing.T) {
-	require.Equal(t, `namespace="ns",pod=~"^$"`, buildTargetMatchers("ns", nil))
-	require.Equal(t, `namespace="ns",pod=~"a-0|b-1"`, buildTargetMatchers("ns", []string{"a-0", "b-1"}))
+	require.Equal(t, `namespace="ns",pod=~"^$"`, buildTargetMatchers("ns", TargetPods{}))
+	require.Equal(t, `namespace="ns",name=~"a|b",pod=~"a-0|b-1"`, buildTargetMatchers("ns", TargetPods{
+		Names: []string{"a-0", "b-1"},
+		Zones: []string{"a", "b"},
+	}))
 }

--- a/pkg/healthcheck/evaluator_test.go
+++ b/pkg/healthcheck/evaluator_test.go
@@ -93,7 +93,7 @@ func TestEvaluator_PassFailNoDataError(t *testing.T) {
 		require.Equal(t, ResultPass, resp.Results["errors"])
 		require.Len(t, q.calls, 3)
 		require.True(t, strings.Contains(q.calls[0], `pod=~"ingester-zone-a-0"`))
-		require.True(t, strings.Contains(q.calls[0], `name=~"ingester-zone-a"`))
+		require.NotContains(t, q.calls[0], `name=~`)
 		require.True(t, strings.Contains(q.calls[0], `[1m]`))
 		require.True(t, strings.Contains(q.calls[1], `pod=~"ingester-zone-b-0"`))
 		require.True(t, strings.Contains(q.calls[1], `[2m]`))
@@ -144,7 +144,7 @@ func TestEvaluator_PassFailNoDataError(t *testing.T) {
 
 func TestBuildTargetMatchers(t *testing.T) {
 	require.Equal(t, `namespace="ns",pod=~"^$"`, buildTargetMatchers("ns", TargetPods{}))
-	require.Equal(t, `namespace="ns",name=~"a|b",pod=~"a-0|b-1"`, buildTargetMatchers("ns", TargetPods{
+	require.Equal(t, `namespace="ns",pod=~"a-0|b-1"`, buildTargetMatchers("ns", TargetPods{
 		Names: []string{"a-0", "b-1"},
 		Zones: []string{"a", "b"},
 	}))

--- a/pkg/healthcheck/gate.go
+++ b/pkg/healthcheck/gate.go
@@ -1,0 +1,203 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+const (
+	eventBlocked       = "RolloutBlockedByHealthCheck"
+	eventMisconfigured = "RolloutHealthCheckMisconfigured"
+	eventWarn          = "RolloutHealthCheckWarn"
+)
+
+// ConfigProvider looks up a RolloutHealthCheck by name.
+type ConfigProvider interface {
+	Get(name string) *Config
+}
+
+// Gate decides whether progression to the next zone should pause for health checks.
+type Gate struct {
+	provider  ConfigProvider
+	evaluator *Evaluator
+	metrics   *Metrics
+	recorder  record.EventRecorder
+	logger    log.Logger
+
+	// Tracks rollout groups currently reported as misconfigured so the counter and
+	// events are not re-emitted on every reconcile while the binding stays broken.
+	misconfiguredGroups sync.Map
+}
+
+// NewGate creates a health-check gate.
+func NewGate(provider ConfigProvider, evaluator *Evaluator, metrics *Metrics, recorder record.EventRecorder, logger log.Logger) *Gate {
+	return &Gate{
+		provider:  provider,
+		evaluator: evaluator,
+		metrics:   metrics,
+		recorder:  recorder,
+		logger:    logger,
+	}
+}
+
+// Decision is the gate result for a single between-zone transition.
+type Decision struct {
+	// ShouldPause is true when the next zone must not start rolling yet.
+	ShouldPause bool
+	// Reason is a human-readable explanation when ShouldPause or a warning/misconfiguration occurred.
+	Reason string
+}
+
+// Request is the input for a between-zone gate evaluation.
+type Request struct {
+	RolloutGroup  string
+	Namespace     string
+	Sets          []*appsv1.StatefulSet
+	NextSTS       *appsv1.StatefulSet
+	CandidatePods []*corev1.Pod
+	StablePods    []*corev1.Pod
+	BaselineTime  time.Time
+}
+
+// Evaluate resolves the RolloutHealthCheck annotation on NextSTS and evaluates checks.
+// Missing / mismatched bindings proceed (ShouldPause=false) but emit misconfiguration signals.
+func (g *Gate) Evaluate(ctx context.Context, req Request) Decision {
+	checkName := strings.TrimSpace(req.NextSTS.Annotations[config.RolloutHealthCheckAnnotationKey])
+	if checkName == "" {
+		g.setBlocked(req.RolloutGroup, false)
+		return Decision{}
+	}
+
+	cfg := g.provider.Get(checkName)
+	if cfg == nil {
+		msg := fmt.Sprintf("RolloutHealthCheck %q referenced by annotation %s was not found", checkName, config.RolloutHealthCheckAnnotationKey)
+		g.reportMisconfigured(req, msg)
+		return Decision{Reason: msg}
+	}
+
+	if !cfg.MatchesLabels(labels.Set(req.NextSTS.Labels)) {
+		msg := fmt.Sprintf("RolloutHealthCheck %q selector does not match StatefulSet %s", checkName, req.NextSTS.Name)
+		g.reportMisconfigured(req, msg)
+		return Decision{Reason: msg}
+	}
+
+	resp := g.evaluator.Evaluate(ctx, EvaluateRequest{
+		Config:        cfg,
+		Namespace:     req.Namespace,
+		RolloutGroup:  req.RolloutGroup,
+		CandidatePods: podNames(req.CandidatePods),
+		StablePods:    podNames(req.StablePods),
+		BaselineTime:  req.BaselineTime,
+		Now:           time.Now(),
+	})
+
+	switch resp.Outcome {
+	case OutcomePause:
+		msg := resp.Message
+		if msg == "" {
+			msg = fmt.Sprintf("health check %q paused rollout of group %s", resp.FailedCheck, req.RolloutGroup)
+		}
+		level.Warn(g.logger).Log("msg", "rollout blocked by health check", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "check", resp.FailedCheck, "detail", msg)
+		g.event(req.NextSTS, corev1.EventTypeWarning, eventBlocked, msg)
+		g.clearMisconfigured(req.RolloutGroup)
+		g.setBlocked(req.RolloutGroup, true)
+		return Decision{ShouldPause: true, Reason: msg}
+	case OutcomeWarn:
+		msg := resp.Message
+		if msg == "" {
+			msg = fmt.Sprintf("health check %q warned for group %s", resp.FailedCheck, req.RolloutGroup)
+		}
+		level.Warn(g.logger).Log("msg", "health check warning", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "check", resp.FailedCheck, "detail", msg)
+		g.event(req.NextSTS, corev1.EventTypeWarning, eventWarn, msg)
+		g.clearMisconfigured(req.RolloutGroup)
+		g.setBlocked(req.RolloutGroup, false)
+		return Decision{Reason: msg}
+	default:
+		g.clearMisconfigured(req.RolloutGroup)
+		g.setBlocked(req.RolloutGroup, false)
+		return Decision{}
+	}
+}
+
+func (g *Gate) reportMisconfigured(req Request, msg string) {
+	level.Error(g.logger).Log("msg", "rollout health check misconfigured", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "detail", msg)
+	_, already := g.misconfiguredGroups.LoadOrStore(req.RolloutGroup, struct{}{})
+	if !already {
+		g.event(req.NextSTS, corev1.EventTypeWarning, eventMisconfigured, msg)
+		if g.metrics != nil {
+			g.metrics.MisconfiguredTotal.WithLabelValues(req.RolloutGroup).Inc()
+		}
+	}
+	if g.metrics != nil {
+		g.metrics.Misconfigured.WithLabelValues(req.RolloutGroup).Set(1)
+	}
+	g.setBlocked(req.RolloutGroup, false)
+}
+
+func (g *Gate) clearMisconfigured(rolloutGroup string) {
+	if _, loaded := g.misconfiguredGroups.LoadAndDelete(rolloutGroup); loaded || g.metrics != nil {
+		if g.metrics != nil {
+			g.metrics.Misconfigured.WithLabelValues(rolloutGroup).Set(0)
+		}
+	}
+}
+
+func (g *Gate) setBlocked(rolloutGroup string, blocked bool) {
+	if g.metrics == nil {
+		return
+	}
+	val := 0.0
+	if blocked {
+		val = 1
+	}
+	g.metrics.Blocked.WithLabelValues(rolloutGroup).Set(val)
+}
+
+func (g *Gate) event(sts *appsv1.StatefulSet, eventType, reason, message string) {
+	if g.recorder == nil || sts == nil {
+		return
+	}
+	g.recorder.Event(sts, eventType, reason, message)
+}
+
+func podNames(pods []*corev1.Pod) []string {
+	names := make([]string, 0, len(pods))
+	for _, p := range pods {
+		names = append(names, p.Name)
+	}
+	return names
+}
+
+// ParseStartedAtAnnotation parses "<updateRevision>=<RFC3339>" from the annotation value.
+// Returns zero time if missing or mismatched revision.
+func ParseStartedAtAnnotation(value, updateRevision string) time.Time {
+	if value == "" || updateRevision == "" {
+		return time.Time{}
+	}
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 || parts[0] != updateRevision {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, parts[1])
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// FormatStartedAtAnnotation builds the annotation value for a revision start time.
+func FormatStartedAtAnnotation(updateRevision string, t time.Time) string {
+	return updateRevision + "=" + t.UTC().Format(time.RFC3339)
+}

--- a/pkg/healthcheck/gate.go
+++ b/pkg/healthcheck/gate.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 
 	"github.com/grafana/rollout-operator/pkg/config"
@@ -78,22 +78,30 @@ type Decision struct {
 
 // Request is the input for a between-zone gate evaluation.
 type Request struct {
-	RolloutGroup  string
-	Namespace     string
-	Sets          []*appsv1.StatefulSet
-	NextSTS       *appsv1.StatefulSet
-	CandidatePods []*corev1.Pod
-	StablePods    []*corev1.Pod
-	BaselineTime  time.Time
-	Now           time.Time
+	RolloutGroup string
+	// StateKey isolates cached policy progress when workloads share a rollout group.
+	// It defaults to RolloutGroup.
+	StateKey          string
+	Namespace         string
+	TargetName        string
+	TargetKind        string
+	TargetLabels      map[string]string
+	TargetAnnotations map[string]string
+	EventTarget       runtime.Object
+	CandidatePods     []*corev1.Pod
+	StablePods        []*corev1.Pod
+	BaselineTime      time.Time
+	Now               time.Time
 }
 
-// Evaluate resolves the RolloutHealthCheck annotation on NextSTS and evaluates checks.
+// Evaluate resolves the RolloutHealthCheck annotation on the target workload and evaluates checks.
 // Missing / mismatched bindings proceed (ShouldPause=false) but emit misconfiguration signals.
 func (g *Gate) Evaluate(ctx context.Context, req Request) Decision {
-	checkName := strings.TrimSpace(req.NextSTS.Annotations[config.RolloutHealthCheckAnnotationKey])
+	stateKey := requestStateKey(req)
+	checkName := strings.TrimSpace(req.TargetAnnotations[config.RolloutHealthCheckAnnotationKey])
 	if checkName == "" {
-		g.clearGroupProgress(req.RolloutGroup)
+		g.clearGroupProgress(stateKey)
+		g.clearMisconfigured(stateKey, req.RolloutGroup)
 		g.setBlocked(req.RolloutGroup, false)
 		return Decision{}
 	}
@@ -105,8 +113,8 @@ func (g *Gate) Evaluate(ctx context.Context, req Request) Decision {
 		return Decision{Reason: msg}
 	}
 
-	if !cfg.MatchesLabels(labels.Set(req.NextSTS.Labels)) {
-		msg := fmt.Sprintf("RolloutHealthCheck %q selector does not match StatefulSet %s", checkName, req.NextSTS.Name)
+	if !cfg.MatchesLabels(labels.Set(req.TargetLabels)) {
+		msg := fmt.Sprintf("RolloutHealthCheck %q selector does not match %s %s", checkName, req.TargetKind, req.TargetName)
 		g.reportMisconfigured(req, msg)
 		return Decision{Reason: msg}
 	}
@@ -117,7 +125,7 @@ func (g *Gate) Evaluate(ctx context.Context, req Request) Decision {
 	}
 
 	// Skip Prometheus queries while every check is still inside its retry/reevaluation window.
-	if cached, ok := g.cachedDecision(req.RolloutGroup, cfg, now); ok {
+	if cached, ok := g.cachedDecision(stateKey, cfg, now); ok {
 		return g.finalize(req, cached, false)
 	}
 
@@ -136,27 +144,27 @@ func (g *Gate) Evaluate(ctx context.Context, req Request) Decision {
 		return g.finalize(req, Decision{ShouldPause: true, Reason: resp.ClientError}, true)
 	}
 
-	decision := g.applyPolicies(req.RolloutGroup, cfg, resp, now)
+	decision := g.applyPolicies(stateKey, cfg, resp, now)
 	return g.finalize(req, decision, true)
 }
 
 func (g *Gate) finalize(req Request, decision Decision, emitEvent bool) Decision {
 	if decision.ShouldPause {
-		level.Warn(g.logger).Log("msg", "rollout blocked by health check", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "detail", decision.Reason)
+		level.Warn(g.logger).Log("msg", "rollout blocked by health check", "rollout_group", req.RolloutGroup, "workload_kind", req.TargetKind, "workload", req.TargetName, "detail", decision.Reason)
 		if emitEvent {
-			g.event(req.NextSTS, corev1.EventTypeWarning, eventBlocked, decision.Reason)
+			g.event(req.EventTarget, corev1.EventTypeWarning, eventBlocked, decision.Reason)
 		}
-		g.clearMisconfigured(req.RolloutGroup)
+		g.clearMisconfigured(requestStateKey(req), req.RolloutGroup)
 		g.setBlocked(req.RolloutGroup, true)
 		return decision
 	}
 	if decision.Reason != "" {
-		level.Warn(g.logger).Log("msg", "health check warning", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "detail", decision.Reason)
+		level.Warn(g.logger).Log("msg", "health check warning", "rollout_group", req.RolloutGroup, "workload_kind", req.TargetKind, "workload", req.TargetName, "detail", decision.Reason)
 		if emitEvent {
-			g.event(req.NextSTS, corev1.EventTypeWarning, eventWarn, decision.Reason)
+			g.event(req.EventTarget, corev1.EventTypeWarning, eventWarn, decision.Reason)
 		}
 	}
-	g.clearMisconfigured(req.RolloutGroup)
+	g.clearMisconfigured(requestStateKey(req), req.RolloutGroup)
 	g.setBlocked(req.RolloutGroup, false)
 	return decision
 }
@@ -381,10 +389,10 @@ func progressKey(rolloutGroup, configName, checkName string) string {
 }
 
 func (g *Gate) reportMisconfigured(req Request, msg string) {
-	level.Error(g.logger).Log("msg", "rollout health check misconfigured", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "detail", msg)
-	_, already := g.misconfiguredGroups.LoadOrStore(req.RolloutGroup, struct{}{})
+	level.Error(g.logger).Log("msg", "rollout health check misconfigured", "rollout_group", req.RolloutGroup, "workload_kind", req.TargetKind, "workload", req.TargetName, "detail", msg)
+	_, already := g.misconfiguredGroups.LoadOrStore(requestStateKey(req), struct{}{})
 	if !already {
-		g.event(req.NextSTS, corev1.EventTypeWarning, eventMisconfigured, msg)
+		g.event(req.EventTarget, corev1.EventTypeWarning, eventMisconfigured, msg)
 		if g.metrics != nil {
 			g.metrics.MisconfiguredTotal.WithLabelValues(req.RolloutGroup).Inc()
 		}
@@ -395,12 +403,19 @@ func (g *Gate) reportMisconfigured(req Request, msg string) {
 	g.setBlocked(req.RolloutGroup, false)
 }
 
-func (g *Gate) clearMisconfigured(rolloutGroup string) {
-	if _, loaded := g.misconfiguredGroups.LoadAndDelete(rolloutGroup); loaded || g.metrics != nil {
+func (g *Gate) clearMisconfigured(stateKey, rolloutGroup string) {
+	if _, loaded := g.misconfiguredGroups.LoadAndDelete(stateKey); loaded || g.metrics != nil {
 		if g.metrics != nil {
 			g.metrics.Misconfigured.WithLabelValues(rolloutGroup).Set(0)
 		}
 	}
+}
+
+func requestStateKey(req Request) string {
+	if req.StateKey != "" {
+		return req.StateKey
+	}
+	return req.RolloutGroup
 }
 
 func (g *Gate) setBlocked(rolloutGroup string, blocked bool) {
@@ -414,11 +429,11 @@ func (g *Gate) setBlocked(rolloutGroup string, blocked bool) {
 	g.metrics.Blocked.WithLabelValues(rolloutGroup).Set(val)
 }
 
-func (g *Gate) event(sts *appsv1.StatefulSet, eventType, reason, message string) {
-	if g.recorder == nil || sts == nil {
+func (g *Gate) event(target runtime.Object, eventType, reason, message string) {
+	if g.recorder == nil || target == nil {
 		return
 	}
-	g.recorder.Event(sts, eventType, reason, message)
+	g.recorder.Event(target, eventType, reason, message)
 }
 
 func targetPodsFromCore(pods []*corev1.Pod) TargetPods {

--- a/pkg/healthcheck/gate.go
+++ b/pkg/healthcheck/gate.go
@@ -74,6 +74,8 @@ type Decision struct {
 	ShouldPause bool
 	// Reason is a human-readable explanation when ShouldPause or a warning/misconfiguration occurred.
 	Reason string
+	// RequeueAfter is the delay until a paused decision should be evaluated again.
+	RequeueAfter time.Duration
 }
 
 // Request is the input for a between-zone gate evaluation.
@@ -133,28 +135,63 @@ func (g *Gate) Evaluate(ctx context.Context, req Request) Decision {
 
 	if resp.ClientError != "" {
 		// Client construction failure is not per-check; pause safely.
-		return g.finalize(req, Decision{ShouldPause: true, Reason: resp.ClientError}, true)
+		return g.finalize(req, Decision{
+			ShouldPause:  true,
+			Reason:       resp.ClientError,
+			RequeueAfter: minimumErrorRetryInterval(cfg),
+		}, true)
 	}
 
-	decision := g.applyPolicies(req.RolloutGroup, cfg, resp, now)
+	policyNow := now
+	if req.Now.IsZero() {
+		policyNow = time.Now()
+	}
+	decision := g.applyPolicies(req.RolloutGroup, cfg, resp, policyNow)
 	return g.finalize(req, decision, true)
 }
 
 func (g *Gate) finalize(req Request, decision Decision, emitEvent bool) Decision {
+	if !emitEvent {
+		g.setBlocked(req.RolloutGroup, decision.ShouldPause)
+		return decision
+	}
+
+	action := "proceed"
 	if decision.ShouldPause {
-		level.Warn(g.logger).Log("msg", "rollout blocked by health check", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "detail", decision.Reason)
-		if emitEvent {
-			g.event(req.NextSTS, corev1.EventTypeWarning, eventBlocked, decision.Reason)
-		}
+		action = "pause"
+		level.Warn(g.logger).Log(
+			"msg", "health check evaluation completed",
+			"rollout_group", req.RolloutGroup,
+			"policy", strings.TrimSpace(req.NextSTS.Annotations[config.RolloutHealthCheckAnnotationKey]),
+			"statefulset", req.NextSTS.Name,
+			"action", action,
+			"requeue_after", decision.RequeueAfter,
+			"detail", decision.Reason,
+		)
+		g.event(req.NextSTS, corev1.EventTypeWarning, eventBlocked, decision.Reason)
 		g.clearMisconfigured(req.RolloutGroup)
 		g.setBlocked(req.RolloutGroup, true)
 		return decision
 	}
 	if decision.Reason != "" {
-		level.Warn(g.logger).Log("msg", "health check warning", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "detail", decision.Reason)
-		if emitEvent {
-			g.event(req.NextSTS, corev1.EventTypeWarning, eventWarn, decision.Reason)
-		}
+		action = "warn"
+		level.Warn(g.logger).Log(
+			"msg", "health check evaluation completed",
+			"rollout_group", req.RolloutGroup,
+			"policy", strings.TrimSpace(req.NextSTS.Annotations[config.RolloutHealthCheckAnnotationKey]),
+			"statefulset", req.NextSTS.Name,
+			"action", action,
+			"detail", decision.Reason,
+		)
+		g.event(req.NextSTS, corev1.EventTypeWarning, eventWarn, decision.Reason)
+	} else {
+		level.Info(g.logger).Log(
+			"msg", "health check evaluation completed",
+			"rollout_group", req.RolloutGroup,
+			"policy", strings.TrimSpace(req.NextSTS.Annotations[config.RolloutHealthCheckAnnotationKey]),
+			"statefulset", req.NextSTS.Name,
+			"action", action,
+		)
 	}
 	g.clearMisconfigured(req.RolloutGroup)
 	g.setBlocked(req.RolloutGroup, false)
@@ -179,6 +216,7 @@ func (g *Gate) applyPolicies(rolloutGroup string, cfg *Config, resp EvaluateResp
 			continue
 		}
 		outcome, msg := g.applyCheckPolicy(rolloutGroup, cfg.Name, check, ev, now)
+		g.logPolicyOutcome(rolloutGroup, cfg.Name, check, ev, outcome)
 		switch outcome {
 		case OutcomePause:
 			shouldPause = true
@@ -193,7 +231,11 @@ func (g *Gate) applyPolicies(rolloutGroup string, cfg *Config, resp EvaluateResp
 	}
 
 	if shouldPause {
-		return Decision{ShouldPause: true, Reason: pauseReason}
+		return Decision{
+			ShouldPause:  true,
+			Reason:       pauseReason,
+			RequeueAfter: g.nextEvaluationDelay(rolloutGroup, cfg, now),
+		}
 	}
 	if warnReason != "" {
 		return Decision{Reason: warnReason}
@@ -340,12 +382,100 @@ func (g *Gate) cachedDecision(rolloutGroup string, cfg *Config, now time.Time) (
 		return Decision{}, false
 	}
 	if shouldPause {
-		return Decision{ShouldPause: true, Reason: pauseReason}, true
+		return Decision{
+			ShouldPause:  true,
+			Reason:       pauseReason,
+			RequeueAfter: g.nextEvaluationDelayLocked(rolloutGroup, cfg, now),
+		}, true
 	}
 	if warnReason != "" {
 		return Decision{Reason: warnReason}, true
 	}
 	return Decision{}, true
+}
+
+func (g *Gate) nextEvaluationDelay(rolloutGroup string, cfg *Config, now time.Time) time.Duration {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.nextEvaluationDelayLocked(rolloutGroup, cfg, now)
+}
+
+func (g *Gate) nextEvaluationDelayLocked(rolloutGroup string, cfg *Config, now time.Time) time.Duration {
+	var earliest time.Time
+	for _, check := range cfg.Checks {
+		if check.Disabled {
+			continue
+		}
+		prog := g.progress[progressKey(rolloutGroup, cfg.Name, check.Name)]
+		if prog == nil || prog.lastEvalAt.IsZero() {
+			continue
+		}
+		due := prog.lastEvalAt.Add(holdInterval(check, prog.lastResult))
+		if earliest.IsZero() || due.Before(earliest) {
+			earliest = due
+		}
+	}
+	if earliest.IsZero() || !earliest.After(now) {
+		return 0
+	}
+	return earliest.Sub(now)
+}
+
+func minimumErrorRetryInterval(cfg *Config) time.Duration {
+	var interval time.Duration
+	for _, check := range cfg.Checks {
+		if check.Disabled {
+			continue
+		}
+		if interval == 0 || check.ErrorPolicy.RetryInterval < interval {
+			interval = check.ErrorPolicy.RetryInterval
+		}
+	}
+	return interval
+}
+
+func (g *Gate) logPolicyOutcome(rolloutGroup, policy string, check Check, ev CheckEvaluation, outcome CheckOutcome) {
+	key := progressKey(rolloutGroup, policy, check.Name)
+	g.mu.Lock()
+	prog := g.progress[key]
+	var snapshot checkProgress
+	if prog != nil {
+		snapshot = *prog
+	}
+	g.mu.Unlock()
+
+	logFn := level.Info
+	if outcome == OutcomeSkipped {
+		logFn = level.Debug
+	}
+	keyvals := []interface{}{
+		"msg", "health check policy applied",
+		"rollout_group", rolloutGroup,
+		"policy", policy,
+		"check", check.Name,
+		"result", ev.Result,
+		"action", outcome,
+		"consecutive_successes", snapshot.consecutiveSuccesses,
+		"required_successes", check.FailurePolicy.ConsecutiveSuccesses,
+		"consecutive_failures", snapshot.consecutiveFailures,
+		"allowed_failures", check.FailurePolicy.ConsecutiveFailures,
+	}
+	if ev.CurrentValue != nil {
+		keyvals = append(keyvals, "current_value", *ev.CurrentValue)
+	}
+	if ev.BaselineValue != nil {
+		keyvals = append(keyvals, "baseline_value", *ev.BaselineValue)
+	}
+	if ev.QueryType != "" {
+		keyvals = append(keyvals, "query_type", ev.QueryType)
+	}
+	switch ev.Result {
+	case ResultError:
+		keyvals = append(keyvals, "attempt", snapshot.errorAttempts, "max_attempts", check.ErrorPolicy.MaxAttempts)
+	case ResultNoData:
+		keyvals = append(keyvals, "attempt", snapshot.noDataAttempts, "max_attempts", check.NoDataPolicy.MaxAttempts)
+	}
+	logFn(g.logger).Log(keyvals...)
 }
 
 func holdInterval(check Check, last EvaluationResult) time.Duration {

--- a/pkg/healthcheck/gate.go
+++ b/pkg/healthcheck/gate.go
@@ -28,6 +28,17 @@ type ConfigProvider interface {
 	Get(name string) *Config
 }
 
+type checkProgress struct {
+	consecutiveFailures  int
+	consecutiveSuccesses int
+	errorAttempts        int
+	noDataAttempts       int
+	lastEvalAt           time.Time
+	lastOutcome          CheckOutcome
+	lastMessage          string
+	lastResult           EvaluationResult
+}
+
 // Gate decides whether progression to the next zone should pause for health checks.
 type Gate struct {
 	provider  ConfigProvider
@@ -35,6 +46,10 @@ type Gate struct {
 	metrics   *Metrics
 	recorder  record.EventRecorder
 	logger    log.Logger
+
+	mu sync.Mutex
+	// progress tracks consecutive pass/fail / retry state per rolloutGroup/config/check.
+	progress map[string]*checkProgress
 
 	// Tracks rollout groups currently reported as misconfigured so the counter and
 	// events are not re-emitted on every reconcile while the binding stays broken.
@@ -49,6 +64,7 @@ func NewGate(provider ConfigProvider, evaluator *Evaluator, metrics *Metrics, re
 		metrics:   metrics,
 		recorder:  recorder,
 		logger:    logger,
+		progress:  map[string]*checkProgress{},
 	}
 }
 
@@ -69,6 +85,7 @@ type Request struct {
 	CandidatePods []*corev1.Pod
 	StablePods    []*corev1.Pod
 	BaselineTime  time.Time
+	Now           time.Time
 }
 
 // Evaluate resolves the RolloutHealthCheck annotation on NextSTS and evaluates checks.
@@ -76,6 +93,7 @@ type Request struct {
 func (g *Gate) Evaluate(ctx context.Context, req Request) Decision {
 	checkName := strings.TrimSpace(req.NextSTS.Annotations[config.RolloutHealthCheckAnnotationKey])
 	if checkName == "" {
+		g.clearGroupProgress(req.RolloutGroup)
 		g.setBlocked(req.RolloutGroup, false)
 		return Decision{}
 	}
@@ -93,42 +111,273 @@ func (g *Gate) Evaluate(ctx context.Context, req Request) Decision {
 		return Decision{Reason: msg}
 	}
 
+	now := req.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	// Skip Prometheus queries while every check is still inside its retry/reevaluation window.
+	if cached, ok := g.cachedDecision(req.RolloutGroup, cfg, now); ok {
+		return g.finalize(req, cached, false)
+	}
+
 	resp := g.evaluator.Evaluate(ctx, EvaluateRequest{
 		Config:        cfg,
 		Namespace:     req.Namespace,
 		RolloutGroup:  req.RolloutGroup,
-		CandidatePods: podNames(req.CandidatePods),
-		StablePods:    podNames(req.StablePods),
+		CandidatePods: targetPodsFromCore(req.CandidatePods),
+		StablePods:    targetPodsFromCore(req.StablePods),
 		BaselineTime:  req.BaselineTime,
-		Now:           time.Now(),
+		Now:           now,
 	})
 
-	switch resp.Outcome {
-	case OutcomePause:
-		msg := resp.Message
-		if msg == "" {
-			msg = fmt.Sprintf("health check %q paused rollout of group %s", resp.FailedCheck, req.RolloutGroup)
+	if resp.ClientError != "" {
+		// Client construction failure is not per-check; pause safely.
+		return g.finalize(req, Decision{ShouldPause: true, Reason: resp.ClientError}, true)
+	}
+
+	decision := g.applyPolicies(req.RolloutGroup, cfg, resp, now)
+	return g.finalize(req, decision, true)
+}
+
+func (g *Gate) finalize(req Request, decision Decision, emitEvent bool) Decision {
+	if decision.ShouldPause {
+		level.Warn(g.logger).Log("msg", "rollout blocked by health check", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "detail", decision.Reason)
+		if emitEvent {
+			g.event(req.NextSTS, corev1.EventTypeWarning, eventBlocked, decision.Reason)
 		}
-		level.Warn(g.logger).Log("msg", "rollout blocked by health check", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "check", resp.FailedCheck, "detail", msg)
-		g.event(req.NextSTS, corev1.EventTypeWarning, eventBlocked, msg)
 		g.clearMisconfigured(req.RolloutGroup)
 		g.setBlocked(req.RolloutGroup, true)
-		return Decision{ShouldPause: true, Reason: msg}
-	case OutcomeWarn:
-		msg := resp.Message
-		if msg == "" {
-			msg = fmt.Sprintf("health check %q warned for group %s", resp.FailedCheck, req.RolloutGroup)
-		}
-		level.Warn(g.logger).Log("msg", "health check warning", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "check", resp.FailedCheck, "detail", msg)
-		g.event(req.NextSTS, corev1.EventTypeWarning, eventWarn, msg)
-		g.clearMisconfigured(req.RolloutGroup)
-		g.setBlocked(req.RolloutGroup, false)
-		return Decision{Reason: msg}
-	default:
-		g.clearMisconfigured(req.RolloutGroup)
-		g.setBlocked(req.RolloutGroup, false)
-		return Decision{}
+		return decision
 	}
+	if decision.Reason != "" {
+		level.Warn(g.logger).Log("msg", "health check warning", "rollout_group", req.RolloutGroup, "statefulset", req.NextSTS.Name, "detail", decision.Reason)
+		if emitEvent {
+			g.event(req.NextSTS, corev1.EventTypeWarning, eventWarn, decision.Reason)
+		}
+	}
+	g.clearMisconfigured(req.RolloutGroup)
+	g.setBlocked(req.RolloutGroup, false)
+	return decision
+}
+
+func (g *Gate) applyPolicies(rolloutGroup string, cfg *Config, resp EvaluateResponse, now time.Time) Decision {
+	checkByName := map[string]Check{}
+	for _, c := range cfg.Checks {
+		checkByName[c.Name] = c
+	}
+
+	var (
+		shouldPause bool
+		warnReason  string
+		pauseReason string
+	)
+
+	for _, ev := range resp.Checks {
+		check, ok := checkByName[ev.Name]
+		if !ok {
+			continue
+		}
+		outcome, msg := g.applyCheckPolicy(rolloutGroup, cfg.Name, check, ev, now)
+		switch outcome {
+		case OutcomePause:
+			shouldPause = true
+			if pauseReason == "" {
+				pauseReason = msg
+			}
+		case OutcomeWarn:
+			if warnReason == "" {
+				warnReason = msg
+			}
+		}
+	}
+
+	if shouldPause {
+		return Decision{ShouldPause: true, Reason: pauseReason}
+	}
+	if warnReason != "" {
+		return Decision{Reason: warnReason}
+	}
+	return Decision{}
+}
+
+func (g *Gate) applyCheckPolicy(rolloutGroup, configName string, check Check, ev CheckEvaluation, now time.Time) (CheckOutcome, string) {
+	key := progressKey(rolloutGroup, configName, check.Name)
+
+	switch ev.Result {
+	case ResultSkipped:
+		g.clearProgress(key)
+		return OutcomeSkipped, ""
+	case ResultError:
+		return g.applyRetryPolicy(key, check.ErrorPolicy, ResultError, ev.Message, now, "error")
+	case ResultNoData:
+		return g.applyRetryPolicy(key, check.NoDataPolicy, ResultNoData, ev.Message, now, "no-data")
+	case ResultPass, ResultFail:
+		return g.applyFailurePolicy(key, check, ev, now)
+	default:
+		return OutcomePause, ev.Message
+	}
+}
+
+func (g *Gate) applyRetryPolicy(key string, policy RetryPolicy, result EvaluationResult, message string, now time.Time, kind string) (CheckOutcome, string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	prog := g.progress[key]
+	if prog == nil {
+		prog = &checkProgress{}
+		g.progress[key] = prog
+	}
+
+	attempts := &prog.errorAttempts
+	if result == ResultNoData {
+		attempts = &prog.noDataAttempts
+	}
+	*attempts++
+
+	prog.lastEvalAt = now
+	prog.lastResult = result
+	msg := message
+	if msg == "" {
+		msg = fmt.Sprintf("%s on health check", kind)
+	}
+
+	if *attempts < policy.MaxAttempts {
+		prog.lastOutcome = OutcomePause
+		prog.lastMessage = fmt.Sprintf("%s (attempt %d/%d)", msg, *attempts, policy.MaxAttempts)
+		return OutcomePause, prog.lastMessage
+	}
+
+	outcome := actionToOutcome(policy.ExhaustedAction)
+	prog.lastOutcome = outcome
+	prog.lastMessage = fmt.Sprintf("%s after %d attempts", msg, *attempts)
+	return outcome, prog.lastMessage
+}
+
+func (g *Gate) applyFailurePolicy(key string, check Check, ev CheckEvaluation, now time.Time) (CheckOutcome, string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	prog := g.progress[key]
+	if prog == nil {
+		prog = &checkProgress{}
+		g.progress[key] = prog
+	}
+
+	// Fresh query results always update counters. reevaluationInterval only gates whether
+	// Evaluate re-queries (via cachedDecision), not whether new results are applied.
+	prog.lastEvalAt = now
+	prog.lastResult = ev.Result
+	prog.errorAttempts = 0
+	prog.noDataAttempts = 0
+	msg := ev.Message
+
+	if ev.Result == ResultPass {
+		prog.consecutiveSuccesses++
+		prog.consecutiveFailures = 0
+		if prog.consecutiveSuccesses >= check.FailurePolicy.ConsecutiveSuccesses {
+			prog.lastOutcome = OutcomePass
+			prog.lastMessage = ""
+			return OutcomePass, ""
+		}
+		prog.lastOutcome = OutcomePause
+		prog.lastMessage = fmt.Sprintf("check %q needs %d consecutive successes (have %d)", check.Name, check.FailurePolicy.ConsecutiveSuccesses, prog.consecutiveSuccesses)
+		return OutcomePause, prog.lastMessage
+	}
+
+	prog.consecutiveFailures++
+	prog.consecutiveSuccesses = 0
+	if msg == "" {
+		msg = fmt.Sprintf("check %q failed", check.Name)
+	}
+	if prog.consecutiveFailures >= check.FailurePolicy.ConsecutiveFailures {
+		outcome := actionToOutcome(check.FailurePolicy.ExceededAction)
+		prog.lastOutcome = outcome
+		prog.lastMessage = msg
+		return outcome, msg
+	}
+	prog.lastOutcome = OutcomePause
+	prog.lastMessage = fmt.Sprintf("%s (%d/%d consecutive failures)", msg, prog.consecutiveFailures, check.FailurePolicy.ConsecutiveFailures)
+	return OutcomePause, prog.lastMessage
+}
+
+func (g *Gate) cachedDecision(rolloutGroup string, cfg *Config, now time.Time) (Decision, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	var (
+		sawAny      bool
+		shouldPause bool
+		warnReason  string
+		pauseReason string
+	)
+	for _, check := range cfg.Checks {
+		if check.Disabled {
+			continue
+		}
+		prog := g.progress[progressKey(rolloutGroup, cfg.Name, check.Name)]
+		if prog == nil || prog.lastEvalAt.IsZero() {
+			return Decision{}, false
+		}
+		interval := holdInterval(check, prog.lastResult)
+		if !now.Before(prog.lastEvalAt.Add(interval)) {
+			return Decision{}, false
+		}
+		sawAny = true
+		switch prog.lastOutcome {
+		case OutcomePause:
+			shouldPause = true
+			if pauseReason == "" {
+				pauseReason = prog.lastMessage
+			}
+		case OutcomeWarn:
+			if warnReason == "" {
+				warnReason = prog.lastMessage
+			}
+		}
+	}
+	if !sawAny {
+		return Decision{}, false
+	}
+	if shouldPause {
+		return Decision{ShouldPause: true, Reason: pauseReason}, true
+	}
+	if warnReason != "" {
+		return Decision{Reason: warnReason}, true
+	}
+	return Decision{}, true
+}
+
+func holdInterval(check Check, last EvaluationResult) time.Duration {
+	switch last {
+	case ResultError:
+		return check.ErrorPolicy.RetryInterval
+	case ResultNoData:
+		return check.NoDataPolicy.RetryInterval
+	default:
+		return check.FailurePolicy.ReevaluationInterval
+	}
+}
+
+func (g *Gate) clearProgress(key string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.progress, key)
+}
+
+func (g *Gate) clearGroupProgress(rolloutGroup string) {
+	prefix := rolloutGroup + "/"
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for k := range g.progress {
+		if strings.HasPrefix(k, prefix) {
+			delete(g.progress, k)
+		}
+	}
+}
+
+func progressKey(rolloutGroup, configName, checkName string) string {
+	return rolloutGroup + "/" + configName + "/" + checkName
 }
 
 func (g *Gate) reportMisconfigured(req Request, msg string) {
@@ -172,12 +421,16 @@ func (g *Gate) event(sts *appsv1.StatefulSet, eventType, reason, message string)
 	g.recorder.Event(sts, eventType, reason, message)
 }
 
-func podNames(pods []*corev1.Pod) []string {
+func targetPodsFromCore(pods []*corev1.Pod) TargetPods {
 	names := make([]string, 0, len(pods))
+	zones := make([]string, 0, len(pods))
 	for _, p := range pods {
 		names = append(names, p.Name)
+		if z := p.Labels["name"]; z != "" {
+			zones = append(zones, z)
+		}
 	}
-	return names
+	return TargetPods{Names: names, Zones: uniqueNonEmpty(zones)}
 }
 
 // ParseStartedAtAnnotation parses "<updateRevision>=<RFC3339>" from the annotation value.

--- a/pkg/healthcheck/gate_test.go
+++ b/pkg/healthcheck/gate_test.go
@@ -1,0 +1,78 @@
+package healthcheck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+type staticProvider struct {
+	cfg *Config
+}
+
+func (s staticProvider) Get(name string) *Config {
+	if s.cfg != nil && s.cfg.Name == name {
+		return s.cfg
+	}
+	return nil
+}
+
+func TestGate_MisconfiguredProceeds(t *testing.T) {
+	recorder := record.NewFakeRecorder(10)
+	eval := NewEvaluator(func(string) (Querier, error) {
+		t.Fatal("should not query")
+		return nil, nil
+	}, nil, log.NewNopLogger())
+	gate := NewGate(staticProvider{}, eval, nil, recorder, log.NewNopLogger())
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ingester-zone-b",
+			Annotations: map[string]string{
+				config.RolloutHealthCheckAnnotationKey: "missing",
+			},
+			Labels: map[string]string{"rollout-group": "ingester"},
+		},
+	}
+	decision := gate.Evaluate(context.Background(), Request{
+		RolloutGroup: "ingester",
+		Namespace:    "ns",
+		Sets:         []*appsv1.StatefulSet{sts},
+		NextSTS:      sts,
+	})
+	require.False(t, decision.ShouldPause)
+	require.Contains(t, decision.Reason, "was not found")
+}
+
+func TestGate_SelectorMismatchProceeds(t *testing.T) {
+	recorder := record.NewFakeRecorder(10)
+	cfg := &Config{
+		Name:     "hc",
+		Selector: labels.SelectorFromSet(labels.Set{"rollout-group": "other"}),
+	}
+	gate := NewGate(staticProvider{cfg: cfg}, NewEvaluator(nil, nil, log.NewNopLogger()), nil, recorder, log.NewNopLogger())
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ingester-zone-b",
+			Annotations: map[string]string{
+				config.RolloutHealthCheckAnnotationKey: "hc",
+			},
+			Labels: map[string]string{"rollout-group": "ingester"},
+		},
+	}
+	decision := gate.Evaluate(context.Background(), Request{
+		RolloutGroup: "ingester",
+		Sets:         []*appsv1.StatefulSet{sts},
+		NextSTS:      sts,
+	})
+	require.False(t, decision.ShouldPause)
+	require.Contains(t, decision.Reason, "selector does not match")
+}

--- a/pkg/healthcheck/gate_test.go
+++ b/pkg/healthcheck/gate_test.go
@@ -46,10 +46,13 @@ func TestGate_MisconfiguredProceeds(t *testing.T) {
 		},
 	}
 	decision := gate.Evaluate(context.Background(), Request{
-		RolloutGroup: "ingester",
-		Namespace:    "ns",
-		Sets:         []*appsv1.StatefulSet{sts},
-		NextSTS:      sts,
+		RolloutGroup:      "ingester",
+		Namespace:         "ns",
+		TargetName:        sts.Name,
+		TargetKind:        "StatefulSet",
+		TargetLabels:      sts.Labels,
+		TargetAnnotations: sts.Annotations,
+		EventTarget:       sts,
 	})
 	require.False(t, decision.ShouldPause)
 	require.Contains(t, decision.Reason, "was not found")
@@ -72,9 +75,12 @@ func TestGate_SelectorMismatchProceeds(t *testing.T) {
 		},
 	}
 	decision := gate.Evaluate(context.Background(), Request{
-		RolloutGroup: "ingester",
-		Sets:         []*appsv1.StatefulSet{sts},
-		NextSTS:      sts,
+		RolloutGroup:      "ingester",
+		TargetName:        sts.Name,
+		TargetKind:        "StatefulSet",
+		TargetLabels:      sts.Labels,
+		TargetAnnotations: sts.Annotations,
+		EventTarget:       sts,
 	})
 	require.False(t, decision.ShouldPause)
 	require.Contains(t, decision.Reason, "selector does not match")
@@ -115,12 +121,9 @@ func TestGate_ConsecutiveFailures(t *testing.T) {
 		q.sequence = failSeq()
 		q.seqIdx = 0
 		time.Sleep(2 * time.Millisecond)
-		decision := gate.Evaluate(context.Background(), Request{
-			RolloutGroup: "ingester",
-			Namespace:    "ns",
-			NextSTS:      sts,
-			Now:          now.Add(time.Duration(i) * time.Second),
-		})
+		req := requestForStatefulSet(sts)
+		req.Now = now.Add(time.Duration(i) * time.Second)
+		decision := gate.Evaluate(context.Background(), req)
 		require.True(t, decision.ShouldPause, "iteration %d", i)
 		if i < 3 {
 			require.Contains(t, decision.Reason, "consecutive failures")
@@ -152,7 +155,9 @@ func TestGate_WarnOnFailureExceeded(t *testing.T) {
 			Labels:      map[string]string{"rollout-group": "ingester"},
 		},
 	}
-	decision := gate.Evaluate(context.Background(), Request{RolloutGroup: "ingester", Namespace: "ns", NextSTS: sts, Now: time.Now()})
+	req := requestForStatefulSet(sts)
+	req.Now = time.Now()
+	decision := gate.Evaluate(context.Background(), req)
 	require.False(t, decision.ShouldPause)
 	require.NotEmpty(t, decision.Reason)
 }
@@ -185,12 +190,9 @@ func TestGate_ErrorRetriesAcrossReconciles(t *testing.T) {
 		q.sequence = []func() (model.Value, error){
 			func() (model.Value, error) { return nil, errors.New("boom") },
 		}
-		decision := gate.Evaluate(context.Background(), Request{
-			RolloutGroup: "ingester",
-			Namespace:    "ns",
-			NextSTS:      sts,
-			Now:          now.Add(time.Duration(i) * time.Second),
-		})
+		req := requestForStatefulSet(sts)
+		req.Now = now.Add(time.Duration(i) * time.Second)
+		decision := gate.Evaluate(context.Background(), req)
 		require.True(t, decision.ShouldPause, "attempt %d", i)
 		if i < 3 {
 			require.Contains(t, decision.Reason, "attempt")
@@ -229,13 +231,28 @@ func TestGate_ConsecutiveSuccessesRequired(t *testing.T) {
 	}
 	now := time.Now()
 	q.sequence = passSeq()
-	decision := gate.Evaluate(context.Background(), Request{RolloutGroup: "ingester", Namespace: "ns", NextSTS: sts, Now: now})
+	req := requestForStatefulSet(sts)
+	req.Now = now
+	decision := gate.Evaluate(context.Background(), req)
 	require.True(t, decision.ShouldPause)
 	require.Contains(t, decision.Reason, "consecutive successes")
 
 	q.seqIdx = 0
 	q.sequence = passSeq()
-	decision = gate.Evaluate(context.Background(), Request{RolloutGroup: "ingester", Namespace: "ns", NextSTS: sts, Now: now.Add(time.Second)})
+	req.Now = now.Add(time.Second)
+	decision = gate.Evaluate(context.Background(), req)
 	require.False(t, decision.ShouldPause)
 	require.Empty(t, decision.Reason)
+}
+
+func requestForStatefulSet(sts *appsv1.StatefulSet) Request {
+	return Request{
+		RolloutGroup:      "ingester",
+		Namespace:         "ns",
+		TargetName:        sts.Name,
+		TargetKind:        "StatefulSet",
+		TargetLabels:      sts.Labels,
+		TargetAnnotations: sts.Annotations,
+		EventTarget:       sts,
+	}
 }

--- a/pkg/healthcheck/gate_test.go
+++ b/pkg/healthcheck/gate_test.go
@@ -2,9 +2,12 @@ package healthcheck
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,4 +78,164 @@ func TestGate_SelectorMismatchProceeds(t *testing.T) {
 	})
 	require.False(t, decision.ShouldPause)
 	require.Contains(t, decision.Reason, "selector does not match")
+}
+
+func TestGate_ConsecutiveFailures(t *testing.T) {
+	check := testCheck()
+	check.FailurePolicy.ConsecutiveFailures = 3
+	check.FailurePolicy.ConsecutiveSuccesses = 1
+	check.FailurePolicy.ReevaluationInterval = time.Millisecond
+	cfg := &Config{
+		Name:          "hc",
+		PrometheusURL: "http://prometheus",
+		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
+		Checks:        []Check{check},
+	}
+
+	failSeq := func() []func() (model.Value, error) {
+		return []func() (model.Value, error){
+			func() (model.Value, error) { return scalar(5), nil },
+			func() (model.Value, error) { return scalar(0.1), nil },
+			func() (model.Value, error) { return scalar(0), nil },
+		}
+	}
+
+	q := &fakeQuerier{sequence: failSeq()}
+	gate := NewGate(staticProvider{cfg: cfg}, NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger()), nil, record.NewFakeRecorder(10), log.NewNopLogger())
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ingester-zone-b",
+			Annotations: map[string]string{config.RolloutHealthCheckAnnotationKey: "hc"},
+			Labels:      map[string]string{"rollout-group": "ingester"},
+		},
+	}
+
+	now := time.Now()
+	for i := 1; i <= 3; i++ {
+		q.sequence = failSeq()
+		q.seqIdx = 0
+		time.Sleep(2 * time.Millisecond)
+		decision := gate.Evaluate(context.Background(), Request{
+			RolloutGroup: "ingester",
+			Namespace:    "ns",
+			NextSTS:      sts,
+			Now:          now.Add(time.Duration(i) * time.Second),
+		})
+		require.True(t, decision.ShouldPause, "iteration %d", i)
+		if i < 3 {
+			require.Contains(t, decision.Reason, "consecutive failures")
+		}
+	}
+}
+
+func TestGate_WarnOnFailureExceeded(t *testing.T) {
+	check := testCheck()
+	check.FailurePolicy.ConsecutiveFailures = 1
+	check.FailurePolicy.ExceededAction = ActionWarn
+	check.FailurePolicy.ReevaluationInterval = time.Millisecond
+	cfg := &Config{
+		Name:          "hc",
+		PrometheusURL: "http://prometheus",
+		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
+		Checks:        []Check{check},
+	}
+	q := &fakeQuerier{sequence: []func() (model.Value, error){
+		func() (model.Value, error) { return scalar(5), nil },
+		func() (model.Value, error) { return scalar(0.1), nil },
+		func() (model.Value, error) { return scalar(0), nil },
+	}}
+	gate := NewGate(staticProvider{cfg: cfg}, NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger()), nil, record.NewFakeRecorder(10), log.NewNopLogger())
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ingester-zone-b",
+			Annotations: map[string]string{config.RolloutHealthCheckAnnotationKey: "hc"},
+			Labels:      map[string]string{"rollout-group": "ingester"},
+		},
+	}
+	decision := gate.Evaluate(context.Background(), Request{RolloutGroup: "ingester", Namespace: "ns", NextSTS: sts, Now: time.Now()})
+	require.False(t, decision.ShouldPause)
+	require.NotEmpty(t, decision.Reason)
+}
+
+func TestGate_ErrorRetriesAcrossReconciles(t *testing.T) {
+	check := testCheck()
+	check.ErrorPolicy.MaxAttempts = 3
+	check.ErrorPolicy.RetryInterval = time.Millisecond
+	check.ErrorPolicy.ExhaustedAction = ActionPause
+	cfg := &Config{
+		Name:          "hc",
+		PrometheusURL: "http://prometheus",
+		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
+		Checks:        []Check{check},
+	}
+	q := &fakeQuerier{sequence: []func() (model.Value, error){
+		func() (model.Value, error) { return nil, errors.New("boom") },
+	}}
+	gate := NewGate(staticProvider{cfg: cfg}, NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger()), nil, record.NewFakeRecorder(10), log.NewNopLogger())
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ingester-zone-b",
+			Annotations: map[string]string{config.RolloutHealthCheckAnnotationKey: "hc"},
+			Labels:      map[string]string{"rollout-group": "ingester"},
+		},
+	}
+	now := time.Now()
+	for i := 1; i <= 3; i++ {
+		q.seqIdx = 0
+		q.sequence = []func() (model.Value, error){
+			func() (model.Value, error) { return nil, errors.New("boom") },
+		}
+		decision := gate.Evaluate(context.Background(), Request{
+			RolloutGroup: "ingester",
+			Namespace:    "ns",
+			NextSTS:      sts,
+			Now:          now.Add(time.Duration(i) * time.Second),
+		})
+		require.True(t, decision.ShouldPause, "attempt %d", i)
+		if i < 3 {
+			require.Contains(t, decision.Reason, "attempt")
+		} else {
+			require.Contains(t, decision.Reason, "after 3 attempts")
+		}
+	}
+}
+
+func TestGate_ConsecutiveSuccessesRequired(t *testing.T) {
+	check := testCheck()
+	check.FailurePolicy.ConsecutiveSuccesses = 2
+	check.FailurePolicy.ConsecutiveFailures = 3
+	check.FailurePolicy.ReevaluationInterval = time.Millisecond
+	cfg := &Config{
+		Name:          "hc",
+		PrometheusURL: "http://prometheus",
+		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
+		Checks:        []Check{check},
+	}
+	passSeq := func() []func() (model.Value, error) {
+		return []func() (model.Value, error){
+			func() (model.Value, error) { return scalar(0.1), nil },
+			func() (model.Value, error) { return scalar(0.2), nil },
+			func() (model.Value, error) { return scalar(1), nil },
+		}
+	}
+	q := &fakeQuerier{sequence: passSeq()}
+	gate := NewGate(staticProvider{cfg: cfg}, NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger()), nil, record.NewFakeRecorder(10), log.NewNopLogger())
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ingester-zone-b",
+			Annotations: map[string]string{config.RolloutHealthCheckAnnotationKey: "hc"},
+			Labels:      map[string]string{"rollout-group": "ingester"},
+		},
+	}
+	now := time.Now()
+	q.sequence = passSeq()
+	decision := gate.Evaluate(context.Background(), Request{RolloutGroup: "ingester", Namespace: "ns", NextSTS: sts, Now: now})
+	require.True(t, decision.ShouldPause)
+	require.Contains(t, decision.Reason, "consecutive successes")
+
+	q.seqIdx = 0
+	q.sequence = passSeq()
+	decision = gate.Evaluate(context.Background(), Request{RolloutGroup: "ingester", Namespace: "ns", NextSTS: sts, Now: now.Add(time.Second)})
+	require.False(t, decision.ShouldPause)
+	require.Empty(t, decision.Reason)
 }

--- a/pkg/healthcheck/gate_test.go
+++ b/pkg/healthcheck/gate_test.go
@@ -1,8 +1,10 @@
 package healthcheck
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -126,6 +128,98 @@ func TestGate_ConsecutiveFailures(t *testing.T) {
 			require.Contains(t, decision.Reason, "consecutive failures")
 		}
 	}
+}
+
+func TestGate_PausedDecisionReturnsNextEvaluationDelay(t *testing.T) {
+	check := testCheck()
+	check.FailurePolicy.ReevaluationInterval = time.Minute
+	cfg := &Config{
+		Name:          "hc",
+		PrometheusURL: "http://prometheus",
+		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
+		Checks:        []Check{check},
+	}
+	failSequence := func() []func() (model.Value, error) {
+		return []func() (model.Value, error){
+			func() (model.Value, error) { return scalar(5), nil },
+			func() (model.Value, error) { return scalar(0.1), nil },
+			func() (model.Value, error) { return scalar(0), nil },
+		}
+	}
+	q := &fakeQuerier{sequence: failSequence()}
+	gate := NewGate(staticProvider{cfg: cfg}, NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, log.NewNopLogger()), nil, nil, log.NewNopLogger())
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ingester-zone-b",
+			Annotations: map[string]string{config.RolloutHealthCheckAnnotationKey: "hc"},
+			Labels:      map[string]string{"rollout-group": "ingester"},
+		},
+	}
+	now := time.Now()
+	req := Request{RolloutGroup: "ingester", Namespace: "ns", NextSTS: sts, Now: now}
+
+	decision := gate.Evaluate(context.Background(), req)
+	require.True(t, decision.ShouldPause)
+	require.Equal(t, time.Minute, decision.RequeueAfter)
+	require.Len(t, q.calls, 3)
+
+	req.Now = now.Add(20 * time.Second)
+	decision = gate.Evaluate(context.Background(), req)
+	require.True(t, decision.ShouldPause)
+	require.Equal(t, 40*time.Second, decision.RequeueAfter)
+	require.Len(t, q.calls, 3, "cached decision must not query before the deadline")
+
+	q.sequence = failSequence()
+	q.seqIdx = 0
+	req.Now = now.Add(time.Minute)
+	decision = gate.Evaluate(context.Background(), req)
+	require.True(t, decision.ShouldPause)
+	require.Equal(t, time.Minute, decision.RequeueAfter)
+	require.Len(t, q.calls, 6)
+}
+
+func TestGate_LogsPolicyOutcomeWithoutQueries(t *testing.T) {
+	check := testCheck()
+	cfg := &Config{
+		Name:          "hc",
+		PrometheusURL: "http://prometheus",
+		Selector:      labels.SelectorFromSet(labels.Set{"rollout-group": "ingester"}),
+		Checks:        []Check{check},
+	}
+	q := &fakeQuerier{sequence: []func() (model.Value, error){
+		func() (model.Value, error) { return scalar(5), nil },
+		func() (model.Value, error) { return scalar(0.1), nil },
+		func() (model.Value, error) { return scalar(0), nil },
+	}}
+	var logs bytes.Buffer
+	logger := log.NewLogfmtLogger(&logs)
+	gate := NewGate(staticProvider{cfg: cfg}, NewEvaluator(func(string) (Querier, error) { return q, nil }, nil, logger), nil, nil, logger)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ingester-zone-b",
+			Annotations: map[string]string{config.RolloutHealthCheckAnnotationKey: "hc"},
+			Labels:      map[string]string{"rollout-group": "ingester"},
+		},
+	}
+
+	decision := gate.Evaluate(context.Background(), Request{
+		RolloutGroup: "ingester",
+		Namespace:    "ns",
+		NextSTS:      sts,
+		Now:          time.Now(),
+	})
+
+	require.True(t, decision.ShouldPause)
+	output := logs.String()
+	require.Contains(t, output, "msg=\"health check policy applied\"")
+	require.Contains(t, output, "policy=hc")
+	require.Contains(t, output, "check=errors")
+	require.Contains(t, output, "action=pause")
+	require.Contains(t, output, "current_value=5")
+	require.Contains(t, output, "baseline_value=0.1")
+	require.Contains(t, output, "consecutive_failures=1")
+	require.False(t, strings.Contains(output, check.Query))
+	require.False(t, strings.Contains(output, check.SuccessQuery))
 }
 
 func TestGate_WarnOnFailureExceeded(t *testing.T) {

--- a/pkg/healthcheck/metrics.go
+++ b/pkg/healthcheck/metrics.go
@@ -1,0 +1,59 @@
+package healthcheck
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metrics for RolloutHealthCheck observation and evaluation.
+type Metrics struct {
+	ConfigurationsObserved *prometheus.CounterVec
+	EvaluationsTotal       *prometheus.CounterVec
+	Blocked                *prometheus.GaugeVec
+	MisconfiguredTotal     *prometheus.CounterVec
+	Misconfigured          *prometheus.GaugeVec
+	QueryDuration          *prometheus.HistogramVec
+}
+
+// NewMetrics registers health-check metrics on reg.
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	return &Metrics{
+		ConfigurationsObserved: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "rollout_operator_health_check_configurations_observed_total",
+			Help: "Total number of RolloutHealthCheck configuration events observed by outcome.",
+		}, []string{"outcome"}),
+		EvaluationsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "rollout_operator_health_check_evaluations_total",
+			Help: "Total number of health check evaluations by result.",
+		}, []string{"rollout_group", "check", "result"}),
+		Blocked: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_health_check_blocked",
+			Help: "Whether a rollout group is currently blocked by a health check (1) or not (0).",
+		}, []string{"rollout_group"}),
+		MisconfiguredTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "rollout_operator_health_check_misconfigured_total",
+			Help: "Total number of misconfigured health-check bindings observed for a rollout group.",
+		}, []string{"rollout_group"}),
+		Misconfigured: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_health_check_misconfigured",
+			Help: "Whether a rollout group currently has a misconfigured health-check binding (1) or not (0).",
+		}, []string{"rollout_group"}),
+		QueryDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "rollout_operator_health_check_query_duration_seconds",
+			Help:    "Duration of Prometheus queries issued for health checks.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"rollout_group", "check", "query_type"}),
+	}
+}
+
+// DeleteGroup removes series labeled with the given rollout group.
+func (m *Metrics) DeleteGroup(rolloutGroup string) {
+	if m == nil {
+		return
+	}
+	m.Blocked.DeleteLabelValues(rolloutGroup)
+	m.Misconfigured.DeleteLabelValues(rolloutGroup)
+	m.MisconfiguredTotal.DeleteLabelValues(rolloutGroup)
+	m.EvaluationsTotal.DeletePartialMatch(prometheus.Labels{"rollout_group": rolloutGroup})
+	m.QueryDuration.DeletePartialMatch(prometheus.Labels{"rollout_group": rolloutGroup})
+}

--- a/pkg/healthcheck/observer.go
+++ b/pkg/healthcheck/observer.go
@@ -1,0 +1,153 @@
+package healthcheck
+
+import (
+	"errors"
+	"reflect"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	k8cache "k8s.io/client-go/tools/cache"
+)
+
+const informerSyncInterval = 5 * time.Minute
+
+// Observer watches RolloutHealthCheck objects and keeps an in-memory cache.
+type Observer struct {
+	factory  dynamicinformer.DynamicSharedInformerFactory
+	informer k8cache.SharedIndexInformer
+	cache    *configCache
+	metrics  *Metrics
+	logger   log.Logger
+	stopCh   chan struct{}
+}
+
+// NewObserver creates a namespace-scoped observer for RolloutHealthCheck resources.
+func NewObserver(dyn dynamic.Interface, namespace string, logger log.Logger, metrics *Metrics) *Observer {
+	gvr := schema.GroupVersionResource{
+		Group:    RolloutHealthChecksSpecGroup,
+		Version:  RolloutHealthChecksVersion,
+		Resource: RolloutHealthChecksPlural,
+	}
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dyn, informerSyncInterval, namespace, nil)
+	informer := factory.ForResource(gvr)
+
+	return &Observer{
+		factory:  factory,
+		informer: informer.Informer(),
+		cache:    newConfigCache(),
+		metrics:  metrics,
+		logger:   logger,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// Start begins watching and blocks until the informer cache has synced.
+func (o *Observer) Start() error {
+	_, err := o.informer.AddEventHandler(k8cache.ResourceEventHandlerFuncs{
+		AddFunc:    o.onAdded,
+		UpdateFunc: o.onUpdated,
+		DeleteFunc: o.onDeleted,
+	})
+	if err != nil {
+		return err
+	}
+
+	go o.factory.Start(o.stopCh)
+
+	level.Info(o.logger).Log("msg", "rollout health check informer caches are syncing")
+	if ok := k8cache.WaitForCacheSync(o.stopCh, o.informer.HasSynced); !ok {
+		return errors.New("rollout health check informer caches failed to sync")
+	}
+	level.Info(o.logger).Log("msg", "rollout health check informer caches have synced")
+	return nil
+}
+
+// Stop stops the informer.
+func (o *Observer) Stop() {
+	close(o.stopCh)
+}
+
+// Get returns the cached config for name, or nil if missing / invalid.
+func (o *Observer) Get(name string) *Config {
+	return o.cache.Get(name)
+}
+
+func (o *Observer) addOrUpdate(obj *unstructured.Unstructured) {
+	updated, generation, err := o.cache.addOrUpdateRaw(obj)
+	if err != nil {
+		level.Error(o.logger).Log("msg", "rollout health check configuration error", "name", obj.GetName(), "err", err)
+		// Drop any previously cached valid config so we do not keep evaluating stale rules.
+		o.cache.invalidate(obj.GetName())
+		if o.metrics != nil {
+			o.metrics.ConfigurationsObserved.WithLabelValues("invalid").Inc()
+		}
+		return
+	}
+	if updated {
+		level.Info(o.logger).Log("msg", "rollout health check configuration updated", "name", obj.GetName(), "generation", generation)
+		if o.metrics != nil {
+			o.metrics.ConfigurationsObserved.WithLabelValues("updated").Inc()
+		}
+		return
+	}
+	level.Info(o.logger).Log("msg", "rollout health check configuration update ignored", "name", obj.GetName(), "generation", generation, "ignored-generation", obj.GetGeneration())
+	if o.metrics != nil {
+		o.metrics.ConfigurationsObserved.WithLabelValues("ignored").Inc()
+	}
+}
+
+func (o *Observer) onAdded(obj interface{}) {
+	unstructuredObj, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		if o.metrics != nil {
+			o.metrics.ConfigurationsObserved.WithLabelValues("ignored").Inc()
+		}
+		level.Warn(o.logger).Log("msg", "unexpected object passed through health check informer", "type", reflect.TypeOf(obj))
+		return
+	}
+	o.addOrUpdate(unstructuredObj)
+}
+
+func (o *Observer) onUpdated(old, new interface{}) {
+	_, oldOK := old.(*unstructured.Unstructured)
+	newCfg, newOK := new.(*unstructured.Unstructured)
+	if !oldOK || !newOK {
+		if o.metrics != nil {
+			o.metrics.ConfigurationsObserved.WithLabelValues("ignored").Inc()
+		}
+		level.Warn(o.logger).Log("msg", "unexpected object passed through health check informer", "old_type", reflect.TypeOf(old), "new_type", reflect.TypeOf(new))
+		return
+	}
+	o.addOrUpdate(newCfg)
+}
+
+func (o *Observer) onDeleted(obj interface{}) {
+	if tombstone, ok := obj.(k8cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	oldCfg, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		if o.metrics != nil {
+			o.metrics.ConfigurationsObserved.WithLabelValues("ignored").Inc()
+		}
+		level.Warn(o.logger).Log("msg", "unexpected object passed through health check informer", "type", reflect.TypeOf(obj))
+		return
+	}
+	success, generation := o.cache.delete(oldCfg.GetGeneration(), oldCfg.GetName())
+	if success {
+		if o.metrics != nil {
+			o.metrics.ConfigurationsObserved.WithLabelValues("deleted").Inc()
+		}
+		level.Info(o.logger).Log("msg", "rollout health check configuration deleted", "name", oldCfg.GetName(), "generation", generation)
+		return
+	}
+	if o.metrics != nil {
+		o.metrics.ConfigurationsObserved.WithLabelValues("delete-ignored").Inc()
+	}
+	level.Info(o.logger).Log("msg", "rollout health check configuration delete ignored", "name", oldCfg.GetName(), "generation", generation, "ignored-generation", oldCfg.GetGeneration())
+}

--- a/pkg/phased/phased.go
+++ b/pkg/phased/phased.go
@@ -1,0 +1,278 @@
+package phased
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/common/model"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+const (
+	DefaultSoakDuration      = 5 * time.Minute
+	DefaultRestartThreshold  = 0.10
+	HadPausedAnnotationTrue  = "true"
+	HadPausedAnnotationFalse = "false"
+)
+
+// IsOptedIn reports whether the Deployment participates in phased rollouts.
+func IsOptedIn(d *appsv1.Deployment) bool {
+	if d == nil || d.Labels == nil {
+		return false
+	}
+	return d.Labels[config.RolloutPhasedLabelKey] == config.RolloutPhasedLabelValue
+}
+
+// DependsOn returns the upstream Deployment name, or empty if none.
+func DependsOn(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return strings.TrimSpace(d.Annotations[config.RolloutDependsOnAnnotationKey])
+}
+
+// Revision returns the shared rollout revision stamp.
+func Revision(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return strings.TrimSpace(d.Annotations[config.RolloutRevisionAnnotationKey])
+}
+
+// Phase returns the current dependency gate phase.
+func Phase(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return d.Annotations[config.RolloutDependencyPhaseAnnotationKey]
+}
+
+// DependencyRevision returns the revision currently being gated.
+func DependencyRevision(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return d.Annotations[config.RolloutDependencyRevisionAnnotationKey]
+}
+
+// ResumeRevision returns the revision requested for an explicit resume bypass.
+func ResumeRevision(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return strings.TrimSpace(d.Annotations[config.RolloutResumeAnnotationKey])
+}
+
+// GateActive reports whether the Deployment must stay paused for the current revision.
+func GateActive(d *appsv1.Deployment) bool {
+	if !IsOptedIn(d) || DependsOn(d) == "" {
+		return false
+	}
+	rev := Revision(d)
+	if rev == "" || DependencyRevision(d) != rev {
+		return false
+	}
+	phase := Phase(d)
+	return phase != "" && phase != config.RolloutDependencyPhaseComplete
+}
+
+// NeedsNewGate reports whether a revision change requires (re)starting the gate.
+func NeedsNewGate(d *appsv1.Deployment) bool {
+	if !IsOptedIn(d) || DependsOn(d) == "" {
+		return false
+	}
+	rev := Revision(d)
+	if rev == "" {
+		return false
+	}
+	return DependencyRevision(d) != rev
+}
+
+// ParseSoakDuration returns the soak duration from annotations, or the default.
+func ParseSoakDuration(annotations map[string]string) (time.Duration, error) {
+	if annotations == nil {
+		return DefaultSoakDuration, nil
+	}
+	raw := strings.TrimSpace(annotations[config.RolloutSoakDurationAnnotationKey])
+	if raw == "" {
+		return DefaultSoakDuration, nil
+	}
+	d, err := model.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", config.RolloutSoakDurationAnnotationKey, raw, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("%s must be positive, got %q", config.RolloutSoakDurationAnnotationKey, raw)
+	}
+	return time.Duration(d), nil
+}
+
+// ParseRestartThreshold returns the restart ratio threshold from annotations, or the default.
+func ParseRestartThreshold(annotations map[string]string) (float64, error) {
+	if annotations == nil {
+		return DefaultRestartThreshold, nil
+	}
+	raw := strings.TrimSpace(annotations[config.RolloutRestartThresholdAnnotationKey])
+	if raw == "" {
+		return DefaultRestartThreshold, nil
+	}
+	percent := false
+	if strings.HasSuffix(raw, "%") {
+		percent = true
+		raw = strings.TrimSuffix(raw, "%")
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", config.RolloutRestartThresholdAnnotationKey, annotations[config.RolloutRestartThresholdAnnotationKey], err)
+	}
+	if percent {
+		v = v / 100
+	}
+	if v < 0 {
+		return 0, fmt.Errorf("%s must be non-negative, got %q", config.RolloutRestartThresholdAnnotationKey, annotations[config.RolloutRestartThresholdAnnotationKey])
+	}
+	return v, nil
+}
+
+// ExceedsRestartThreshold reports whether the measured ratio should block progression.
+// A threshold of 0 means any positive restart ratio blocks; otherwise ratio >= threshold blocks.
+func ExceedsRestartThreshold(ratio, threshold float64) bool {
+	if threshold == 0 {
+		return ratio > 0
+	}
+	return ratio >= threshold
+}
+
+// IsFullyRolledOut reports whether every replica is updated, ready, and available.
+func IsFullyRolledOut(d *appsv1.Deployment) bool {
+	if d == nil {
+		return false
+	}
+	if d.Spec.Paused {
+		return false
+	}
+	desired := int32(1)
+	if d.Spec.Replicas != nil {
+		desired = *d.Spec.Replicas
+	}
+	if desired == 0 {
+		return d.Status.Replicas == 0 && d.Status.ObservedGeneration >= d.Generation
+	}
+	if d.Status.ObservedGeneration < d.Generation {
+		return false
+	}
+	return d.Status.UpdatedReplicas == desired &&
+		d.Status.ReadyReplicas == desired &&
+		d.Status.AvailableReplicas == desired &&
+		d.Status.Replicas == desired
+}
+
+// RestartBaseline maps "podUID/containerName" to restart count at soak start.
+type RestartBaseline map[string]int32
+
+func baselineKey(podUID types.UID, containerName string) string {
+	return string(podUID) + "/" + containerName
+}
+
+// BuildRestartBaseline captures current restart counts for the given pods.
+func BuildRestartBaseline(pods []*corev1.Pod) RestartBaseline {
+	baseline := make(RestartBaseline)
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			baseline[baselineKey(pod.UID, cs.Name)] = cs.RestartCount
+		}
+	}
+	return baseline
+}
+
+// EncodeRestartBaseline serializes a baseline for annotation storage.
+func EncodeRestartBaseline(baseline RestartBaseline) (string, error) {
+	if baseline == nil {
+		baseline = RestartBaseline{}
+	}
+	b, err := json.Marshal(baseline)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// DecodeRestartBaseline parses a baseline annotation value.
+func DecodeRestartBaseline(raw string) (RestartBaseline, error) {
+	if raw == "" {
+		return RestartBaseline{}, nil
+	}
+	var baseline RestartBaseline
+	if err := json.Unmarshal([]byte(raw), &baseline); err != nil {
+		return nil, err
+	}
+	if baseline == nil {
+		baseline = RestartBaseline{}
+	}
+	return baseline, nil
+}
+
+// RestartRatio is sum(container restart deltas since baseline) / len(pods).
+// Missing baseline entries (new pods/containers) are treated as zero.
+func RestartRatio(pods []*corev1.Pod, baseline RestartBaseline) float64 {
+	if len(pods) == 0 {
+		return 0
+	}
+	if baseline == nil {
+		baseline = RestartBaseline{}
+	}
+	var totalDelta int64
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			prev := baseline[baselineKey(pod.UID, cs.Name)]
+			delta := cs.RestartCount - prev
+			if delta > 0 {
+				totalDelta += int64(delta)
+			}
+		}
+	}
+	return float64(totalDelta) / float64(len(pods))
+}
+
+// DetectDependencyCycle walks depends-on links starting from start.
+// deployments is keyed by name. Returns true if a cycle involving start is found.
+func DetectDependencyCycle(start string, deployments map[string]*appsv1.Deployment) bool {
+	seen := map[string]struct{}{}
+	cur := start
+	for {
+		if _, ok := seen[cur]; ok {
+			return true
+		}
+		seen[cur] = struct{}{}
+		d, ok := deployments[cur]
+		if !ok {
+			return false
+		}
+		next := DependsOn(d)
+		if next == "" {
+			return false
+		}
+		cur = next
+	}
+}
+
+// AnnotationJSONPointer escapes an annotation key for use in a JSON Patch path.
+func AnnotationJSONPointer(key string) string {
+	// JSON Pointer: ~ -> ~0, / -> ~1
+	escaped := strings.ReplaceAll(key, "~", "~0")
+	escaped = strings.ReplaceAll(escaped, "/", "~1")
+	return "/metadata/annotations/" + escaped
+}

--- a/pkg/phased/phased.go
+++ b/pkg/phased/phased.go
@@ -1,23 +1,16 @@
 package phased
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
-	"github.com/prometheus/common/model"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/grafana/rollout-operator/pkg/config"
 )
 
 const (
-	DefaultSoakDuration      = 5 * time.Minute
-	DefaultRestartThreshold  = 0.10
 	HadPausedAnnotationTrue  = "true"
 	HadPausedAnnotationFalse = "false"
 )
@@ -30,12 +23,31 @@ func IsOptedIn(d *appsv1.Deployment) bool {
 	return d.Labels[config.RolloutPhasedLabelKey] == config.RolloutPhasedLabelValue
 }
 
-// DependsOn returns the upstream Deployment name, or empty if none.
-func DependsOn(d *appsv1.Deployment) string {
+// Canaries returns the canary Deployment names this Deployment depends on.
+// Values are comma-separated in grafana.com/rollout-canary.
+func Canaries(d *appsv1.Deployment) []string {
 	if d == nil || d.Annotations == nil {
-		return ""
+		return nil
 	}
-	return strings.TrimSpace(d.Annotations[config.RolloutDependsOnAnnotationKey])
+	raw := strings.TrimSpace(d.Annotations[config.RolloutCanaryAnnotationKey])
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+	for _, p := range parts {
+		name := strings.TrimSpace(p)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
 }
 
 // Revision returns the shared rollout revision stamp.
@@ -62,17 +74,34 @@ func DependencyRevision(d *appsv1.Deployment) string {
 	return d.Annotations[config.RolloutDependencyRevisionAnnotationKey]
 }
 
-// ResumeRevision returns the revision requested for an explicit resume bypass.
-func ResumeRevision(d *appsv1.Deployment) string {
+// BypassUntil parses grafana.com/rollout-bypass-until. ok is false when unset.
+func BypassUntil(d *appsv1.Deployment) (until time.Time, ok bool, err error) {
 	if d == nil || d.Annotations == nil {
-		return ""
+		return time.Time{}, false, nil
 	}
-	return strings.TrimSpace(d.Annotations[config.RolloutResumeAnnotationKey])
+	raw := strings.TrimSpace(d.Annotations[config.RolloutBypassUntilAnnotationKey])
+	if raw == "" {
+		return time.Time{}, false, nil
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("invalid %s %q: %w", config.RolloutBypassUntilAnnotationKey, raw, err)
+	}
+	return t, true, nil
+}
+
+// BypassActive reports whether a valid bypass-until annotation is still in the future.
+func BypassActive(d *appsv1.Deployment, now time.Time) bool {
+	until, ok, err := BypassUntil(d)
+	if err != nil || !ok {
+		return false
+	}
+	return now.Before(until)
 }
 
 // GateActive reports whether the Deployment must stay paused for the current revision.
 func GateActive(d *appsv1.Deployment) bool {
-	if !IsOptedIn(d) || DependsOn(d) == "" {
+	if !IsOptedIn(d) || len(Canaries(d)) == 0 {
 		return false
 	}
 	rev := Revision(d)
@@ -85,7 +114,7 @@ func GateActive(d *appsv1.Deployment) bool {
 
 // NeedsNewGate reports whether a revision change requires (re)starting the gate.
 func NeedsNewGate(d *appsv1.Deployment) bool {
-	if !IsOptedIn(d) || DependsOn(d) == "" {
+	if !IsOptedIn(d) || len(Canaries(d)) == 0 {
 		return false
 	}
 	rev := Revision(d)
@@ -93,61 +122,6 @@ func NeedsNewGate(d *appsv1.Deployment) bool {
 		return false
 	}
 	return DependencyRevision(d) != rev
-}
-
-// ParseSoakDuration returns the soak duration from annotations, or the default.
-func ParseSoakDuration(annotations map[string]string) (time.Duration, error) {
-	if annotations == nil {
-		return DefaultSoakDuration, nil
-	}
-	raw := strings.TrimSpace(annotations[config.RolloutSoakDurationAnnotationKey])
-	if raw == "" {
-		return DefaultSoakDuration, nil
-	}
-	d, err := model.ParseDuration(raw)
-	if err != nil {
-		return 0, fmt.Errorf("invalid %s %q: %w", config.RolloutSoakDurationAnnotationKey, raw, err)
-	}
-	if d <= 0 {
-		return 0, fmt.Errorf("%s must be positive, got %q", config.RolloutSoakDurationAnnotationKey, raw)
-	}
-	return time.Duration(d), nil
-}
-
-// ParseRestartThreshold returns the restart ratio threshold from annotations, or the default.
-func ParseRestartThreshold(annotations map[string]string) (float64, error) {
-	if annotations == nil {
-		return DefaultRestartThreshold, nil
-	}
-	raw := strings.TrimSpace(annotations[config.RolloutRestartThresholdAnnotationKey])
-	if raw == "" {
-		return DefaultRestartThreshold, nil
-	}
-	percent := false
-	if strings.HasSuffix(raw, "%") {
-		percent = true
-		raw = strings.TrimSuffix(raw, "%")
-	}
-	v, err := strconv.ParseFloat(raw, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid %s %q: %w", config.RolloutRestartThresholdAnnotationKey, annotations[config.RolloutRestartThresholdAnnotationKey], err)
-	}
-	if percent {
-		v = v / 100
-	}
-	if v < 0 {
-		return 0, fmt.Errorf("%s must be non-negative, got %q", config.RolloutRestartThresholdAnnotationKey, annotations[config.RolloutRestartThresholdAnnotationKey])
-	}
-	return v, nil
-}
-
-// ExceedsRestartThreshold reports whether the measured ratio should block progression.
-// A threshold of 0 means any positive restart ratio blocks; otherwise ratio >= threshold blocks.
-func ExceedsRestartThreshold(ratio, threshold float64) bool {
-	if threshold == 0 {
-		return ratio > 0
-	}
-	return ratio >= threshold
 }
 
 // IsFullyRolledOut reports whether every replica is updated, ready, and available.
@@ -174,99 +148,32 @@ func IsFullyRolledOut(d *appsv1.Deployment) bool {
 		d.Status.Replicas == desired
 }
 
-// RestartBaseline maps "podUID/containerName" to restart count at soak start.
-type RestartBaseline map[string]int32
-
-func baselineKey(podUID types.UID, containerName string) string {
-	return string(podUID) + "/" + containerName
-}
-
-// BuildRestartBaseline captures current restart counts for the given pods.
-func BuildRestartBaseline(pods []*corev1.Pod) RestartBaseline {
-	baseline := make(RestartBaseline)
-	for _, pod := range pods {
-		if pod == nil {
-			continue
-		}
-		for _, cs := range pod.Status.ContainerStatuses {
-			baseline[baselineKey(pod.UID, cs.Name)] = cs.RestartCount
-		}
-	}
-	return baseline
-}
-
-// EncodeRestartBaseline serializes a baseline for annotation storage.
-func EncodeRestartBaseline(baseline RestartBaseline) (string, error) {
-	if baseline == nil {
-		baseline = RestartBaseline{}
-	}
-	b, err := json.Marshal(baseline)
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
-}
-
-// DecodeRestartBaseline parses a baseline annotation value.
-func DecodeRestartBaseline(raw string) (RestartBaseline, error) {
-	if raw == "" {
-		return RestartBaseline{}, nil
-	}
-	var baseline RestartBaseline
-	if err := json.Unmarshal([]byte(raw), &baseline); err != nil {
-		return nil, err
-	}
-	if baseline == nil {
-		baseline = RestartBaseline{}
-	}
-	return baseline, nil
-}
-
-// RestartRatio is sum(container restart deltas since baseline) / len(pods).
-// Missing baseline entries (new pods/containers) are treated as zero.
-func RestartRatio(pods []*corev1.Pod, baseline RestartBaseline) float64 {
-	if len(pods) == 0 {
-		return 0
-	}
-	if baseline == nil {
-		baseline = RestartBaseline{}
-	}
-	var totalDelta int64
-	for _, pod := range pods {
-		if pod == nil {
-			continue
-		}
-		for _, cs := range pod.Status.ContainerStatuses {
-			prev := baseline[baselineKey(pod.UID, cs.Name)]
-			delta := cs.RestartCount - prev
-			if delta > 0 {
-				totalDelta += int64(delta)
-			}
-		}
-	}
-	return float64(totalDelta) / float64(len(pods))
-}
-
-// DetectDependencyCycle walks depends-on links starting from start.
+// DetectDependencyCycle walks canary links starting from start.
 // deployments is keyed by name. Returns true if a cycle involving start is found.
 func DetectDependencyCycle(start string, deployments map[string]*appsv1.Deployment) bool {
+	onPath := map[string]struct{}{}
 	seen := map[string]struct{}{}
-	cur := start
-	for {
-		if _, ok := seen[cur]; ok {
+	var walk func(string) bool
+	walk = func(cur string) bool {
+		if _, ok := onPath[cur]; ok {
 			return true
 		}
+		if _, ok := seen[cur]; ok {
+			return false
+		}
+		onPath[cur] = struct{}{}
 		seen[cur] = struct{}{}
-		d, ok := deployments[cur]
-		if !ok {
-			return false
+		if d, ok := deployments[cur]; ok {
+			for _, next := range Canaries(d) {
+				if walk(next) {
+					return true
+				}
+			}
 		}
-		next := DependsOn(d)
-		if next == "" {
-			return false
-		}
-		cur = next
+		delete(onPath, cur)
+		return false
 	}
+	return walk(start)
 }
 
 // AnnotationJSONPointer escapes an annotation key for use in a JSON Patch path.

--- a/pkg/phased/phased.go
+++ b/pkg/phased/phased.go
@@ -74,6 +74,14 @@ func DependencyRevision(d *appsv1.Deployment) string {
 	return d.Annotations[config.RolloutDependencyRevisionAnnotationKey]
 }
 
+// CanariesReadyRevision returns the revision for which every canary reached full readiness.
+func CanariesReadyRevision(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return strings.TrimSpace(d.Annotations[config.RolloutCanariesReadyRevisionAnnotationKey])
+}
+
 // BypassUntil parses grafana.com/rollout-bypass-until. ok is false when unset.
 func BypassUntil(d *appsv1.Deployment) (until time.Time, ok bool, err error) {
 	if d == nil || d.Annotations == nil {

--- a/pkg/phased/phased_test.go
+++ b/pkg/phased/phased_test.go
@@ -1,0 +1,139 @@
+package phased
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+func TestParseSoakDuration(t *testing.T) {
+	d, err := ParseSoakDuration(nil)
+	require.NoError(t, err)
+	require.Equal(t, DefaultSoakDuration, d)
+
+	d, err = ParseSoakDuration(map[string]string{config.RolloutSoakDurationAnnotationKey: "2m"})
+	require.NoError(t, err)
+	require.Equal(t, 2*time.Minute, d)
+
+	_, err = ParseSoakDuration(map[string]string{config.RolloutSoakDurationAnnotationKey: "nope"})
+	require.Error(t, err)
+}
+
+func TestParseRestartThreshold(t *testing.T) {
+	v, err := ParseRestartThreshold(nil)
+	require.NoError(t, err)
+	require.InDelta(t, 0.10, v, 0.0001)
+
+	v, err = ParseRestartThreshold(map[string]string{config.RolloutRestartThresholdAnnotationKey: "10%"})
+	require.NoError(t, err)
+	require.InDelta(t, 0.10, v, 0.0001)
+
+	v, err = ParseRestartThreshold(map[string]string{config.RolloutRestartThresholdAnnotationKey: "0.25"})
+	require.NoError(t, err)
+	require.InDelta(t, 0.25, v, 0.0001)
+}
+
+func TestIsFullyRolledOut(t *testing.T) {
+	replicas := int32(3)
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Generation: 2},
+		Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 2,
+			Replicas:           3,
+			UpdatedReplicas:    3,
+			ReadyReplicas:      3,
+			AvailableReplicas:  3,
+		},
+	}
+	require.True(t, IsFullyRolledOut(d))
+
+	d.Spec.Paused = true
+	require.False(t, IsFullyRolledOut(d))
+	d.Spec.Paused = false
+
+	d.Status.ReadyReplicas = 2
+	require.False(t, IsFullyRolledOut(d))
+}
+
+func TestRestartRatio(t *testing.T) {
+	pods := []*corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{UID: types.UID("a")},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", RestartCount: 2},
+			}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{UID: types.UID("b")},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", RestartCount: 0},
+			}},
+		},
+	}
+	baseline := RestartBaseline{"a/app": 1, "b/app": 0}
+	// deltas: 1 + 0 = 1; pods = 2; ratio = 0.5
+	require.InDelta(t, 0.5, RestartRatio(pods, baseline), 0.0001)
+
+	// New pod with no baseline counts full restarts.
+	pods = append(pods, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID("c")},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "app", RestartCount: 1},
+		}},
+	})
+	require.InDelta(t, 2.0/3.0, RestartRatio(pods, baseline), 0.0001)
+}
+
+func TestDetectDependencyCycle(t *testing.T) {
+	a := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "a", Annotations: map[string]string{config.RolloutDependsOnAnnotationKey: "c"}}}
+	b := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "b", Annotations: map[string]string{config.RolloutDependsOnAnnotationKey: "a"}}}
+	c := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "c", Annotations: map[string]string{config.RolloutDependsOnAnnotationKey: "b"}}}
+	byName := map[string]*appsv1.Deployment{"a": a, "b": b, "c": c}
+	require.True(t, DetectDependencyCycle("a", byName))
+
+	c.Annotations = nil
+	require.False(t, DetectDependencyCycle("a", byName))
+}
+
+func TestGateActive(t *testing.T) {
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue},
+			Annotations: map[string]string{
+				config.RolloutDependsOnAnnotationKey:          "upstream",
+				config.RolloutRevisionAnnotationKey:           "r1",
+				config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseWaiting,
+				config.RolloutDependencyRevisionAnnotationKey: "r1",
+			},
+		},
+	}
+	require.True(t, GateActive(d))
+
+	d.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseComplete
+	require.False(t, GateActive(d))
+}
+
+func TestExceedsRestartThreshold(t *testing.T) {
+	require.False(t, ExceedsRestartThreshold(0, 0))
+	require.True(t, ExceedsRestartThreshold(0.01, 0))
+	require.False(t, ExceedsRestartThreshold(0.09, 0.1))
+	require.True(t, ExceedsRestartThreshold(0.1, 0.1))
+	require.True(t, ExceedsRestartThreshold(0.2, 0.1))
+}
+
+func TestEncodeDecodeRestartBaseline(t *testing.T) {
+	in := RestartBaseline{"uid/app": 3}
+	raw, err := EncodeRestartBaseline(in)
+	require.NoError(t, err)
+	out, err := DecodeRestartBaseline(raw)
+	require.NoError(t, err)
+	require.Equal(t, in, out)
+}

--- a/pkg/phased/phased_test.go
+++ b/pkg/phased/phased_test.go
@@ -6,38 +6,17 @@ import (
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/grafana/rollout-operator/pkg/config"
 )
 
-func TestParseSoakDuration(t *testing.T) {
-	d, err := ParseSoakDuration(nil)
-	require.NoError(t, err)
-	require.Equal(t, DefaultSoakDuration, d)
-
-	d, err = ParseSoakDuration(map[string]string{config.RolloutSoakDurationAnnotationKey: "2m"})
-	require.NoError(t, err)
-	require.Equal(t, 2*time.Minute, d)
-
-	_, err = ParseSoakDuration(map[string]string{config.RolloutSoakDurationAnnotationKey: "nope"})
-	require.Error(t, err)
-}
-
-func TestParseRestartThreshold(t *testing.T) {
-	v, err := ParseRestartThreshold(nil)
-	require.NoError(t, err)
-	require.InDelta(t, 0.10, v, 0.0001)
-
-	v, err = ParseRestartThreshold(map[string]string{config.RolloutRestartThresholdAnnotationKey: "10%"})
-	require.NoError(t, err)
-	require.InDelta(t, 0.10, v, 0.0001)
-
-	v, err = ParseRestartThreshold(map[string]string{config.RolloutRestartThresholdAnnotationKey: "0.25"})
-	require.NoError(t, err)
-	require.InDelta(t, 0.25, v, 0.0001)
+func TestCanaries(t *testing.T) {
+	d := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		config.RolloutCanaryAnnotationKey: " zone-a , query-frontend-zone-a,zone-a ",
+	}}}
+	require.Equal(t, []string{"zone-a", "query-frontend-zone-a"}, Canaries(d))
+	require.Nil(t, Canaries(&appsv1.Deployment{}))
 }
 
 func TestIsFullyRolledOut(t *testing.T) {
@@ -63,44 +42,21 @@ func TestIsFullyRolledOut(t *testing.T) {
 	require.False(t, IsFullyRolledOut(d))
 }
 
-func TestRestartRatio(t *testing.T) {
-	pods := []*corev1.Pod{
-		{
-			ObjectMeta: metav1.ObjectMeta{UID: types.UID("a")},
-			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
-				{Name: "app", RestartCount: 2},
-			}},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{UID: types.UID("b")},
-			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
-				{Name: "app", RestartCount: 0},
-			}},
-		},
-	}
-	baseline := RestartBaseline{"a/app": 1, "b/app": 0}
-	// deltas: 1 + 0 = 1; pods = 2; ratio = 0.5
-	require.InDelta(t, 0.5, RestartRatio(pods, baseline), 0.0001)
-
-	// New pod with no baseline counts full restarts.
-	pods = append(pods, &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{UID: types.UID("c")},
-		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
-			{Name: "app", RestartCount: 1},
-		}},
-	})
-	require.InDelta(t, 2.0/3.0, RestartRatio(pods, baseline), 0.0001)
-}
-
 func TestDetectDependencyCycle(t *testing.T) {
-	a := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "a", Annotations: map[string]string{config.RolloutDependsOnAnnotationKey: "c"}}}
-	b := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "b", Annotations: map[string]string{config.RolloutDependsOnAnnotationKey: "a"}}}
-	c := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "c", Annotations: map[string]string{config.RolloutDependsOnAnnotationKey: "b"}}}
+	a := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "a", Annotations: map[string]string{config.RolloutCanaryAnnotationKey: "c"}}}
+	b := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "b", Annotations: map[string]string{config.RolloutCanaryAnnotationKey: "a"}}}
+	c := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "c", Annotations: map[string]string{config.RolloutCanaryAnnotationKey: "b"}}}
 	byName := map[string]*appsv1.Deployment{"a": a, "b": b, "c": c}
 	require.True(t, DetectDependencyCycle("a", byName))
 
 	c.Annotations = nil
 	require.False(t, DetectDependencyCycle("a", byName))
+
+	// Multi-canary diamond is not a cycle.
+	main := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "main", Annotations: map[string]string{config.RolloutCanaryAnnotationKey: "left,right"}}}
+	left := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "left"}}
+	right := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "right"}}
+	require.False(t, DetectDependencyCycle("main", map[string]*appsv1.Deployment{"main": main, "left": left, "right": right}))
 }
 
 func TestGateActive(t *testing.T) {
@@ -108,7 +64,7 @@ func TestGateActive(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue},
 			Annotations: map[string]string{
-				config.RolloutDependsOnAnnotationKey:          "upstream",
+				config.RolloutCanaryAnnotationKey:             "upstream",
 				config.RolloutRevisionAnnotationKey:           "r1",
 				config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseWaiting,
 				config.RolloutDependencyRevisionAnnotationKey: "r1",
@@ -121,19 +77,14 @@ func TestGateActive(t *testing.T) {
 	require.False(t, GateActive(d))
 }
 
-func TestExceedsRestartThreshold(t *testing.T) {
-	require.False(t, ExceedsRestartThreshold(0, 0))
-	require.True(t, ExceedsRestartThreshold(0.01, 0))
-	require.False(t, ExceedsRestartThreshold(0.09, 0.1))
-	require.True(t, ExceedsRestartThreshold(0.1, 0.1))
-	require.True(t, ExceedsRestartThreshold(0.2, 0.1))
-}
+func TestBypassActive(t *testing.T) {
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	d := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		config.RolloutBypassUntilAnnotationKey: now.Add(time.Hour).Format(time.RFC3339),
+	}}}
+	require.True(t, BypassActive(d, now))
+	require.False(t, BypassActive(d, now.Add(2*time.Hour)))
 
-func TestEncodeDecodeRestartBaseline(t *testing.T) {
-	in := RestartBaseline{"uid/app": 3}
-	raw, err := EncodeRestartBaseline(in)
-	require.NoError(t, err)
-	out, err := DecodeRestartBaseline(raw)
-	require.NoError(t, err)
-	require.Equal(t, in, out)
+	d.Annotations[config.RolloutBypassUntilAnnotationKey] = "not-a-time"
+	require.False(t, BypassActive(d, now))
 }

--- a/pkg/zpdb/eviction_controller.go
+++ b/pkg/zpdb/eviction_controller.go
@@ -182,8 +182,6 @@ func (c *EvictionController) HandlePodEvictionRequest(ctx context.Context, ar v1
 	// set up key=value pairs we include on all logs within this context
 	request.initLogger()
 
-	level.Debug(logger).Log("msg", "considering pod eviction")
-
 	// validate that this is a valid pod eviction create request
 	if err := request.validate(); err != nil {
 		level.Warn(request.log).Log("msg", logDenyMesg, "reason", "not a valid create pod eviction request", "err", err)
@@ -203,11 +201,15 @@ func (c *EvictionController) HandlePodEvictionRequest(ctx context.Context, ar v1
 	// path below exactly as before.
 	if cachedPod, cacheErr := c.podObserver.podLister.Pods(request.req.Request.Namespace).Get(request.req.Request.Name); cacheErr == nil {
 		if pdbConfig, findErr := c.cfgObserver.pdbCache.find(cachedPod); findErr == nil && pdbConfig == nil {
-			level.Debug(request.log).Log("msg", logAllowMesg, "reason", "pod is not within a zpdb scope")
+			if !isDeploymentManagedPod(cachedPod) {
+				level.Debug(request.log).Log("msg", logAllowMesg, "reason", "pod is not within a zpdb scope")
+			}
 			c.metrics.EvictionRequests.WithLabelValues("pod-not-in-scope", fmt.Sprintf("%d", http.StatusOK)).Inc()
 			return request.allow()
 		}
 	}
+
+	level.Debug(request.log).Log("msg", "considering pod eviction")
 
 	// get the pod which has been requested for eviction
 	var pod *corev1.Pod
@@ -242,7 +244,9 @@ func (c *EvictionController) HandlePodEvictionRequest(ctx context.Context, ar v1
 		c.metrics.EvictionRequests.WithLabelValues("cfg-not-found", fmt.Sprintf("%d", http.StatusBadRequest)).Inc()
 		return request.denyWithReason(err.Error(), http.StatusBadRequest)
 	} else if pdbConfig == nil {
-		level.Debug(request.log).Log("msg", logAllowMesg, "reason", "pod is not within a zpdb scope")
+		if !isDeploymentManagedPod(pod) {
+			level.Debug(request.log).Log("msg", logAllowMesg, "reason", "pod is not within a zpdb scope")
+		}
 		c.metrics.EvictionRequests.WithLabelValues("pod-not-in-scope", fmt.Sprintf("%d", http.StatusOK)).Inc()
 		return request.allow()
 	}

--- a/pkg/zpdb/eviction_controller_test.go
+++ b/pkg/zpdb/eviction_controller_test.go
@@ -103,6 +103,15 @@ func (d *dummyLogger) assertHasLog(t *testing.T, elements []string) {
 	require.Fail(t, "Expected log not found", strings.Join(elements, ", "))
 }
 
+func (d *dummyLogger) assertNoLogContains(t *testing.T, elements ...string) {
+	t.Helper()
+	for _, line := range d.logs {
+		for _, element := range elements {
+			require.NotContains(t, line, element)
+		}
+	}
+}
+
 func newTestContext(t *testing.T, request admissionv1.AdmissionReview, pdbRawConfig *unstructured.Unstructured, objects ...runtime.Object) *testContext {
 	testCtx := &testContext{
 		ctx:     context.Background(),
@@ -245,6 +254,22 @@ func TestPodEviction_PodNotInScope(t *testing.T) {
 	testCtx := newTestContext(t, createBasicEvictionAdmissionReview(testPodZoneA0, testNamespace), nil, pod, sts)
 	defer testCtx.controller.Stop()
 	testCtx.assertAllowResponse(t)
+	testCtx.logs.assertHasLog(t, []string{`msg="pod eviction allowed"`, `reason="pod is not within a zpdb scope"`})
+	require.Equal(t, float64(1), testutil.ToFloat64(testCtx.controller.metrics.EvictionRequests.WithLabelValues("pod-not-in-scope", "200")))
+}
+
+func TestPodEviction_DeploymentPodNotInScope_DoesNotLogZPDBDecision(t *testing.T) {
+	pod := newDeploymentPod("distributor-zone-b-abc")
+	testCtx := newTestContext(t, createBasicEvictionAdmissionReview(pod.Name, testNamespace), nil, pod)
+	defer testCtx.controller.Stop()
+
+	testCtx.assertAllowResponse(t)
+
+	testCtx.logs.assertNoLogContains(t,
+		"observer ignoring pod - not within zpdb scope",
+		"considering pod eviction",
+		"pod eviction allowed",
+	)
 	require.Equal(t, float64(1), testutil.ToFloat64(testCtx.controller.metrics.EvictionRequests.WithLabelValues("pod-not-in-scope", "200")))
 }
 
@@ -790,6 +815,24 @@ func newPod(name string, sts *appsv1.StatefulSet) *corev1.Pod {
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
 		},
+	}
+}
+
+func newDeploymentPod(name string) *corev1.Pod {
+	controller := true
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID(uuid.New().String()),
+			Name:      name,
+			Namespace: testNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "ReplicaSet",
+				Name:       "distributor-zone-b-abc",
+				Controller: &controller,
+			}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
 }
 

--- a/pkg/zpdb/pod_observer.go
+++ b/pkg/zpdb/pod_observer.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -124,11 +126,20 @@ func (c *podObserver) accept(obj interface{}) (*corev1.Pod, bool) {
 		return nil, false
 	}
 	if pdbConfig == nil {
-		level.Debug(c.logger).Log("msg", "observer ignoring pod - not within zpdb scope", "pod", pod.Name)
+		if !isDeploymentManagedPod(pod) {
+			level.Debug(c.logger).Log("msg", "observer ignoring pod - not within zpdb scope", "pod", pod.Name)
+		}
 		return nil, false
 	}
 
 	return pod, true
+}
+
+func isDeploymentManagedPod(pod *corev1.Pod) bool {
+	owner := metav1.GetControllerOf(pod)
+	// Deployment pods are directly controlled by ReplicaSets; checking the local owner reference avoids
+	// an API lookup on every pod informer event.
+	return owner != nil && owner.APIVersion == appsv1.SchemeGroupVersion.String() && owner.Kind == "ReplicaSet"
 }
 
 func (c *podObserver) onPodAdded(obj interface{}) {

--- a/pkg/zpdb/pod_observer_test.go
+++ b/pkg/zpdb/pod_observer_test.go
@@ -134,6 +134,40 @@ func TestPodObserver_InvalidObject(t *testing.T) {
 	observer.onPodDeleted(invalidObj)
 }
 
+func TestIsDeploymentManagedPod(t *testing.T) {
+	controller := true
+	notController := false
+	tests := map[string]struct {
+		owner *metav1.OwnerReference
+		want  bool
+	}{
+		"deployment ReplicaSet": {
+			owner: &metav1.OwnerReference{APIVersion: "apps/v1", Kind: "ReplicaSet", Controller: &controller},
+			want:  true,
+		},
+		"StatefulSet": {
+			owner: &metav1.OwnerReference{APIVersion: "apps/v1", Kind: "StatefulSet", Controller: &controller},
+		},
+		"non-controller ReplicaSet reference": {
+			owner: &metav1.OwnerReference{APIVersion: "apps/v1", Kind: "ReplicaSet", Controller: &notController},
+		},
+		"ReplicaSet from another API group": {
+			owner: &metav1.OwnerReference{APIVersion: "example.com/v1", Kind: "ReplicaSet", Controller: &controller},
+		},
+		"no owner": {},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			pod := &corev1.Pod{}
+			if tc.owner != nil {
+				pod.OwnerReferences = []metav1.OwnerReference{*tc.owner}
+			}
+			require.Equal(t, tc.want, isDeploymentManagedPod(pod))
+		})
+	}
+}
+
 // TestObserver_IgnorePodEvents validates the pod eviction cache is not invalidated until the pod phase changes
 func TestObserver_IgnorePodEvents(t *testing.T) {
 	_, observer := newPodObserverTestCase(t)

--- a/vendor/github.com/prometheus/client_golang/api/client.go
+++ b/vendor/github.com/prometheus/client_golang/api/client.go
@@ -1,0 +1,156 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package api provides clients for the HTTP APIs.
+package api
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+)
+
+// DefaultRoundTripper is used if no RoundTripper is set in Config.
+var DefaultRoundTripper http.RoundTripper = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	DialContext: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext,
+	TLSHandshakeTimeout: 10 * time.Second,
+}
+
+// Config defines configuration parameters for a new client.
+type Config struct {
+	// The address of the Prometheus to connect to.
+	Address string
+
+	// Client is used by the Client to drive HTTP requests. If not provided,
+	// a new one based on the provided RoundTripper (or DefaultRoundTripper) will be used.
+	Client *http.Client
+
+	// RoundTripper is used by the Client to drive HTTP requests. If not
+	// provided, DefaultRoundTripper will be used.
+	RoundTripper http.RoundTripper
+}
+
+func (cfg *Config) roundTripper() http.RoundTripper {
+	if cfg.RoundTripper == nil {
+		return DefaultRoundTripper
+	}
+	return cfg.RoundTripper
+}
+
+func (cfg *Config) client() http.Client {
+	if cfg.Client == nil {
+		return http.Client{
+			Transport: cfg.roundTripper(),
+		}
+	}
+	return *cfg.Client
+}
+
+func (cfg *Config) validate() error {
+	if cfg.Client != nil && cfg.RoundTripper != nil {
+		return errors.New("api.Config.RoundTripper and api.Config.Client are mutually exclusive")
+	}
+	return nil
+}
+
+// Client is the interface for an API client.
+type Client interface {
+	URL(ep string, args map[string]string) *url.URL
+	Do(context.Context, *http.Request) (*http.Response, []byte, error)
+}
+
+type CloseIdler interface {
+	CloseIdleConnections()
+}
+
+// NewClient returns a new Client.
+//
+// It is safe to use the returned Client from multiple goroutines.
+func NewClient(cfg Config) (Client, error) {
+	u, err := url.Parse(cfg.Address)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	return &httpClient{
+		endpoint: u,
+		client:   cfg.client(),
+	}, nil
+}
+
+type httpClient struct {
+	endpoint *url.URL
+	client   http.Client
+}
+
+func (c *httpClient) URL(ep string, args map[string]string) *url.URL {
+	p := path.Join(c.endpoint.Path, ep)
+
+	for arg, val := range args {
+		arg = ":" + arg
+		p = strings.ReplaceAll(p, arg, val)
+	}
+
+	u := *c.endpoint
+	u.Path = p
+
+	return &u
+}
+
+func (c *httpClient) CloseIdleConnections() {
+	c.client.CloseIdleConnections()
+}
+
+func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var body []byte
+	done := make(chan error, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, err := buf.ReadFrom(resp.Body)
+		body = buf.Bytes()
+		done <- err
+	}()
+
+	select {
+	case <-ctx.Done():
+		resp.Body.Close()
+		<-done
+		return resp, nil, ctx.Err()
+	case err = <-done:
+		resp.Body.Close()
+		return resp, body, err
+	}
+}

--- a/vendor/github.com/prometheus/client_golang/api/client.go
+++ b/vendor/github.com/prometheus/client_golang/api/client.go
@@ -27,13 +27,18 @@ import (
 )
 
 // DefaultRoundTripper is used if no RoundTripper is set in Config.
+// refer https://github.com/golang/go/blob/master/src/net/http/transport.go#L46
 var DefaultRoundTripper http.RoundTripper = &http.Transport{
 	Proxy: http.ProxyFromEnvironment,
 	DialContext: (&net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}).DialContext,
-	TLSHandshakeTimeout: 10 * time.Second,
+	ForceAttemptHTTP2:     true,
+	MaxIdleConns:          100,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   10 * time.Second,
+	ExpectContinueTimeout: 1 * time.Second,
 }
 
 // Config defines configuration parameters for a new client.
@@ -136,21 +141,21 @@ func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response,
 	}
 
 	var body []byte
-	done := make(chan error, 1)
+	done := make(chan struct{})
+	var readErr error
 	go func() {
+		defer close(done)
 		var buf bytes.Buffer
-		_, err := buf.ReadFrom(resp.Body)
+		_, readErr = buf.ReadFrom(resp.Body)
 		body = buf.Bytes()
-		done <- err
 	}()
 
 	select {
 	case <-ctx.Done():
 		resp.Body.Close()
-		<-done
 		return resp, nil, ctx.Err()
-	case err = <-done:
+	case <-done:
 		resp.Body.Close()
-		return resp, body, err
+		return resp, body, readErr
 	}
 }

--- a/vendor/github.com/prometheus/client_golang/api/prometheus/v1/api.go
+++ b/vendor/github.com/prometheus/client_golang/api/prometheus/v1/api.go
@@ -1,0 +1,1502 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v1 provides bindings to the Prometheus HTTP API v1:
+// http://prometheus.io/docs/querying/api/
+package v1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+	"unsafe"
+
+	json "github.com/json-iterator/go"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/client_golang/api"
+)
+
+func init() {
+	json.RegisterTypeEncoderFunc("model.SamplePair", marshalSamplePairJSON, marshalJSONIsEmpty)
+	json.RegisterTypeDecoderFunc("model.SamplePair", unmarshalSamplePairJSON)
+	json.RegisterTypeEncoderFunc("model.SampleHistogramPair", marshalSampleHistogramPairJSON, marshalJSONIsEmpty)
+	json.RegisterTypeDecoderFunc("model.SampleHistogramPair", unmarshalSampleHistogramPairJSON)
+	json.RegisterTypeEncoderFunc("model.SampleStream", marshalSampleStreamJSON, marshalJSONIsEmpty) // Only needed for benchmark.
+	json.RegisterTypeDecoderFunc("model.SampleStream", unmarshalSampleStreamJSON)                   // Only needed for benchmark.
+}
+
+func unmarshalSamplePairJSON(ptr unsafe.Pointer, iter *json.Iterator) {
+	p := (*model.SamplePair)(ptr)
+	if !iter.ReadArray() {
+		iter.ReportError("unmarshal model.SamplePair", "SamplePair must be [timestamp, value]")
+		return
+	}
+	t := iter.ReadNumber()
+	if err := p.Timestamp.UnmarshalJSON([]byte(t)); err != nil {
+		iter.ReportError("unmarshal model.SamplePair", err.Error())
+		return
+	}
+	if !iter.ReadArray() {
+		iter.ReportError("unmarshal model.SamplePair", "SamplePair missing value")
+		return
+	}
+
+	f, err := strconv.ParseFloat(iter.ReadString(), 64)
+	if err != nil {
+		iter.ReportError("unmarshal model.SamplePair", err.Error())
+		return
+	}
+	p.Value = model.SampleValue(f)
+
+	if iter.ReadArray() {
+		iter.ReportError("unmarshal model.SamplePair", "SamplePair has too many values, must be [timestamp, value]")
+		return
+	}
+}
+
+func marshalSamplePairJSON(ptr unsafe.Pointer, stream *json.Stream) {
+	p := *((*model.SamplePair)(ptr))
+	stream.WriteArrayStart()
+	marshalTimestamp(p.Timestamp, stream)
+	stream.WriteMore()
+	marshalFloat(float64(p.Value), stream)
+	stream.WriteArrayEnd()
+}
+
+func unmarshalSampleHistogramPairJSON(ptr unsafe.Pointer, iter *json.Iterator) {
+	p := (*model.SampleHistogramPair)(ptr)
+	if !iter.ReadArray() {
+		iter.ReportError("unmarshal model.SampleHistogramPair", "SampleHistogramPair must be [timestamp, {histogram}]")
+		return
+	}
+	t := iter.ReadNumber()
+	if err := p.Timestamp.UnmarshalJSON([]byte(t)); err != nil {
+		iter.ReportError("unmarshal model.SampleHistogramPair", err.Error())
+		return
+	}
+	if !iter.ReadArray() {
+		iter.ReportError("unmarshal model.SampleHistogramPair", "SamplePair missing histogram")
+		return
+	}
+	h := &model.SampleHistogram{}
+	p.Histogram = h
+	for key := iter.ReadObject(); key != ""; key = iter.ReadObject() {
+		switch key {
+		case "count":
+			f, err := strconv.ParseFloat(iter.ReadString(), 64)
+			if err != nil {
+				iter.ReportError("unmarshal model.SampleHistogramPair", "count of histogram is not a float")
+				return
+			}
+			h.Count = model.FloatString(f)
+		case "sum":
+			f, err := strconv.ParseFloat(iter.ReadString(), 64)
+			if err != nil {
+				iter.ReportError("unmarshal model.SampleHistogramPair", "sum of histogram is not a float")
+				return
+			}
+			h.Sum = model.FloatString(f)
+		case "buckets":
+			for iter.ReadArray() {
+				b, err := unmarshalHistogramBucket(iter)
+				if err != nil {
+					iter.ReportError("unmarshal model.HistogramBucket", err.Error())
+					return
+				}
+				h.Buckets = append(h.Buckets, b)
+			}
+		default:
+			iter.ReportError("unmarshal model.SampleHistogramPair", fmt.Sprint("unexpected key in histogram:", key))
+			return
+		}
+	}
+	if iter.ReadArray() {
+		iter.ReportError("unmarshal model.SampleHistogramPair", "SampleHistogramPair has too many values, must be [timestamp, {histogram}]")
+		return
+	}
+}
+
+func marshalSampleHistogramPairJSON(ptr unsafe.Pointer, stream *json.Stream) {
+	p := *((*model.SampleHistogramPair)(ptr))
+	stream.WriteArrayStart()
+	marshalTimestamp(p.Timestamp, stream)
+	stream.WriteMore()
+	marshalHistogram(*p.Histogram, stream)
+	stream.WriteArrayEnd()
+}
+
+func unmarshalSampleStreamJSON(ptr unsafe.Pointer, iter *json.Iterator) {
+	ss := (*model.SampleStream)(ptr)
+	for key := iter.ReadObject(); key != ""; key = iter.ReadObject() {
+		switch key {
+		case "metric":
+			metricString := iter.ReadAny().ToString()
+			if err := json.UnmarshalFromString(metricString, &ss.Metric); err != nil {
+				iter.ReportError("unmarshal model.SampleStream", err.Error())
+				return
+			}
+		case "values":
+			for iter.ReadArray() {
+				v := model.SamplePair{}
+				unmarshalSamplePairJSON(unsafe.Pointer(&v), iter)
+				ss.Values = append(ss.Values, v)
+			}
+		case "histograms":
+			for iter.ReadArray() {
+				h := model.SampleHistogramPair{}
+				unmarshalSampleHistogramPairJSON(unsafe.Pointer(&h), iter)
+				ss.Histograms = append(ss.Histograms, h)
+			}
+		default:
+			iter.ReportError("unmarshal model.SampleStream", fmt.Sprint("unexpected key:", key))
+			return
+		}
+	}
+}
+
+func marshalSampleStreamJSON(ptr unsafe.Pointer, stream *json.Stream) {
+	ss := *((*model.SampleStream)(ptr))
+	stream.WriteObjectStart()
+	stream.WriteObjectField(`metric`)
+	m, err := json.ConfigCompatibleWithStandardLibrary.Marshal(ss.Metric)
+	if err != nil {
+		stream.Error = err
+		return
+	}
+	stream.SetBuffer(append(stream.Buffer(), m...))
+	if len(ss.Values) > 0 {
+		stream.WriteMore()
+		stream.WriteObjectField(`values`)
+		stream.WriteArrayStart()
+		for i, v := range ss.Values {
+			if i > 0 {
+				stream.WriteMore()
+			}
+			marshalSamplePairJSON(unsafe.Pointer(&v), stream)
+		}
+		stream.WriteArrayEnd()
+	}
+	if len(ss.Histograms) > 0 {
+		stream.WriteMore()
+		stream.WriteObjectField(`histograms`)
+		stream.WriteArrayStart()
+		for i, h := range ss.Histograms {
+			if i > 0 {
+				stream.WriteMore()
+			}
+			marshalSampleHistogramPairJSON(unsafe.Pointer(&h), stream)
+		}
+		stream.WriteArrayEnd()
+	}
+	stream.WriteObjectEnd()
+}
+
+func marshalFloat(v float64, stream *json.Stream) {
+	stream.WriteRaw(`"`)
+	// Taken from https://github.com/json-iterator/go/blob/master/stream_float.go#L71 as a workaround
+	// to https://github.com/json-iterator/go/issues/365 (json-iterator, to follow json standard, doesn't allow inf/nan).
+	buf := stream.Buffer()
+	abs := math.Abs(v)
+	fmt := byte('f')
+	// Note: Must use float32 comparisons for underlying float32 value to get precise cutoffs right.
+	if abs != 0 {
+		if abs < 1e-6 || abs >= 1e21 {
+			fmt = 'e'
+		}
+	}
+	buf = strconv.AppendFloat(buf, v, fmt, -1, 64)
+	stream.SetBuffer(buf)
+	stream.WriteRaw(`"`)
+}
+
+func marshalTimestamp(timestamp model.Time, stream *json.Stream) {
+	t := int64(timestamp)
+	// Write out the timestamp as a float divided by 1000.
+	// This is ~3x faster than converting to a float.
+	if t < 0 {
+		stream.WriteRaw(`-`)
+		t = -t
+	}
+	stream.WriteInt64(t / 1000)
+	fraction := t % 1000
+	if fraction != 0 {
+		stream.WriteRaw(`.`)
+		if fraction < 100 {
+			stream.WriteRaw(`0`)
+		}
+		if fraction < 10 {
+			stream.WriteRaw(`0`)
+		}
+		stream.WriteInt64(fraction)
+	}
+}
+
+func unmarshalHistogramBucket(iter *json.Iterator) (*model.HistogramBucket, error) {
+	b := model.HistogramBucket{}
+	if !iter.ReadArray() {
+		return nil, errors.New("HistogramBucket must be [boundaries, lower, upper, count]")
+	}
+	boundaries, err := iter.ReadNumber().Int64()
+	if err != nil {
+		return nil, err
+	}
+	b.Boundaries = int32(boundaries)
+	if !iter.ReadArray() {
+		return nil, errors.New("HistogramBucket must be [boundaries, lower, upper, count]")
+	}
+	f, err := strconv.ParseFloat(iter.ReadString(), 64)
+	if err != nil {
+		return nil, err
+	}
+	b.Lower = model.FloatString(f)
+	if !iter.ReadArray() {
+		return nil, errors.New("HistogramBucket must be [boundaries, lower, upper, count]")
+	}
+	f, err = strconv.ParseFloat(iter.ReadString(), 64)
+	if err != nil {
+		return nil, err
+	}
+	b.Upper = model.FloatString(f)
+	if !iter.ReadArray() {
+		return nil, errors.New("HistogramBucket must be [boundaries, lower, upper, count]")
+	}
+	f, err = strconv.ParseFloat(iter.ReadString(), 64)
+	if err != nil {
+		return nil, err
+	}
+	b.Count = model.FloatString(f)
+	if iter.ReadArray() {
+		return nil, errors.New("HistogramBucket has too many values, must be [boundaries, lower, upper, count]")
+	}
+	return &b, nil
+}
+
+// marshalHistogramBucket writes something like: [ 3, "-0.25", "0.25", "3"]
+// See marshalHistogram to understand what the numbers mean
+func marshalHistogramBucket(b model.HistogramBucket, stream *json.Stream) {
+	stream.WriteArrayStart()
+	stream.WriteInt32(b.Boundaries)
+	stream.WriteMore()
+	marshalFloat(float64(b.Lower), stream)
+	stream.WriteMore()
+	marshalFloat(float64(b.Upper), stream)
+	stream.WriteMore()
+	marshalFloat(float64(b.Count), stream)
+	stream.WriteArrayEnd()
+}
+
+// marshalHistogram writes something like:
+//
+//	{
+//	    "count": "42",
+//	    "sum": "34593.34",
+//	    "buckets": [
+//	      [ 3, "-0.25", "0.25", "3"],
+//	      [ 0, "0.25", "0.5", "12"],
+//	      [ 0, "0.5", "1", "21"],
+//	      [ 0, "2", "4", "6"]
+//	    ]
+//	}
+//
+// The 1st element in each bucket array determines if the boundaries are
+// inclusive (AKA closed) or exclusive (AKA open):
+//
+//	0: lower exclusive, upper inclusive
+//	1: lower inclusive, upper exclusive
+//	2: both exclusive
+//	3: both inclusive
+//
+// The 2nd and 3rd elements are the lower and upper boundary. The 4th element is
+// the bucket count.
+func marshalHistogram(h model.SampleHistogram, stream *json.Stream) {
+	stream.WriteObjectStart()
+	stream.WriteObjectField(`count`)
+	marshalFloat(float64(h.Count), stream)
+	stream.WriteMore()
+	stream.WriteObjectField(`sum`)
+	marshalFloat(float64(h.Sum), stream)
+
+	bucketFound := false
+	for _, bucket := range h.Buckets {
+		if bucket.Count == 0 {
+			continue // No need to expose empty buckets in JSON.
+		}
+		stream.WriteMore()
+		if !bucketFound {
+			stream.WriteObjectField(`buckets`)
+			stream.WriteArrayStart()
+		}
+		bucketFound = true
+		marshalHistogramBucket(*bucket, stream)
+	}
+	if bucketFound {
+		stream.WriteArrayEnd()
+	}
+	stream.WriteObjectEnd()
+}
+
+func marshalJSONIsEmpty(ptr unsafe.Pointer) bool {
+	return false
+}
+
+const (
+	apiPrefix = "/api/v1"
+
+	epAlerts          = apiPrefix + "/alerts"
+	epAlertManagers   = apiPrefix + "/alertmanagers"
+	epQuery           = apiPrefix + "/query"
+	epQueryRange      = apiPrefix + "/query_range"
+	epQueryExemplars  = apiPrefix + "/query_exemplars"
+	epLabels          = apiPrefix + "/labels"
+	epLabelValues     = apiPrefix + "/label/:name/values"
+	epSeries          = apiPrefix + "/series"
+	epTargets         = apiPrefix + "/targets"
+	epTargetsMetadata = apiPrefix + "/targets/metadata"
+	epMetadata        = apiPrefix + "/metadata"
+	epRules           = apiPrefix + "/rules"
+	epSnapshot        = apiPrefix + "/admin/tsdb/snapshot"
+	epDeleteSeries    = apiPrefix + "/admin/tsdb/delete_series"
+	epCleanTombstones = apiPrefix + "/admin/tsdb/clean_tombstones"
+	epConfig          = apiPrefix + "/status/config"
+	epFlags           = apiPrefix + "/status/flags"
+	epBuildinfo       = apiPrefix + "/status/buildinfo"
+	epRuntimeinfo     = apiPrefix + "/status/runtimeinfo"
+	epTSDB            = apiPrefix + "/status/tsdb"
+	epWalReplay       = apiPrefix + "/status/walreplay"
+)
+
+// AlertState models the state of an alert.
+type AlertState string
+
+// ErrorType models the different API error types.
+type ErrorType string
+
+// HealthStatus models the health status of a scrape target.
+type HealthStatus string
+
+// RuleType models the type of a rule.
+type RuleType string
+
+// RuleHealth models the health status of a rule.
+type RuleHealth string
+
+// MetricType models the type of a metric.
+type MetricType string
+
+const (
+	// Possible values for AlertState.
+	AlertStateFiring   AlertState = "firing"
+	AlertStateInactive AlertState = "inactive"
+	AlertStatePending  AlertState = "pending"
+
+	// Possible values for ErrorType.
+	ErrBadData     ErrorType = "bad_data"
+	ErrTimeout     ErrorType = "timeout"
+	ErrCanceled    ErrorType = "canceled"
+	ErrExec        ErrorType = "execution"
+	ErrBadResponse ErrorType = "bad_response"
+	ErrServer      ErrorType = "server_error"
+	ErrClient      ErrorType = "client_error"
+
+	// Possible values for HealthStatus.
+	HealthGood    HealthStatus = "up"
+	HealthUnknown HealthStatus = "unknown"
+	HealthBad     HealthStatus = "down"
+
+	// Possible values for RuleType.
+	RuleTypeRecording RuleType = "recording"
+	RuleTypeAlerting  RuleType = "alerting"
+
+	// Possible values for RuleHealth.
+	RuleHealthGood    = "ok"
+	RuleHealthUnknown = "unknown"
+	RuleHealthBad     = "err"
+
+	// Possible values for MetricType
+	MetricTypeCounter        MetricType = "counter"
+	MetricTypeGauge          MetricType = "gauge"
+	MetricTypeHistogram      MetricType = "histogram"
+	MetricTypeGaugeHistogram MetricType = "gaugehistogram"
+	MetricTypeSummary        MetricType = "summary"
+	MetricTypeInfo           MetricType = "info"
+	MetricTypeStateset       MetricType = "stateset"
+	MetricTypeUnknown        MetricType = "unknown"
+)
+
+// Error is an error returned by the API.
+type Error struct {
+	Type   ErrorType
+	Msg    string
+	Detail string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s: %s", e.Type, e.Msg)
+}
+
+// Range represents a sliced time range.
+type Range struct {
+	// The boundaries of the time range.
+	Start, End time.Time
+	// The maximum time between two slices within the boundaries.
+	Step time.Duration
+}
+
+// API provides bindings for Prometheus's v1 API.
+type API interface {
+	// Alerts returns a list of all active alerts.
+	Alerts(ctx context.Context) (AlertsResult, error)
+	// AlertManagers returns an overview of the current state of the Prometheus alert manager discovery.
+	AlertManagers(ctx context.Context) (AlertManagersResult, error)
+	// CleanTombstones removes the deleted data from disk and cleans up the existing tombstones.
+	CleanTombstones(ctx context.Context) error
+	// Config returns the current Prometheus configuration.
+	Config(ctx context.Context) (ConfigResult, error)
+	// DeleteSeries deletes data for a selection of series in a time range.
+	DeleteSeries(ctx context.Context, matches []string, startTime, endTime time.Time) error
+	// Flags returns the flag values that Prometheus was launched with.
+	Flags(ctx context.Context) (FlagsResult, error)
+	// LabelNames returns the unique label names present in the block in sorted order by given time range and matchers.
+	LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]string, Warnings, error)
+	// LabelValues performs a query for the values of the given label, time range and matchers.
+	LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, error)
+	// Query performs a query for the given time.
+	Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, error)
+	// QueryRange performs a query for the given range.
+	QueryRange(ctx context.Context, query string, r Range, opts ...Option) (model.Value, Warnings, error)
+	// QueryExemplars performs a query for exemplars by the given query and time range.
+	QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]ExemplarQueryResult, error)
+	// Buildinfo returns various build information properties about the Prometheus server
+	Buildinfo(ctx context.Context) (BuildinfoResult, error)
+	// Runtimeinfo returns the various runtime information properties about the Prometheus server.
+	Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error)
+	// Series finds series by label matchers.
+	Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, error)
+	// Snapshot creates a snapshot of all current data into snapshots/<datetime>-<rand>
+	// under the TSDB's data directory and returns the directory as response.
+	Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error)
+	// Rules returns a list of alerting and recording rules that are currently loaded.
+	Rules(ctx context.Context) (RulesResult, error)
+	// Targets returns an overview of the current state of the Prometheus target discovery.
+	Targets(ctx context.Context) (TargetsResult, error)
+	// TargetsMetadata returns metadata about metrics currently scraped by the target.
+	TargetsMetadata(ctx context.Context, matchTarget, metric, limit string) ([]MetricMetadata, error)
+	// Metadata returns metadata about metrics currently scraped by the metric name.
+	Metadata(ctx context.Context, metric, limit string) (map[string][]Metadata, error)
+	// TSDB returns the cardinality statistics.
+	TSDB(ctx context.Context, opts ...Option) (TSDBResult, error)
+	// WalReplay returns the current replay status of the wal.
+	WalReplay(ctx context.Context) (WalReplayStatus, error)
+}
+
+// AlertsResult contains the result from querying the alerts endpoint.
+type AlertsResult struct {
+	Alerts []Alert `json:"alerts"`
+}
+
+// AlertManagersResult contains the result from querying the alertmanagers endpoint.
+type AlertManagersResult struct {
+	Active  []AlertManager `json:"activeAlertManagers"`
+	Dropped []AlertManager `json:"droppedAlertManagers"`
+}
+
+// AlertManager models a configured Alert Manager.
+type AlertManager struct {
+	URL string `json:"url"`
+}
+
+// ConfigResult contains the result from querying the config endpoint.
+type ConfigResult struct {
+	YAML string `json:"yaml"`
+}
+
+// FlagsResult contains the result from querying the flag endpoint.
+type FlagsResult map[string]string
+
+// BuildinfoResult contains the results from querying the buildinfo endpoint.
+type BuildinfoResult struct {
+	Version   string `json:"version"`
+	Revision  string `json:"revision"`
+	Branch    string `json:"branch"`
+	BuildUser string `json:"buildUser"`
+	BuildDate string `json:"buildDate"`
+	GoVersion string `json:"goVersion"`
+}
+
+// RuntimeinfoResult contains the result from querying the runtimeinfo endpoint.
+type RuntimeinfoResult struct {
+	StartTime           time.Time `json:"startTime"`
+	CWD                 string    `json:"CWD"`
+	ReloadConfigSuccess bool      `json:"reloadConfigSuccess"`
+	LastConfigTime      time.Time `json:"lastConfigTime"`
+	CorruptionCount     int       `json:"corruptionCount"`
+	GoroutineCount      int       `json:"goroutineCount"`
+	GOMAXPROCS          int       `json:"GOMAXPROCS"`
+	GOGC                string    `json:"GOGC"`
+	GODEBUG             string    `json:"GODEBUG"`
+	StorageRetention    string    `json:"storageRetention"`
+}
+
+// SnapshotResult contains the result from querying the snapshot endpoint.
+type SnapshotResult struct {
+	Name string `json:"name"`
+}
+
+// RulesResult contains the result from querying the rules endpoint.
+type RulesResult struct {
+	Groups []RuleGroup `json:"groups"`
+}
+
+// RuleGroup models a rule group that contains a set of recording and alerting rules.
+type RuleGroup struct {
+	Name     string  `json:"name"`
+	File     string  `json:"file"`
+	Interval float64 `json:"interval"`
+	Rules    Rules   `json:"rules"`
+}
+
+// Recording and alerting rules are stored in the same slice to preserve the order
+// that rules are returned in by the API.
+//
+// Rule types can be determined using a type switch:
+//
+//	switch v := rule.(type) {
+//	case RecordingRule:
+//		fmt.Print("got a recording rule")
+//	case AlertingRule:
+//		fmt.Print("got a alerting rule")
+//	default:
+//		fmt.Printf("unknown rule type %s", v)
+//	}
+type Rules []interface{}
+
+// AlertingRule models a alerting rule.
+type AlertingRule struct {
+	Name           string         `json:"name"`
+	Query          string         `json:"query"`
+	Duration       float64        `json:"duration"`
+	Labels         model.LabelSet `json:"labels"`
+	Annotations    model.LabelSet `json:"annotations"`
+	Alerts         []*Alert       `json:"alerts"`
+	Health         RuleHealth     `json:"health"`
+	LastError      string         `json:"lastError,omitempty"`
+	EvaluationTime float64        `json:"evaluationTime"`
+	LastEvaluation time.Time      `json:"lastEvaluation"`
+	State          string         `json:"state"`
+}
+
+// RecordingRule models a recording rule.
+type RecordingRule struct {
+	Name           string         `json:"name"`
+	Query          string         `json:"query"`
+	Labels         model.LabelSet `json:"labels,omitempty"`
+	Health         RuleHealth     `json:"health"`
+	LastError      string         `json:"lastError,omitempty"`
+	EvaluationTime float64        `json:"evaluationTime"`
+	LastEvaluation time.Time      `json:"lastEvaluation"`
+}
+
+// Alert models an active alert.
+type Alert struct {
+	ActiveAt    time.Time `json:"activeAt"`
+	Annotations model.LabelSet
+	Labels      model.LabelSet
+	State       AlertState
+	Value       string
+}
+
+// TargetsResult contains the result from querying the targets endpoint.
+type TargetsResult struct {
+	Active  []ActiveTarget  `json:"activeTargets"`
+	Dropped []DroppedTarget `json:"droppedTargets"`
+}
+
+// ActiveTarget models an active Prometheus scrape target.
+type ActiveTarget struct {
+	DiscoveredLabels   map[string]string `json:"discoveredLabels"`
+	Labels             model.LabelSet    `json:"labels"`
+	ScrapePool         string            `json:"scrapePool"`
+	ScrapeURL          string            `json:"scrapeUrl"`
+	GlobalURL          string            `json:"globalUrl"`
+	LastError          string            `json:"lastError"`
+	LastScrape         time.Time         `json:"lastScrape"`
+	LastScrapeDuration float64           `json:"lastScrapeDuration"`
+	Health             HealthStatus      `json:"health"`
+}
+
+// DroppedTarget models a dropped Prometheus scrape target.
+type DroppedTarget struct {
+	DiscoveredLabels map[string]string `json:"discoveredLabels"`
+}
+
+// MetricMetadata models the metadata of a metric with its scrape target and name.
+type MetricMetadata struct {
+	Target map[string]string `json:"target"`
+	Metric string            `json:"metric,omitempty"`
+	Type   MetricType        `json:"type"`
+	Help   string            `json:"help"`
+	Unit   string            `json:"unit"`
+}
+
+// Metadata models the metadata of a metric.
+type Metadata struct {
+	Type MetricType `json:"type"`
+	Help string     `json:"help"`
+	Unit string     `json:"unit"`
+}
+
+// queryResult contains result data for a query.
+type queryResult struct {
+	Type   model.ValueType `json:"resultType"`
+	Result interface{}     `json:"result"`
+
+	// The decoded value.
+	v model.Value
+}
+
+// TSDBResult contains the result from querying the tsdb endpoint.
+type TSDBResult struct {
+	HeadStats                   TSDBHeadStats `json:"headStats"`
+	SeriesCountByMetricName     []Stat        `json:"seriesCountByMetricName"`
+	LabelValueCountByLabelName  []Stat        `json:"labelValueCountByLabelName"`
+	MemoryInBytesByLabelName    []Stat        `json:"memoryInBytesByLabelName"`
+	SeriesCountByLabelValuePair []Stat        `json:"seriesCountByLabelValuePair"`
+}
+
+// TSDBHeadStats contains TSDB stats
+type TSDBHeadStats struct {
+	NumSeries     int `json:"numSeries"`
+	NumLabelPairs int `json:"numLabelPairs"`
+	ChunkCount    int `json:"chunkCount"`
+	MinTime       int `json:"minTime"`
+	MaxTime       int `json:"maxTime"`
+}
+
+// WalReplayStatus represents the wal replay status.
+type WalReplayStatus struct {
+	Min     int `json:"min"`
+	Max     int `json:"max"`
+	Current int `json:"current"`
+}
+
+// Stat models information about statistic value.
+type Stat struct {
+	Name  string `json:"name"`
+	Value uint64 `json:"value"`
+}
+
+func (rg *RuleGroup) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Name     string            `json:"name"`
+		File     string            `json:"file"`
+		Interval float64           `json:"interval"`
+		Rules    []json.RawMessage `json:"rules"`
+	}{}
+
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+
+	rg.Name = v.Name
+	rg.File = v.File
+	rg.Interval = v.Interval
+
+	for _, rule := range v.Rules {
+		alertingRule := AlertingRule{}
+		if err := json.Unmarshal(rule, &alertingRule); err == nil {
+			rg.Rules = append(rg.Rules, alertingRule)
+			continue
+		}
+		recordingRule := RecordingRule{}
+		if err := json.Unmarshal(rule, &recordingRule); err == nil {
+			rg.Rules = append(rg.Rules, recordingRule)
+			continue
+		}
+		return errors.New("failed to decode JSON into an alerting or recording rule")
+	}
+
+	return nil
+}
+
+func (r *AlertingRule) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Type string `json:"type"`
+	}{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	if v.Type == "" {
+		return errors.New("type field not present in rule")
+	}
+	if v.Type != string(RuleTypeAlerting) {
+		return fmt.Errorf("expected rule of type %s but got %s", string(RuleTypeAlerting), v.Type)
+	}
+
+	rule := struct {
+		Name           string         `json:"name"`
+		Query          string         `json:"query"`
+		Duration       float64        `json:"duration"`
+		Labels         model.LabelSet `json:"labels"`
+		Annotations    model.LabelSet `json:"annotations"`
+		Alerts         []*Alert       `json:"alerts"`
+		Health         RuleHealth     `json:"health"`
+		LastError      string         `json:"lastError,omitempty"`
+		EvaluationTime float64        `json:"evaluationTime"`
+		LastEvaluation time.Time      `json:"lastEvaluation"`
+		State          string         `json:"state"`
+	}{}
+	if err := json.Unmarshal(b, &rule); err != nil {
+		return err
+	}
+	r.Health = rule.Health
+	r.Annotations = rule.Annotations
+	r.Name = rule.Name
+	r.Query = rule.Query
+	r.Alerts = rule.Alerts
+	r.Duration = rule.Duration
+	r.Labels = rule.Labels
+	r.LastError = rule.LastError
+	r.EvaluationTime = rule.EvaluationTime
+	r.LastEvaluation = rule.LastEvaluation
+	r.State = rule.State
+
+	return nil
+}
+
+func (r *RecordingRule) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Type string `json:"type"`
+	}{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	if v.Type == "" {
+		return errors.New("type field not present in rule")
+	}
+	if v.Type != string(RuleTypeRecording) {
+		return fmt.Errorf("expected rule of type %s but got %s", string(RuleTypeRecording), v.Type)
+	}
+
+	rule := struct {
+		Name           string         `json:"name"`
+		Query          string         `json:"query"`
+		Labels         model.LabelSet `json:"labels,omitempty"`
+		Health         RuleHealth     `json:"health"`
+		LastError      string         `json:"lastError,omitempty"`
+		EvaluationTime float64        `json:"evaluationTime"`
+		LastEvaluation time.Time      `json:"lastEvaluation"`
+	}{}
+	if err := json.Unmarshal(b, &rule); err != nil {
+		return err
+	}
+	r.Health = rule.Health
+	r.Labels = rule.Labels
+	r.Name = rule.Name
+	r.LastError = rule.LastError
+	r.Query = rule.Query
+	r.EvaluationTime = rule.EvaluationTime
+	r.LastEvaluation = rule.LastEvaluation
+
+	return nil
+}
+
+func (qr *queryResult) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Type   model.ValueType `json:"resultType"`
+		Result json.RawMessage `json:"result"`
+	}{}
+
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	switch v.Type {
+	case model.ValScalar:
+		var sv model.Scalar
+		err = json.Unmarshal(v.Result, &sv)
+		qr.v = &sv
+
+	case model.ValVector:
+		var vv model.Vector
+		err = json.Unmarshal(v.Result, &vv)
+		qr.v = vv
+
+	case model.ValMatrix:
+		var mv model.Matrix
+		err = json.Unmarshal(v.Result, &mv)
+		qr.v = mv
+
+	default:
+		err = fmt.Errorf("unexpected value type %q", v.Type)
+	}
+	return err
+}
+
+// Exemplar is additional information associated with a time series.
+type Exemplar struct {
+	Labels    model.LabelSet    `json:"labels"`
+	Value     model.SampleValue `json:"value"`
+	Timestamp model.Time        `json:"timestamp"`
+}
+
+type ExemplarQueryResult struct {
+	SeriesLabels model.LabelSet `json:"seriesLabels"`
+	Exemplars    []Exemplar     `json:"exemplars"`
+}
+
+// NewAPI returns a new API for the client.
+//
+// It is safe to use the returned API from multiple goroutines.
+func NewAPI(c api.Client) API {
+	return &httpAPI{
+		client: &apiClientImpl{
+			client: c,
+		},
+	}
+}
+
+type httpAPI struct {
+	client apiClient
+}
+
+func (h *httpAPI) Alerts(ctx context.Context) (AlertsResult, error) {
+	u := h.client.URL(epAlerts, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return AlertsResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return AlertsResult{}, err
+	}
+
+	var res AlertsResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) AlertManagers(ctx context.Context) (AlertManagersResult, error) {
+	u := h.client.URL(epAlertManagers, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return AlertManagersResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return AlertManagersResult{}, err
+	}
+
+	var res AlertManagersResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) CleanTombstones(ctx context.Context) error {
+	u := h.client.URL(epCleanTombstones, nil)
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	_, _, _, err = h.client.Do(ctx, req)
+	return err
+}
+
+func (h *httpAPI) Config(ctx context.Context) (ConfigResult, error) {
+	u := h.client.URL(epConfig, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return ConfigResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return ConfigResult{}, err
+	}
+
+	var res ConfigResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) DeleteSeries(ctx context.Context, matches []string, startTime, endTime time.Time) error {
+	u := h.client.URL(epDeleteSeries, nil)
+	q := u.Query()
+
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
+
+	if !startTime.IsZero() {
+		q.Set("start", formatTime(startTime))
+	}
+	if !endTime.IsZero() {
+		q.Set("end", formatTime(endTime))
+	}
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	_, _, _, err = h.client.Do(ctx, req)
+	return err
+}
+
+func (h *httpAPI) Flags(ctx context.Context) (FlagsResult, error) {
+	u := h.client.URL(epFlags, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return FlagsResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return FlagsResult{}, err
+	}
+
+	var res FlagsResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) Buildinfo(ctx context.Context) (BuildinfoResult, error) {
+	u := h.client.URL(epBuildinfo, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return BuildinfoResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return BuildinfoResult{}, err
+	}
+
+	var res BuildinfoResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error) {
+	u := h.client.URL(epRuntimeinfo, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return RuntimeinfoResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return RuntimeinfoResult{}, err
+	}
+
+	var res RuntimeinfoResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]string, Warnings, error) {
+	u := h.client.URL(epLabels, nil)
+	q := addOptionalURLParams(u.Query(), opts)
+
+	if !startTime.IsZero() {
+		q.Set("start", formatTime(startTime))
+	}
+	if !endTime.IsZero() {
+		q.Set("end", formatTime(endTime))
+	}
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
+
+	_, body, w, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return nil, w, err
+	}
+	var labelNames []string
+	err = json.Unmarshal(body, &labelNames)
+	return labelNames, w, err
+}
+
+func (h *httpAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, error) {
+	u := h.client.URL(epLabelValues, map[string]string{"name": label})
+	q := addOptionalURLParams(u.Query(), opts)
+
+	if !startTime.IsZero() {
+		q.Set("start", formatTime(startTime))
+	}
+	if !endTime.IsZero() {
+		q.Set("end", formatTime(endTime))
+	}
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	_, body, w, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, w, err
+	}
+	var labelValues model.LabelValues
+	err = json.Unmarshal(body, &labelValues)
+	return labelValues, w, err
+}
+
+// StatsValue is a type for `stats` query parameter.
+type StatsValue string
+
+// AllStatsValue is the query parameter value to return all the query statistics.
+const (
+	AllStatsValue StatsValue = "all"
+)
+
+type apiOptions struct {
+	timeout       time.Duration
+	lookbackDelta time.Duration
+	stats         StatsValue
+	limit         uint64
+}
+
+type Option func(c *apiOptions)
+
+// WithTimeout can be used to provide an optional query evaluation timeout for Query and QueryRange.
+// https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
+func WithTimeout(timeout time.Duration) Option {
+	return func(o *apiOptions) {
+		o.timeout = timeout
+	}
+}
+
+// WithLookbackDelta can be used to provide an optional query lookback delta for Query and QueryRange.
+// This URL variable is not documented on Prometheus HTTP API.
+// https://github.com/prometheus/prometheus/blob/e04913aea2792a5c8bc7b3130c389ca1b027dd9b/promql/engine.go#L162-L167
+func WithLookbackDelta(lookbackDelta time.Duration) Option {
+	return func(o *apiOptions) {
+		o.lookbackDelta = lookbackDelta
+	}
+}
+
+// WithStats can be used to provide an optional per step stats for Query and QueryRange.
+// This URL variable is not documented on Prometheus HTTP API.
+// https://github.com/prometheus/prometheus/blob/e04913aea2792a5c8bc7b3130c389ca1b027dd9b/promql/engine.go#L162-L167
+func WithStats(stats StatsValue) Option {
+	return func(o *apiOptions) {
+		o.stats = stats
+	}
+}
+
+// WithLimit provides an optional maximum number of returned entries for APIs that support limit parameter
+// e.g. https://prometheus.io/docs/prometheus/latest/querying/api/#instant-querie:~:text=%3A%20End%20timestamp.-,limit%3D%3Cnumber%3E,-%3A%20Maximum%20number%20of
+func WithLimit(limit uint64) Option {
+	return func(o *apiOptions) {
+		o.limit = limit
+	}
+}
+
+func addOptionalURLParams(q url.Values, opts []Option) url.Values {
+	opt := &apiOptions{}
+	for _, o := range opts {
+		o(opt)
+	}
+
+	if opt.timeout > 0 {
+		q.Set("timeout", opt.timeout.String())
+	}
+
+	if opt.lookbackDelta > 0 {
+		q.Set("lookback_delta", opt.lookbackDelta.String())
+	}
+
+	if opt.stats != "" {
+		q.Set("stats", string(opt.stats))
+	}
+
+	if opt.limit > 0 {
+		q.Set("limit", strconv.FormatUint(opt.limit, 10))
+	}
+
+	return q
+}
+
+func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, error) {
+	u := h.client.URL(epQuery, nil)
+	q := addOptionalURLParams(u.Query(), opts)
+
+	q.Set("query", query)
+	if !ts.IsZero() {
+		q.Set("time", formatTime(ts))
+	}
+
+	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return nil, warnings, err
+	}
+
+	var qres queryResult
+	return qres.v, warnings, json.Unmarshal(body, &qres)
+}
+
+func (h *httpAPI) QueryRange(ctx context.Context, query string, r Range, opts ...Option) (model.Value, Warnings, error) {
+	u := h.client.URL(epQueryRange, nil)
+	q := addOptionalURLParams(u.Query(), opts)
+
+	q.Set("query", query)
+	q.Set("start", formatTime(r.Start))
+	q.Set("end", formatTime(r.End))
+	q.Set("step", strconv.FormatFloat(r.Step.Seconds(), 'f', -1, 64))
+
+	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return nil, warnings, err
+	}
+
+	var qres queryResult
+	return qres.v, warnings, json.Unmarshal(body, &qres)
+}
+
+func (h *httpAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, error) {
+	u := h.client.URL(epSeries, nil)
+	q := addOptionalURLParams(u.Query(), opts)
+
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
+
+	if !startTime.IsZero() {
+		q.Set("start", formatTime(startTime))
+	}
+	if !endTime.IsZero() {
+		q.Set("end", formatTime(endTime))
+	}
+
+	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return nil, warnings, err
+	}
+
+	var mset []model.LabelSet
+	return mset, warnings, json.Unmarshal(body, &mset)
+}
+
+func (h *httpAPI) Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error) {
+	u := h.client.URL(epSnapshot, nil)
+	q := u.Query()
+
+	q.Set("skip_head", strconv.FormatBool(skipHead))
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return SnapshotResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return SnapshotResult{}, err
+	}
+
+	var res SnapshotResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) Rules(ctx context.Context) (RulesResult, error) {
+	u := h.client.URL(epRules, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return RulesResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return RulesResult{}, err
+	}
+
+	var res RulesResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) Targets(ctx context.Context) (TargetsResult, error) {
+	u := h.client.URL(epTargets, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return TargetsResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return TargetsResult{}, err
+	}
+
+	var res TargetsResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) TargetsMetadata(ctx context.Context, matchTarget, metric, limit string) ([]MetricMetadata, error) {
+	u := h.client.URL(epTargetsMetadata, nil)
+	q := u.Query()
+
+	q.Set("match_target", matchTarget)
+	q.Set("metric", metric)
+	q.Set("limit", limit)
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []MetricMetadata
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]Metadata, error) {
+	u := h.client.URL(epMetadata, nil)
+	q := u.Query()
+
+	q.Set("metric", metric)
+	q.Set("limit", limit)
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var res map[string][]Metadata
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) TSDB(ctx context.Context, opts ...Option) (TSDBResult, error) {
+	u := h.client.URL(epTSDB, nil)
+	q := addOptionalURLParams(u.Query(), opts)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return TSDBResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return TSDBResult{}, err
+	}
+
+	var res TSDBResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) WalReplay(ctx context.Context) (WalReplayStatus, error) {
+	u := h.client.URL(epWalReplay, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return WalReplayStatus{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return WalReplayStatus{}, err
+	}
+
+	var res WalReplayStatus
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]ExemplarQueryResult, error) {
+	u := h.client.URL(epQueryExemplars, nil)
+	q := u.Query()
+
+	q.Set("query", query)
+	if !startTime.IsZero() {
+		q.Set("start", formatTime(startTime))
+	}
+	if !endTime.IsZero() {
+		q.Set("end", formatTime(endTime))
+	}
+
+	_, body, _, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []ExemplarQueryResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+// Warnings is an array of non critical errors
+type Warnings []string
+
+// apiClient wraps a regular client and processes successful API responses.
+// Successful also includes responses that errored at the API level.
+type apiClient interface {
+	URL(ep string, args map[string]string) *url.URL
+	Do(context.Context, *http.Request) (*http.Response, []byte, Warnings, error)
+	DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error)
+}
+
+type apiClientImpl struct {
+	client api.Client
+}
+
+type apiResponse struct {
+	Status    string          `json:"status"`
+	Data      json.RawMessage `json:"data"`
+	ErrorType ErrorType       `json:"errorType"`
+	Error     string          `json:"error"`
+	Warnings  []string        `json:"warnings,omitempty"`
+}
+
+func apiError(code int) bool {
+	// These are the codes that Prometheus sends when it returns an error.
+	return code == http.StatusUnprocessableEntity || code == http.StatusBadRequest
+}
+
+func errorTypeAndMsgFor(resp *http.Response) (ErrorType, string) {
+	switch resp.StatusCode / 100 {
+	case 4:
+		return ErrClient, fmt.Sprintf("client error: %d", resp.StatusCode)
+	case 5:
+		return ErrServer, fmt.Sprintf("server error: %d", resp.StatusCode)
+	}
+	return ErrBadResponse, fmt.Sprintf("bad response code %d", resp.StatusCode)
+}
+
+func (h *apiClientImpl) URL(ep string, args map[string]string) *url.URL {
+	return h.client.URL(ep, args)
+}
+
+func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, Warnings, error) {
+	resp, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return resp, body, nil, err
+	}
+
+	code := resp.StatusCode
+
+	if code/100 != 2 && !apiError(code) {
+		errorType, errorMsg := errorTypeAndMsgFor(resp)
+		return resp, body, nil, &Error{
+			Type:   errorType,
+			Msg:    errorMsg,
+			Detail: string(body),
+		}
+	}
+
+	var result apiResponse
+
+	if http.StatusNoContent != code {
+		if jsonErr := json.Unmarshal(body, &result); jsonErr != nil {
+			return resp, body, nil, &Error{
+				Type: ErrBadResponse,
+				Msg:  jsonErr.Error(),
+			}
+		}
+	}
+
+	if apiError(code) && result.Status == "success" {
+		err = &Error{
+			Type: ErrBadResponse,
+			Msg:  "inconsistent body for response code",
+		}
+	}
+
+	if result.Status == "error" {
+		err = &Error{
+			Type: result.ErrorType,
+			Msg:  result.Error,
+		}
+	}
+
+	return resp, []byte(result.Data), result.Warnings, err
+}
+
+// DoGetFallback will attempt to do the request as-is, and on a 405 or 501 it
+// will fallback to a GET request.
+func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error) {
+	encodedArgs := args.Encode()
+	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(encodedArgs))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// Following comment originates from https://pkg.go.dev/net/http#Transport
+	// Transport only retries a request upon encountering a network error if the request is
+	// idempotent and either has no body or has its Request.GetBody defined. HTTP requests
+	// are considered idempotent if they have HTTP methods GET, HEAD, OPTIONS, or TRACE; or
+	// if their Header map contains an "Idempotency-Key" or "X-Idempotency-Key" entry. If the
+	// idempotency key value is a zero-length slice, the request is treated as idempotent but
+	// the header is not sent on the wire.
+	req.Header["Idempotency-Key"] = nil
+
+	resp, body, warnings, err := h.Do(ctx, req)
+	if resp != nil && (resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented) {
+		u.RawQuery = encodedArgs
+		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, nil, warnings, err
+		}
+		return h.Do(ctx, req)
+	}
+	return resp, body, warnings, err
+}
+
+func formatTime(t time.Time) string {
+	return strconv.FormatFloat(float64(t.Unix())+float64(t.Nanosecond())/1e9, 'f', -1, 64)
+}

--- a/vendor/github.com/prometheus/client_golang/api/prometheus/v1/api.go
+++ b/vendor/github.com/prometheus/client_golang/api/prometheus/v1/api.go
@@ -380,7 +380,9 @@ const (
 	epBuildinfo       = apiPrefix + "/status/buildinfo"
 	epRuntimeinfo     = apiPrefix + "/status/runtimeinfo"
 	epTSDB            = apiPrefix + "/status/tsdb"
+	epTSDBBlocks      = apiPrefix + "/status/tsdb/blocks"
 	epWalReplay       = apiPrefix + "/status/walreplay"
+	epFormatQuery     = apiPrefix + "/format_query"
 )
 
 // AlertState models the state of an alert.
@@ -475,7 +477,7 @@ type API interface {
 	// Flags returns the flag values that Prometheus was launched with.
 	Flags(ctx context.Context) (FlagsResult, error)
 	// LabelNames returns the unique label names present in the block in sorted order by given time range and matchers.
-	LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]string, Warnings, error)
+	LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelNames, Warnings, error)
 	// LabelValues performs a query for the values of the given label, time range and matchers.
 	LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, error)
 	// Query performs a query for the given time.
@@ -494,7 +496,7 @@ type API interface {
 	// under the TSDB's data directory and returns the directory as response.
 	Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error)
 	// Rules returns a list of alerting and recording rules that are currently loaded.
-	Rules(ctx context.Context) (RulesResult, error)
+	Rules(ctx context.Context, matches []string) (RulesResult, error)
 	// Targets returns an overview of the current state of the Prometheus target discovery.
 	Targets(ctx context.Context) (TargetsResult, error)
 	// TargetsMetadata returns metadata about metrics currently scraped by the target.
@@ -503,8 +505,12 @@ type API interface {
 	Metadata(ctx context.Context, metric, limit string) (map[string][]Metadata, error)
 	// TSDB returns the cardinality statistics.
 	TSDB(ctx context.Context, opts ...Option) (TSDBResult, error)
+	// TSDBBlocks returns the list of currently loaded TSDB blocks and their metadata.
+	TSDBBlocks(ctx context.Context) (TSDBBlocksResult, error)
 	// WalReplay returns the current replay status of the wal.
 	WalReplay(ctx context.Context) (WalReplayStatus, error)
+	// FormatQuery formats a PromQL expression in a prettified way.
+	FormatQuery(ctx context.Context, query string) (string, error)
 }
 
 // AlertsResult contains the result from querying the alerts endpoint.
@@ -586,7 +592,7 @@ type RuleGroup struct {
 //	default:
 //		fmt.Printf("unknown rule type %s", v)
 //	}
-type Rules []interface{}
+type Rules []any
 
 // AlertingRule models a alerting rule.
 type AlertingRule struct {
@@ -666,7 +672,7 @@ type Metadata struct {
 // queryResult contains result data for a query.
 type queryResult struct {
 	Type   model.ValueType `json:"resultType"`
-	Result interface{}     `json:"result"`
+	Result any             `json:"result"`
 
 	// The decoded value.
 	v model.Value
@@ -688,6 +694,40 @@ type TSDBHeadStats struct {
 	ChunkCount    int `json:"chunkCount"`
 	MinTime       int `json:"minTime"`
 	MaxTime       int `json:"maxTime"`
+}
+
+// TSDBBlocksResult contains the results from querying the tsdb blocks endpoint.
+type TSDBBlocksResult struct {
+	Status string         `json:"status"`
+	Data   TSDBBlocksData `json:"data"`
+}
+
+// TSDBBlocksData contains the metadata for the tsdb blocks.
+type TSDBBlocksData struct {
+	Blocks []TSDBBlocksBlockMetadata `json:"blocks"`
+}
+
+// TSDBBlocksBlockMetadata contains the metadata for a single tsdb block.
+type TSDBBlocksBlockMetadata struct {
+	Ulid       string               `json:"ulid"`
+	MinTime    int64                `json:"minTime"`
+	MaxTime    int64                `json:"maxTime"`
+	Stats      TSDBBlocksStats      `json:"stats"`
+	Compaction TSDBBlocksCompaction `json:"compaction"`
+	Version    int                  `json:"version"`
+}
+
+// TSDBBlocksStats contains block stats for a single tsdb block.
+type TSDBBlocksStats struct {
+	NumSamples int `json:"numSamples"`
+	NumSeries  int `json:"numSeries"`
+	NumChunks  int `json:"numChunks"`
+}
+
+// TSDBBlocksCompaction contains block compaction details for a single block.
+type TSDBBlocksCompaction struct {
+	Level   int      `json:"level"`
+	Sources []string `json:"sources"`
 }
 
 // WalReplayStatus represents the wal replay status.
@@ -1024,7 +1064,7 @@ func (h *httpAPI) Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error) {
 	return res, err
 }
 
-func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]string, Warnings, error) {
+func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelNames, Warnings, error) {
 	u := h.client.URL(epLabels, nil)
 	q := addOptionalURLParams(u.Query(), opts)
 
@@ -1042,7 +1082,7 @@ func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, e
 	if err != nil {
 		return nil, w, err
 	}
-	var labelNames []string
+	var labelNames model.LabelNames
 	err = json.Unmarshal(body, &labelNames)
 	return labelNames, w, err
 }
@@ -1235,8 +1275,15 @@ func (h *httpAPI) Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, 
 	return res, err
 }
 
-func (h *httpAPI) Rules(ctx context.Context) (RulesResult, error) {
+func (h *httpAPI) Rules(ctx context.Context, matches []string) (RulesResult, error) {
 	u := h.client.URL(epRules, nil)
+	q := u.Query()
+
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
+
+	u.RawQuery = q.Encode()
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
@@ -1340,6 +1387,24 @@ func (h *httpAPI) TSDB(ctx context.Context, opts ...Option) (TSDBResult, error) 
 	return res, err
 }
 
+func (h *httpAPI) TSDBBlocks(ctx context.Context) (TSDBBlocksResult, error) {
+	u := h.client.URL(epTSDBBlocks, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return TSDBBlocksResult{}, err
+	}
+
+	_, body, _, err := h.client.Do(ctx, req)
+	if err != nil {
+		return TSDBBlocksResult{}, err
+	}
+
+	var res TSDBBlocksResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
 func (h *httpAPI) WalReplay(ctx context.Context) (WalReplayStatus, error) {
 	u := h.client.URL(epWalReplay, nil)
 
@@ -1378,6 +1443,19 @@ func (h *httpAPI) QueryExemplars(ctx context.Context, query string, startTime, e
 	var res []ExemplarQueryResult
 	err = json.Unmarshal(body, &res)
 	return res, err
+}
+
+func (h *httpAPI) FormatQuery(ctx context.Context, query string) (string, error) {
+	u := h.client.URL(epFormatQuery, nil)
+	q := u.Query()
+	q.Set("query", query)
+
+	_, body, _, err := h.client.DoGetFallback(ctx, u, q)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
 }
 
 // Warnings is an array of non critical errors
@@ -1467,8 +1545,8 @@ func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Respon
 	return resp, []byte(result.Data), result.Warnings, err
 }
 
-// DoGetFallback will attempt to do the request as-is, and on a 405 or 501 it
-// will fallback to a GET request.
+// DoGetFallback will attempt to do the request as-is, and on a 403, 405, or
+// 501 it will fallback to a GET request.
 func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error) {
 	encodedArgs := args.Encode()
 	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(encodedArgs))
@@ -1486,7 +1564,7 @@ func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.
 	req.Header["Idempotency-Key"] = nil
 
 	resp, body, warnings, err := h.Do(ctx, req)
-	if resp != nil && (resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented) {
+	if resp != nil && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented) {
 		u.RawQuery = encodedArgs
 		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
 		if err != nil {

--- a/vendor/k8s.io/client-go/tools/internal/events/interfaces.go
+++ b/vendor/k8s.io/client-go/tools/internal/events/interfaces.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package internal is needed to break an import cycle: record.EventRecorderAdapter
+// needs this interface definition to implement it, but event.NewEventBroadcasterAdapter
+// needs record.NewBroadcaster. Therefore this interface cannot be in event/interfaces.go.
+package internal
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+)
+
+// EventRecorder knows how to record events on behalf of an EventSource.
+type EventRecorder interface {
+	// Eventf constructs an event from the given information and puts it in the queue for sending.
+	// 'regarding' is the object this event is about. Event will make a reference-- or you may also
+	// pass a reference to the object directly.
+	// 'related' is the secondary object for more complex actions. E.g. when regarding object triggers
+	// a creation or deletion of related object.
+	// 'type' of this event, and can be one of Normal, Warning. New types could be added in future
+	// 'reason' is the reason this event is generated. 'reason' should be short and unique; it
+	// should be in UpperCamelCase format (starting with a capital letter). "reason" will be used
+	// to automate handling of events, so imagine people writing switch statements to handle them.
+	// You want to make that easy.
+	// 'action' explains what happened with regarding/what action did the ReportingController
+	// (ReportingController is a type of a Controller reporting an Event, e.g. k8s.io/node-controller, k8s.io/kubelet.)
+	// take in regarding's name; it should be in UpperCamelCase format (starting with a capital letter).
+	// 'note' is intended to be human readable.
+	Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{})
+}
+
+// EventRecorderLogger extends EventRecorder such that a logger can
+// be set for methods in EventRecorder. Normally, those methods
+// uses the global default logger to record errors and debug messages.
+// If that is not desired, use WithLogger to provide a logger instance.
+type EventRecorderLogger interface {
+	EventRecorder
+
+	// WithLogger replaces the context used for logging. This is a cheap call
+	// and meant to be used for contextual logging:
+	//    recorder := ...
+	//    logger := klog.FromContext(ctx)
+	//    recorder.WithLogger(logger).Eventf(...)
+	WithLogger(logger klog.Logger) EventRecorderLogger
+}

--- a/vendor/k8s.io/client-go/tools/record/OWNERS
+++ b/vendor/k8s.io/client-go/tools/record/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-instrumentation-reviewers
+approvers:
+  - sig-instrumentation-approvers

--- a/vendor/k8s.io/client-go/tools/record/doc.go
+++ b/vendor/k8s.io/client-go/tools/record/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package record has all client logic for recording and reporting
+// "k8s.io/api/core/v1".Event events.
+package record

--- a/vendor/k8s.io/client-go/tools/record/event.go
+++ b/vendor/k8s.io/client-go/tools/record/event.go
@@ -1,0 +1,530 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package record
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	restclient "k8s.io/client-go/rest"
+	internalevents "k8s.io/client-go/tools/internal/events"
+	"k8s.io/client-go/tools/record/util"
+	ref "k8s.io/client-go/tools/reference"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+const maxTriesPerEvent = 12
+
+var defaultSleepDuration = 10 * time.Second
+
+const maxQueuedEvents = 1000
+
+// EventSink knows how to store events (client.Client implements it.)
+// EventSink must respect the namespace that will be embedded in 'event'.
+// It is assumed that EventSink will return the same sorts of errors as
+// pkg/client's REST client.
+type EventSink interface {
+	Create(event *v1.Event) (*v1.Event, error)
+	Update(event *v1.Event) (*v1.Event, error)
+	Patch(oldEvent *v1.Event, data []byte) (*v1.Event, error)
+}
+
+// CorrelatorOptions allows you to change the default of the EventSourceObjectSpamFilter
+// and EventAggregator in EventCorrelator
+type CorrelatorOptions struct {
+	// The lru cache size used for both EventSourceObjectSpamFilter and the EventAggregator
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the LRUCacheSize has to be greater than 0.
+	LRUCacheSize int
+	// The burst size used by the token bucket rate filtering in EventSourceObjectSpamFilter
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the BurstSize has to be greater than 0.
+	BurstSize int
+	// The fill rate of the token bucket in queries per second in EventSourceObjectSpamFilter
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the QPS has to be greater than 0.
+	QPS float32
+	// The func used by the EventAggregator to group event keys for aggregation
+	// If not specified (zero value), EventAggregatorByReasonFunc will be used
+	KeyFunc EventAggregatorKeyFunc
+	// The func used by the EventAggregator to produced aggregated message
+	// If not specified (zero value), EventAggregatorByReasonMessageFunc will be used
+	MessageFunc EventAggregatorMessageFunc
+	// The number of events in an interval before aggregation happens by the EventAggregator
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the MaxEvents has to be greater than 0
+	MaxEvents int
+	// The amount of time in seconds that must transpire since the last occurrence of a similar event before it is considered new by the EventAggregator
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the MaxIntervalInSeconds has to be greater than 0
+	MaxIntervalInSeconds int
+	// The clock used by the EventAggregator to allow for testing
+	// If not specified (zero value), clock.RealClock{} will be used
+	Clock clock.PassiveClock
+	// The func used by EventFilterFunc, which returns a key for given event, based on which filtering will take place
+	// If not specified (zero value), getSpamKey will be used
+	SpamKeyFunc EventSpamKeyFunc
+}
+
+// EventRecorder knows how to record events on behalf of an EventSource.
+type EventRecorder interface {
+	// Event constructs an event from the given information and puts it in the queue for sending.
+	// 'object' is the object this event is about. Event will make a reference-- or you may also
+	// pass a reference to the object directly.
+	// 'eventtype' of this event, and can be one of Normal, Warning. New types could be added in future
+	// 'reason' is the reason this event is generated. 'reason' should be short and unique; it
+	// should be in UpperCamelCase format (starting with a capital letter). "reason" will be used
+	// to automate handling of events, so imagine people writing switch statements to handle them.
+	// You want to make that easy.
+	// 'message' is intended to be human readable.
+	//
+	// The resulting event will be created in the same namespace as the reference object.
+	Event(object runtime.Object, eventtype, reason, message string)
+
+	// Eventf is just like Event, but with Sprintf for the message field.
+	Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{})
+
+	// AnnotatedEventf is just like eventf, but with annotations attached
+	AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{})
+}
+
+// EventRecorderLogger extends EventRecorder such that a logger can
+// be set for methods in EventRecorder. Normally, those methods
+// uses the global default logger to record errors and debug messages.
+// If that is not desired, use WithLogger to provide a logger instance.
+type EventRecorderLogger interface {
+	EventRecorder
+
+	// WithLogger replaces the context used for logging. This is a cheap call
+	// and meant to be used for contextual logging:
+	//    recorder := ...
+	//    logger := klog.FromContext(ctx)
+	//    recorder.WithLogger(logger).Eventf(...)
+	WithLogger(logger klog.Logger) EventRecorderLogger
+}
+
+// EventBroadcaster knows how to receive events and send them to any EventSink, watcher, or log.
+type EventBroadcaster interface {
+	// StartEventWatcher starts sending events received from this EventBroadcaster to the given
+	// event handler function. The return value can be ignored or used to stop recording, if
+	// desired.
+	StartEventWatcher(eventHandler func(*v1.Event)) watch.Interface
+
+	// StartRecordingToSink starts sending events received from this EventBroadcaster to the given
+	// sink. The return value can be ignored or used to stop recording, if desired.
+	StartRecordingToSink(sink EventSink) watch.Interface
+
+	// StartLogging starts sending events received from this EventBroadcaster to the given logging
+	// function. The return value can be ignored or used to stop recording, if desired.
+	StartLogging(logf func(format string, args ...interface{})) watch.Interface
+
+	// StartStructuredLogging starts sending events received from this EventBroadcaster to the structured
+	// logging function. The return value can be ignored or used to stop recording, if desired.
+	StartStructuredLogging(verbosity klog.Level) watch.Interface
+
+	// NewRecorder returns an EventRecorder that can be used to send events to this EventBroadcaster
+	// with the event source set to the given event source.
+	NewRecorder(scheme *runtime.Scheme, source v1.EventSource) EventRecorderLogger
+
+	// Shutdown shuts down the broadcaster. Once the broadcaster is shut
+	// down, it will only try to record an event in a sink once before
+	// giving up on it with an error message.
+	Shutdown()
+}
+
+// EventRecorderAdapter is a wrapper around a "k8s.io/client-go/tools/record".EventRecorder
+// implementing the new "k8s.io/client-go/tools/events".EventRecorder interface.
+type EventRecorderAdapter struct {
+	recorder EventRecorderLogger
+}
+
+var _ internalevents.EventRecorder = &EventRecorderAdapter{}
+
+// NewEventRecorderAdapter returns an adapter implementing the new
+// "k8s.io/client-go/tools/events".EventRecorder interface.
+func NewEventRecorderAdapter(recorder EventRecorderLogger) *EventRecorderAdapter {
+	return &EventRecorderAdapter{
+		recorder: recorder,
+	}
+}
+
+// Eventf is a wrapper around v1 Eventf
+func (a *EventRecorderAdapter) Eventf(regarding, _ runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
+	a.recorder.Eventf(regarding, eventtype, reason, note, args...)
+}
+
+func (a *EventRecorderAdapter) WithLogger(logger klog.Logger) internalevents.EventRecorderLogger {
+	return &EventRecorderAdapter{
+		recorder: a.recorder.WithLogger(logger),
+	}
+}
+
+// Creates a new event broadcaster.
+func NewBroadcaster(opts ...BroadcasterOption) EventBroadcaster {
+	c := config{
+		sleepDuration: defaultSleepDuration,
+	}
+	for _, opt := range opts {
+		opt(&c)
+	}
+	eventBroadcaster := &eventBroadcasterImpl{
+		Broadcaster:   watch.NewLongQueueBroadcaster(maxQueuedEvents, watch.DropIfChannelFull),
+		sleepDuration: c.sleepDuration,
+		options:       c.CorrelatorOptions,
+	}
+	ctx := c.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// The are two scenarios where it makes no sense to wait for context cancelation:
+	// - The context was nil.
+	// - The context was context.Background() to begin with.
+	//
+	// Both cases get checked here: we have cancelation if (and only if) there is a channel.
+	haveCtxCancelation := ctx.Done() != nil
+
+	eventBroadcaster.cancelationCtx, eventBroadcaster.cancel = context.WithCancel(ctx)
+
+	if haveCtxCancelation {
+		// Calling Shutdown is not required when a context was provided:
+		// when the context is canceled, this goroutine will shut down
+		// the broadcaster.
+		//
+		// If Shutdown is called first, then this goroutine will
+		// also stop.
+		go func() {
+			<-eventBroadcaster.cancelationCtx.Done()
+			eventBroadcaster.Broadcaster.Shutdown()
+		}()
+	}
+
+	return eventBroadcaster
+}
+
+func NewBroadcasterForTests(sleepDuration time.Duration) EventBroadcaster {
+	return NewBroadcaster(WithSleepDuration(sleepDuration))
+}
+
+func NewBroadcasterWithCorrelatorOptions(options CorrelatorOptions) EventBroadcaster {
+	return NewBroadcaster(WithCorrelatorOptions(options))
+}
+
+func WithCorrelatorOptions(options CorrelatorOptions) BroadcasterOption {
+	return func(c *config) {
+		c.CorrelatorOptions = options
+	}
+}
+
+// WithContext sets a context for the broadcaster. Canceling the context will
+// shut down the broadcaster, Shutdown doesn't need to be called. The context
+// can also be used to provide a logger.
+func WithContext(ctx context.Context) BroadcasterOption {
+	return func(c *config) {
+		c.Context = ctx
+	}
+}
+
+func WithSleepDuration(sleepDuration time.Duration) BroadcasterOption {
+	return func(c *config) {
+		c.sleepDuration = sleepDuration
+	}
+}
+
+type BroadcasterOption func(*config)
+
+type config struct {
+	CorrelatorOptions
+	context.Context
+	sleepDuration time.Duration
+}
+
+type eventBroadcasterImpl struct {
+	*watch.Broadcaster
+	sleepDuration  time.Duration
+	options        CorrelatorOptions
+	cancelationCtx context.Context
+	cancel         func()
+}
+
+// StartRecordingToSink starts sending events received from the specified eventBroadcaster to the given sink.
+// The return value can be ignored or used to stop recording, if desired.
+// TODO: make me an object with parameterizable queue length and retry interval
+func (e *eventBroadcasterImpl) StartRecordingToSink(sink EventSink) watch.Interface {
+	eventCorrelator := NewEventCorrelatorWithOptions(e.options)
+	return e.StartEventWatcher(
+		func(event *v1.Event) {
+			e.recordToSink(sink, event, eventCorrelator)
+		})
+}
+
+func (e *eventBroadcasterImpl) Shutdown() {
+	e.Broadcaster.Shutdown()
+	e.cancel()
+}
+
+func (e *eventBroadcasterImpl) recordToSink(sink EventSink, event *v1.Event, eventCorrelator *EventCorrelator) {
+	// Make a copy before modification, because there could be multiple listeners.
+	// Events are safe to copy like this.
+	eventCopy := *event
+	event = &eventCopy
+	result, err := eventCorrelator.EventCorrelate(event)
+	if err != nil {
+		utilruntime.HandleError(err)
+	}
+	if result.Skip {
+		return
+	}
+	tries := 0
+	for {
+		if recordEvent(e.cancelationCtx, sink, result.Event, result.Patch, result.Event.Count > 1, eventCorrelator) {
+			break
+		}
+		tries++
+		if tries >= maxTriesPerEvent {
+			klog.FromContext(e.cancelationCtx).Error(nil, "Unable to write event (retry limit exceeded!)", "event", event)
+			break
+		}
+
+		// Randomize the first sleep so that various clients won't all be
+		// synced up if the master goes down.
+		delay := e.sleepDuration
+		if tries == 1 {
+			delay = time.Duration(float64(delay) * rand.Float64())
+		}
+		select {
+		case <-e.cancelationCtx.Done():
+			klog.FromContext(e.cancelationCtx).Error(nil, "Unable to write event (broadcaster is shut down)", "event", event)
+			return
+		case <-time.After(delay):
+		}
+	}
+}
+
+// recordEvent attempts to write event to a sink. It returns true if the event
+// was successfully recorded or discarded, false if it should be retried.
+// If updateExistingEvent is false, it creates a new event, otherwise it updates
+// existing event.
+func recordEvent(ctx context.Context, sink EventSink, event *v1.Event, patch []byte, updateExistingEvent bool, eventCorrelator *EventCorrelator) bool {
+	var newEvent *v1.Event
+	var err error
+	if updateExistingEvent {
+		newEvent, err = sink.Patch(event, patch)
+	}
+	// Update can fail because the event may have been removed and it no longer exists.
+	if !updateExistingEvent || util.IsKeyNotFoundError(err) {
+		// Making sure that ResourceVersion is empty on creation
+		event.ResourceVersion = ""
+		newEvent, err = sink.Create(event)
+	}
+	if err == nil {
+		// we need to update our event correlator with the server returned state to handle name/resourceversion
+		eventCorrelator.UpdateState(newEvent)
+		return true
+	}
+
+	// If we can't contact the server, then hold everything while we keep trying.
+	// Otherwise, something about the event is malformed and we should abandon it.
+	switch err.(type) {
+	case *restclient.RequestConstructionError:
+		// We will construct the request the same next time, so don't keep trying.
+		klog.FromContext(ctx).Error(err, "Unable to construct event (will not retry!)", "event", event)
+		return true
+	case *errors.StatusError:
+		if errors.IsAlreadyExists(err) || errors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
+			klog.FromContext(ctx).V(5).Info("Server rejected event (will not retry!)", "event", event, "err", err)
+		} else {
+			klog.FromContext(ctx).Error(err, "Server rejected event (will not retry!)", "event", event)
+		}
+		return true
+	case *errors.UnexpectedObjectError:
+		// We don't expect this; it implies the server's response didn't match a
+		// known pattern. Go ahead and retry.
+	default:
+		// This case includes actual http transport errors. Go ahead and retry.
+	}
+	klog.FromContext(ctx).Error(err, "Unable to write event (may retry after sleeping)", "event", event)
+	return false
+}
+
+// StartLogging starts sending events received from this EventBroadcaster to the given logging function.
+// The return value can be ignored or used to stop recording, if desired.
+func (e *eventBroadcasterImpl) StartLogging(logf func(format string, args ...interface{})) watch.Interface {
+	return e.StartEventWatcher(
+		func(e *v1.Event) {
+			logf("Event(%#v): type: '%v' reason: '%v' %v", e.InvolvedObject, e.Type, e.Reason, e.Message)
+		})
+}
+
+// StartStructuredLogging starts sending events received from this EventBroadcaster to a structured logger.
+// The logger is retrieved from a context if the broadcaster was constructed with a context, otherwise
+// the global default is used.
+// The return value can be ignored or used to stop recording, if desired.
+func (e *eventBroadcasterImpl) StartStructuredLogging(verbosity klog.Level) watch.Interface {
+	loggerV := klog.FromContext(e.cancelationCtx).V(int(verbosity))
+	return e.StartEventWatcher(
+		func(e *v1.Event) {
+			loggerV.Info("Event occurred", "object", klog.KRef(e.InvolvedObject.Namespace, e.InvolvedObject.Name), "fieldPath", e.InvolvedObject.FieldPath, "kind", e.InvolvedObject.Kind, "apiVersion", e.InvolvedObject.APIVersion, "type", e.Type, "reason", e.Reason, "message", e.Message)
+		})
+}
+
+// StartEventWatcher starts sending events received from this EventBroadcaster to the given event handler function.
+// The return value can be ignored or used to stop recording, if desired.
+func (e *eventBroadcasterImpl) StartEventWatcher(eventHandler func(*v1.Event)) watch.Interface {
+	watcher, err := e.Watch()
+	if err != nil {
+		// This function traditionally returns no error even though it can fail.
+		// Instead, it logs the error and returns an empty watch. The empty
+		// watch ensures that callers don't crash when calling Stop.
+		klog.FromContext(e.cancelationCtx).Error(err, "Unable start event watcher (will not retry!)")
+		return watch.NewEmptyWatch()
+	}
+	go func() {
+		defer utilruntime.HandleCrash()
+		for {
+			select {
+			case <-e.cancelationCtx.Done():
+				watcher.Stop()
+				return
+			case watchEvent, ok := <-watcher.ResultChan():
+				if !ok {
+					return
+				}
+				event, ok := watchEvent.Object.(*v1.Event)
+				if !ok {
+					// This is all local, so there's no reason this should
+					// ever happen.
+					continue
+				}
+				eventHandler(event)
+			}
+		}
+	}()
+	return watcher
+}
+
+// NewRecorder returns an EventRecorder that records events with the given event source.
+func (e *eventBroadcasterImpl) NewRecorder(scheme *runtime.Scheme, source v1.EventSource) EventRecorderLogger {
+	return &recorderImplLogger{recorderImpl: &recorderImpl{scheme, source, e.Broadcaster, clock.RealClock{}}, logger: klog.Background()}
+}
+
+type recorderImpl struct {
+	scheme *runtime.Scheme
+	source v1.EventSource
+	*watch.Broadcaster
+	clock clock.PassiveClock
+}
+
+var _ EventRecorder = &recorderImpl{}
+
+func (recorder *recorderImpl) generateEvent(logger klog.Logger, object runtime.Object, annotations map[string]string, eventtype, reason, message string) {
+	ref, err := ref.GetReference(recorder.scheme, object)
+	if err != nil {
+		logger.Error(err, "Could not construct reference, will not report event", "object", object, "eventType", eventtype, "reason", reason, "message", message)
+		return
+	}
+
+	if !util.ValidateEventType(eventtype) {
+		logger.Error(nil, "Unsupported event type", "eventType", eventtype)
+		return
+	}
+
+	event := recorder.makeEvent(ref, annotations, eventtype, reason, message)
+	event.Source = recorder.source
+
+	event.ReportingInstance = recorder.source.Host
+	event.ReportingController = recorder.source.Component
+
+	// NOTE: events should be a non-blocking operation, but we also need to not
+	// put this in a goroutine, otherwise we'll race to write to a closed channel
+	// when we go to shut down this broadcaster.  Just drop events if we get overloaded,
+	// and log an error if that happens (we've configured the broadcaster to drop
+	// outgoing events anyway).
+	sent, err := recorder.ActionOrDrop(watch.Added, event)
+	if err != nil {
+		logger.Error(err, "Unable to record event (will not retry!)")
+		return
+	}
+	if !sent {
+		logger.Error(nil, "Unable to record event: too many queued events, dropped event", "event", event)
+	}
+}
+
+func (recorder *recorderImpl) Event(object runtime.Object, eventtype, reason, message string) {
+	recorder.generateEvent(klog.Background(), object, nil, eventtype, reason, message)
+}
+
+func (recorder *recorderImpl) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	recorder.Event(object, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (recorder *recorderImpl) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	recorder.generateEvent(klog.Background(), object, annotations, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (recorder *recorderImpl) makeEvent(ref *v1.ObjectReference, annotations map[string]string, eventtype, reason, message string) *v1.Event {
+	t := metav1.Time{Time: recorder.clock.Now()}
+	namespace := ref.Namespace
+	if namespace == "" {
+		namespace = metav1.NamespaceDefault
+	}
+	return &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        util.GenerateEventName(ref.Name, t.UnixNano()),
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		InvolvedObject: *ref,
+		Reason:         reason,
+		Message:        message,
+		FirstTimestamp: t,
+		LastTimestamp:  t,
+		Count:          1,
+		Type:           eventtype,
+	}
+}
+
+type recorderImplLogger struct {
+	*recorderImpl
+	logger klog.Logger
+}
+
+var _ EventRecorderLogger = &recorderImplLogger{}
+
+func (recorder recorderImplLogger) Event(object runtime.Object, eventtype, reason, message string) {
+	recorder.recorderImpl.generateEvent(recorder.logger, object, nil, eventtype, reason, message)
+}
+
+func (recorder recorderImplLogger) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	recorder.Event(object, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (recorder recorderImplLogger) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	recorder.generateEvent(recorder.logger, object, annotations, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (recorder recorderImplLogger) WithLogger(logger klog.Logger) EventRecorderLogger {
+	return recorderImplLogger{recorderImpl: recorder.recorderImpl, logger: logger}
+}

--- a/vendor/k8s.io/client-go/tools/record/events_cache.go
+++ b/vendor/k8s.io/client-go/tools/record/events_cache.go
@@ -1,0 +1,521 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package record
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/clock"
+	"k8s.io/utils/lru"
+)
+
+const (
+	maxLruCacheEntries = 4096
+
+	// if we see the same event that varies only by message
+	// more than 10 times in a 10 minute period, aggregate the event
+	defaultAggregateMaxEvents         = 10
+	defaultAggregateIntervalInSeconds = 600
+
+	// by default, allow a source to send 25 events about an object
+	// but control the refill rate to 1 new event every 5 minutes
+	// this helps control the long-tail of events for things that are always
+	// unhealthy
+	defaultSpamBurst = 25
+	defaultSpamQPS   = 1. / 300.
+)
+
+// getEventKey builds unique event key based on source, involvedObject, reason, message
+func getEventKey(event *v1.Event) string {
+	return strings.Join([]string{
+		event.Source.Component,
+		event.Source.Host,
+		event.InvolvedObject.Kind,
+		event.InvolvedObject.Namespace,
+		event.InvolvedObject.Name,
+		event.InvolvedObject.FieldPath,
+		string(event.InvolvedObject.UID),
+		event.InvolvedObject.APIVersion,
+		event.Type,
+		event.Reason,
+		event.Message,
+	},
+		"")
+}
+
+// getSpamKey builds unique event key based on source, involvedObject
+func getSpamKey(event *v1.Event) string {
+	return strings.Join([]string{
+		event.Source.Component,
+		event.Source.Host,
+		event.InvolvedObject.Kind,
+		event.InvolvedObject.Namespace,
+		event.InvolvedObject.Name,
+		string(event.InvolvedObject.UID),
+		event.InvolvedObject.APIVersion,
+		event.Type,
+	},
+		"")
+}
+
+// EventSpamKeyFunc is a function that returns unique key based on provided event
+type EventSpamKeyFunc func(event *v1.Event) string
+
+// EventFilterFunc is a function that returns true if the event should be skipped
+type EventFilterFunc func(event *v1.Event) bool
+
+// EventSourceObjectSpamFilter is responsible for throttling
+// the amount of events a source and object can produce.
+type EventSourceObjectSpamFilter struct {
+	// the cache that manages last synced state
+	cache *lru.Cache
+
+	// burst is the amount of events we allow per source + object
+	burst int
+
+	// qps is the refill rate of the token bucket in queries per second
+	qps float32
+
+	// clock is used to allow for testing over a time interval
+	clock clock.PassiveClock
+
+	// spamKeyFunc is a func used to create a key based on an event, which is later used to filter spam events.
+	spamKeyFunc EventSpamKeyFunc
+}
+
+// NewEventSourceObjectSpamFilter allows burst events from a source about an object with the specified qps refill.
+func NewEventSourceObjectSpamFilter(lruCacheSize, burst int, qps float32, clock clock.PassiveClock, spamKeyFunc EventSpamKeyFunc) *EventSourceObjectSpamFilter {
+	return &EventSourceObjectSpamFilter{
+		cache:       lru.New(lruCacheSize),
+		burst:       burst,
+		qps:         qps,
+		clock:       clock,
+		spamKeyFunc: spamKeyFunc,
+	}
+}
+
+// spamRecord holds data used to perform spam filtering decisions.
+type spamRecord struct {
+	// rateLimiter controls the rate of events about this object
+	rateLimiter flowcontrol.PassiveRateLimiter
+}
+
+// Filter controls that a given source+object are not exceeding the allowed rate.
+func (f *EventSourceObjectSpamFilter) Filter(event *v1.Event) bool {
+	var record spamRecord
+
+	// controls our cached information about this event
+	eventKey := f.spamKeyFunc(event)
+
+	// do we have a record of similar events in our cache?
+	value, found := f.cache.Get(eventKey)
+	if found {
+		record = value.(spamRecord)
+	}
+
+	// verify we have a rate limiter for this record
+	if record.rateLimiter == nil {
+		record.rateLimiter = flowcontrol.NewTokenBucketPassiveRateLimiterWithClock(f.qps, f.burst, f.clock)
+	}
+
+	// ensure we have available rate
+	filter := !record.rateLimiter.TryAccept()
+
+	// update the cache
+	f.cache.Add(eventKey, record)
+
+	return filter
+}
+
+// EventAggregatorKeyFunc is responsible for grouping events for aggregation
+// It returns a tuple of the following:
+// aggregateKey - key the identifies the aggregate group to bucket this event
+// localKey - key that makes this event in the local group
+type EventAggregatorKeyFunc func(event *v1.Event) (aggregateKey string, localKey string)
+
+// EventAggregatorByReasonFunc aggregates events by exact match on event.Source, event.InvolvedObject, event.Type,
+// event.Reason, event.ReportingController and event.ReportingInstance
+func EventAggregatorByReasonFunc(event *v1.Event) (string, string) {
+	return strings.Join([]string{
+		event.Source.Component,
+		event.Source.Host,
+		event.InvolvedObject.Kind,
+		event.InvolvedObject.Namespace,
+		event.InvolvedObject.Name,
+		string(event.InvolvedObject.UID),
+		event.InvolvedObject.APIVersion,
+		event.Type,
+		event.Reason,
+		event.ReportingController,
+		event.ReportingInstance,
+	},
+		""), event.Message
+}
+
+// EventAggregatorMessageFunc is responsible for producing an aggregation message
+type EventAggregatorMessageFunc func(event *v1.Event) string
+
+// EventAggregatorByReasonMessageFunc returns an aggregate message by prefixing the incoming message
+func EventAggregatorByReasonMessageFunc(event *v1.Event) string {
+	return "(combined from similar events): " + event.Message
+}
+
+// EventAggregator identifies similar events and aggregates them into a single event
+type EventAggregator struct {
+	sync.RWMutex
+
+	// The cache that manages aggregation state
+	cache *lru.Cache
+
+	// The function that groups events for aggregation
+	keyFunc EventAggregatorKeyFunc
+
+	// The function that generates a message for an aggregate event
+	messageFunc EventAggregatorMessageFunc
+
+	// The maximum number of events in the specified interval before aggregation occurs
+	maxEvents uint
+
+	// The amount of time in seconds that must transpire since the last occurrence of a similar event before it's considered new
+	maxIntervalInSeconds uint
+
+	// clock is used to allow for testing over a time interval
+	clock clock.PassiveClock
+}
+
+// NewEventAggregator returns a new instance of an EventAggregator
+func NewEventAggregator(lruCacheSize int, keyFunc EventAggregatorKeyFunc, messageFunc EventAggregatorMessageFunc,
+	maxEvents int, maxIntervalInSeconds int, clock clock.PassiveClock) *EventAggregator {
+	return &EventAggregator{
+		cache:                lru.New(lruCacheSize),
+		keyFunc:              keyFunc,
+		messageFunc:          messageFunc,
+		maxEvents:            uint(maxEvents),
+		maxIntervalInSeconds: uint(maxIntervalInSeconds),
+		clock:                clock,
+	}
+}
+
+// aggregateRecord holds data used to perform aggregation decisions
+type aggregateRecord struct {
+	// we track the number of unique local keys we have seen in the aggregate set to know when to actually aggregate
+	// if the size of this set exceeds the max, we know we need to aggregate
+	localKeys sets.Set[string]
+	// The last time at which the aggregate was recorded
+	lastTimestamp metav1.Time
+}
+
+// EventAggregate checks if a similar event has been seen according to the
+// aggregation configuration (max events, max interval, etc) and returns:
+//
+//   - The (potentially modified) event that should be created
+//   - The cache key for the event, for correlation purposes. This will be set to
+//     the full key for normal events, and to the result of
+//     EventAggregatorMessageFunc for aggregate events.
+func (e *EventAggregator) EventAggregate(newEvent *v1.Event) (*v1.Event, string) {
+	now := metav1.NewTime(e.clock.Now())
+	var record aggregateRecord
+	// eventKey is the full cache key for this event
+	eventKey := getEventKey(newEvent)
+	// aggregateKey is for the aggregate event, if one is needed.
+	aggregateKey, localKey := e.keyFunc(newEvent)
+
+	// Do we have a record of similar events in our cache?
+	e.Lock()
+	defer e.Unlock()
+	value, found := e.cache.Get(aggregateKey)
+	if found {
+		record = value.(aggregateRecord)
+	}
+
+	// Is the previous record too old? If so, make a fresh one. Note: if we didn't
+	// find a similar record, its lastTimestamp will be the zero value, so we
+	// create a new one in that case.
+	maxInterval := time.Duration(e.maxIntervalInSeconds) * time.Second
+	interval := now.Time.Sub(record.lastTimestamp.Time)
+	if interval > maxInterval {
+		record = aggregateRecord{localKeys: sets.New[string]()}
+	}
+
+	// Write the new event into the aggregation record and put it on the cache
+	record.localKeys.Insert(localKey)
+	record.lastTimestamp = now
+	e.cache.Add(aggregateKey, record)
+
+	// If we are not yet over the threshold for unique events, don't correlate them
+	if uint(record.localKeys.Len()) < e.maxEvents {
+		return newEvent, eventKey
+	}
+
+	// do not grow our local key set any larger than max
+	record.localKeys.PopAny()
+
+	// create a new aggregate event, and return the aggregateKey as the cache key
+	// (so that it can be overwritten.)
+	eventCopy := &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%v.%x", newEvent.InvolvedObject.Name, now.UnixNano()),
+			Namespace: newEvent.Namespace,
+		},
+		Count:          1,
+		FirstTimestamp: now,
+		InvolvedObject: newEvent.InvolvedObject,
+		LastTimestamp:  now,
+		Message:        e.messageFunc(newEvent),
+		Type:           newEvent.Type,
+		Reason:         newEvent.Reason,
+		Source:         newEvent.Source,
+	}
+	return eventCopy, aggregateKey
+}
+
+// eventLog records data about when an event was observed
+type eventLog struct {
+	// The number of times the event has occurred since first occurrence.
+	count uint
+
+	// The time at which the event was first recorded.
+	firstTimestamp metav1.Time
+
+	// The unique name of the first occurrence of this event
+	name string
+
+	// Resource version returned from previous interaction with server
+	resourceVersion string
+}
+
+// eventLogger logs occurrences of an event
+type eventLogger struct {
+	sync.RWMutex
+	cache *lru.Cache
+	clock clock.PassiveClock
+}
+
+// newEventLogger observes events and counts their frequencies
+func newEventLogger(lruCacheEntries int, clock clock.PassiveClock) *eventLogger {
+	return &eventLogger{cache: lru.New(lruCacheEntries), clock: clock}
+}
+
+// eventObserve records an event, or updates an existing one if key is a cache hit
+func (e *eventLogger) eventObserve(newEvent *v1.Event, key string) (*v1.Event, []byte, error) {
+	var (
+		patch []byte
+		err   error
+	)
+	eventCopy := *newEvent
+	event := &eventCopy
+
+	e.Lock()
+	defer e.Unlock()
+
+	// Check if there is an existing event we should update
+	lastObservation := e.lastEventObservationFromCache(key)
+
+	// If we found a result, prepare a patch
+	if lastObservation.count > 0 {
+		// update the event based on the last observation so patch will work as desired
+		event.Name = lastObservation.name
+		event.ResourceVersion = lastObservation.resourceVersion
+		event.FirstTimestamp = lastObservation.firstTimestamp
+		event.Count = int32(lastObservation.count) + 1
+
+		eventCopy2 := *event
+		eventCopy2.Count = 0
+		eventCopy2.LastTimestamp = metav1.NewTime(time.Unix(0, 0))
+		eventCopy2.Message = ""
+
+		newData, _ := json.Marshal(event)
+		oldData, _ := json.Marshal(eventCopy2)
+		patch, err = strategicpatch.CreateTwoWayMergePatch(oldData, newData, event)
+	}
+
+	// record our new observation
+	e.cache.Add(
+		key,
+		eventLog{
+			count:           uint(event.Count),
+			firstTimestamp:  event.FirstTimestamp,
+			name:            event.Name,
+			resourceVersion: event.ResourceVersion,
+		},
+	)
+	return event, patch, err
+}
+
+// updateState updates its internal tracking information based on latest server state
+func (e *eventLogger) updateState(event *v1.Event) {
+	key := getEventKey(event)
+	e.Lock()
+	defer e.Unlock()
+	// record our new observation
+	e.cache.Add(
+		key,
+		eventLog{
+			count:           uint(event.Count),
+			firstTimestamp:  event.FirstTimestamp,
+			name:            event.Name,
+			resourceVersion: event.ResourceVersion,
+		},
+	)
+}
+
+// lastEventObservationFromCache returns the event from the cache, reads must be protected via external lock
+func (e *eventLogger) lastEventObservationFromCache(key string) eventLog {
+	value, ok := e.cache.Get(key)
+	if ok {
+		observationValue, ok := value.(eventLog)
+		if ok {
+			return observationValue
+		}
+	}
+	return eventLog{}
+}
+
+// EventCorrelator processes all incoming events and performs analysis to avoid overwhelming the system.  It can filter all
+// incoming events to see if the event should be filtered from further processing.  It can aggregate similar events that occur
+// frequently to protect the system from spamming events that are difficult for users to distinguish.  It performs de-duplication
+// to ensure events that are observed multiple times are compacted into a single event with increasing counts.
+type EventCorrelator struct {
+	// the function to filter the event
+	filterFunc EventFilterFunc
+	// the object that performs event aggregation
+	aggregator *EventAggregator
+	// the object that observes events as they come through
+	logger *eventLogger
+}
+
+// EventCorrelateResult is the result of a Correlate
+type EventCorrelateResult struct {
+	// the event after correlation
+	Event *v1.Event
+	// if provided, perform a strategic patch when updating the record on the server
+	Patch []byte
+	// if true, do no further processing of the event
+	Skip bool
+}
+
+// NewEventCorrelator returns an EventCorrelator configured with default values.
+//
+// The EventCorrelator is responsible for event filtering, aggregating, and counting
+// prior to interacting with the API server to record the event.
+//
+// The default behavior is as follows:
+//   - Aggregation is performed if a similar event is recorded 10 times
+//     in a 10 minute rolling interval.  A similar event is an event that varies only by
+//     the Event.Message field.  Rather than recording the precise event, aggregation
+//     will create a new event whose message reports that it has combined events with
+//     the same reason.
+//   - Events are incrementally counted if the exact same event is encountered multiple
+//     times.
+//   - A source may burst 25 events about an object, but has a refill rate budget
+//     per object of 1 event every 5 minutes to control long-tail of spam.
+func NewEventCorrelator(clock clock.PassiveClock) *EventCorrelator {
+	cacheSize := maxLruCacheEntries
+	spamFilter := NewEventSourceObjectSpamFilter(cacheSize, defaultSpamBurst, defaultSpamQPS, clock, getSpamKey)
+	return &EventCorrelator{
+		filterFunc: spamFilter.Filter,
+		aggregator: NewEventAggregator(
+			cacheSize,
+			EventAggregatorByReasonFunc,
+			EventAggregatorByReasonMessageFunc,
+			defaultAggregateMaxEvents,
+			defaultAggregateIntervalInSeconds,
+			clock),
+
+		logger: newEventLogger(cacheSize, clock),
+	}
+}
+
+func NewEventCorrelatorWithOptions(options CorrelatorOptions) *EventCorrelator {
+	optionsWithDefaults := populateDefaults(options)
+	spamFilter := NewEventSourceObjectSpamFilter(
+		optionsWithDefaults.LRUCacheSize,
+		optionsWithDefaults.BurstSize,
+		optionsWithDefaults.QPS,
+		optionsWithDefaults.Clock,
+		optionsWithDefaults.SpamKeyFunc)
+	return &EventCorrelator{
+		filterFunc: spamFilter.Filter,
+		aggregator: NewEventAggregator(
+			optionsWithDefaults.LRUCacheSize,
+			optionsWithDefaults.KeyFunc,
+			optionsWithDefaults.MessageFunc,
+			optionsWithDefaults.MaxEvents,
+			optionsWithDefaults.MaxIntervalInSeconds,
+			optionsWithDefaults.Clock),
+		logger: newEventLogger(optionsWithDefaults.LRUCacheSize, optionsWithDefaults.Clock),
+	}
+}
+
+// populateDefaults populates the zero value options with defaults
+func populateDefaults(options CorrelatorOptions) CorrelatorOptions {
+	if options.LRUCacheSize == 0 {
+		options.LRUCacheSize = maxLruCacheEntries
+	}
+	if options.BurstSize == 0 {
+		options.BurstSize = defaultSpamBurst
+	}
+	if options.QPS == 0 {
+		options.QPS = defaultSpamQPS
+	}
+	if options.KeyFunc == nil {
+		options.KeyFunc = EventAggregatorByReasonFunc
+	}
+	if options.MessageFunc == nil {
+		options.MessageFunc = EventAggregatorByReasonMessageFunc
+	}
+	if options.MaxEvents == 0 {
+		options.MaxEvents = defaultAggregateMaxEvents
+	}
+	if options.MaxIntervalInSeconds == 0 {
+		options.MaxIntervalInSeconds = defaultAggregateIntervalInSeconds
+	}
+	if options.Clock == nil {
+		options.Clock = clock.RealClock{}
+	}
+	if options.SpamKeyFunc == nil {
+		options.SpamKeyFunc = getSpamKey
+	}
+	return options
+}
+
+// EventCorrelate filters, aggregates, counts, and de-duplicates all incoming events
+func (c *EventCorrelator) EventCorrelate(newEvent *v1.Event) (*EventCorrelateResult, error) {
+	if newEvent == nil {
+		return nil, fmt.Errorf("event is nil")
+	}
+	aggregateEvent, ckey := c.aggregator.EventAggregate(newEvent)
+	observedEvent, patch, err := c.logger.eventObserve(aggregateEvent, ckey)
+	if c.filterFunc(observedEvent) {
+		return &EventCorrelateResult{Skip: true}, nil
+	}
+	return &EventCorrelateResult{Event: observedEvent, Patch: patch}, err
+}
+
+// UpdateState based on the latest observed state from server
+func (c *EventCorrelator) UpdateState(event *v1.Event) {
+	c.logger.updateState(event)
+}

--- a/vendor/k8s.io/client-go/tools/record/fake.go
+++ b/vendor/k8s.io/client-go/tools/record/fake.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package record
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+)
+
+// FakeRecorder is used as a fake during tests. It is thread safe. It is usable
+// when created manually and not by NewFakeRecorder, however all events may be
+// thrown away in this case.
+type FakeRecorder struct {
+	Events chan string
+
+	IncludeObject bool
+}
+
+var _ EventRecorderLogger = &FakeRecorder{}
+
+func objectString(object runtime.Object, includeObject bool) string {
+	if !includeObject {
+		return ""
+	}
+	return fmt.Sprintf(" involvedObject{kind=%s,apiVersion=%s}",
+		object.GetObjectKind().GroupVersionKind().Kind,
+		object.GetObjectKind().GroupVersionKind().GroupVersion(),
+	)
+}
+
+func annotationsString(annotations map[string]string) string {
+	if len(annotations) == 0 {
+		return ""
+	} else {
+		return " " + fmt.Sprint(annotations)
+	}
+}
+
+func (f *FakeRecorder) writeEvent(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	if f.Events != nil {
+		f.Events <- fmt.Sprintf(eventtype+" "+reason+" "+messageFmt, args...) +
+			objectString(object, f.IncludeObject) + annotationsString(annotations)
+	}
+}
+
+func (f *FakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	f.writeEvent(object, nil, eventtype, reason, "%s", message)
+}
+
+func (f *FakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.writeEvent(object, nil, eventtype, reason, messageFmt, args...)
+}
+
+func (f *FakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.writeEvent(object, annotations, eventtype, reason, messageFmt, args...)
+}
+
+func (f *FakeRecorder) WithLogger(logger klog.Logger) EventRecorderLogger {
+	return f
+}
+
+// NewFakeRecorder creates new fake event recorder with event channel with
+// buffer of given size.
+func NewFakeRecorder(bufferSize int) *FakeRecorder {
+	return &FakeRecorder{
+		Events: make(chan string, bufferSize),
+	}
+}

--- a/vendor/k8s.io/client-go/tools/record/util/util.go
+++ b/vendor/k8s.io/client-go/tools/record/util/util.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+)
+
+// ValidateEventType checks that eventtype is an expected type of event
+func ValidateEventType(eventtype string) bool {
+	switch eventtype {
+	case v1.EventTypeNormal, v1.EventTypeWarning:
+		return true
+	}
+	return false
+}
+
+// IsKeyNotFoundError is utility function that checks if an error is not found error
+func IsKeyNotFoundError(err error) bool {
+	statusErr, _ := err.(*errors.StatusError)
+
+	return statusErr != nil && statusErr.Status().Code == http.StatusNotFound
+}
+
+// GenerateEventName generates a valid Event name from the referenced name and the passed UNIX timestamp.
+// The referenced Object name may not be a valid name for Events and cause the Event to fail
+// to be created, so we need to generate a new one in that case.
+// Ref: https://issues.k8s.io/127594
+func GenerateEventName(refName string, unixNano int64) string {
+	name := fmt.Sprintf("%s.%x", refName, unixNano)
+	if errs := apimachineryvalidation.NameIsDNSSubdomain(name, false); len(errs) > 0 {
+		// Using an uuid guarantees uniqueness and correctness
+		name = uuid.New().String()
+	}
+	return name
+}

--- a/vendor/k8s.io/utils/internal/third_party/forked/golang/golang-lru/lru.go
+++ b/vendor/k8s.io/utils/internal/third_party/forked/golang/golang-lru/lru.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2013 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package lru implements an LRU cache.
+package golang_lru
+
+import "container/list"
+
+// Cache is an LRU cache. It is not safe for concurrent access.
+type Cache struct {
+	// MaxEntries is the maximum number of cache entries before
+	// an item is evicted. Zero means no limit.
+	MaxEntries int
+
+	// OnEvicted optionally specifies a callback function to be
+	// executed when an entry is purged from the cache.
+	OnEvicted func(key Key, value interface{})
+
+	ll    *list.List
+	cache map[interface{}]*list.Element
+}
+
+// A Key may be any value that is comparable. See http://golang.org/ref/spec#Comparison_operators
+type Key interface{}
+
+type entry struct {
+	key   Key
+	value interface{}
+}
+
+// New creates a new Cache.
+// If maxEntries is zero, the cache has no limit and it's assumed
+// that eviction is done by the caller.
+func New(maxEntries int) *Cache {
+	return &Cache{
+		MaxEntries: maxEntries,
+		ll:         list.New(),
+		cache:      make(map[interface{}]*list.Element),
+	}
+}
+
+// Add adds a value to the cache.
+func (c *Cache) Add(key Key, value interface{}) {
+	if c.cache == nil {
+		c.cache = make(map[interface{}]*list.Element)
+		c.ll = list.New()
+	}
+	if ee, ok := c.cache[key]; ok {
+		c.ll.MoveToFront(ee)
+		ee.Value.(*entry).value = value
+		return
+	}
+	ele := c.ll.PushFront(&entry{key, value})
+	c.cache[key] = ele
+	if c.MaxEntries != 0 && c.ll.Len() > c.MaxEntries {
+		c.RemoveOldest()
+	}
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key Key) (value interface{}, ok bool) {
+	if c.cache == nil {
+		return
+	}
+	if ele, hit := c.cache[key]; hit {
+		c.ll.MoveToFront(ele)
+		return ele.Value.(*entry).value, true
+	}
+	return
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key Key) {
+	if c.cache == nil {
+		return
+	}
+	if ele, hit := c.cache[key]; hit {
+		c.removeElement(ele)
+	}
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() {
+	if c.cache == nil {
+		return
+	}
+	ele := c.ll.Back()
+	if ele != nil {
+		c.removeElement(ele)
+	}
+}
+
+func (c *Cache) removeElement(e *list.Element) {
+	c.ll.Remove(e)
+	kv := e.Value.(*entry)
+	delete(c.cache, kv.key)
+	if c.OnEvicted != nil {
+		c.OnEvicted(kv.key, kv.value)
+	}
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	if c.cache == nil {
+		return 0
+	}
+	return c.ll.Len()
+}
+
+// Clear purges all stored items from the cache.
+func (c *Cache) Clear() {
+	if c.OnEvicted != nil {
+		for _, e := range c.cache {
+			kv := e.Value.(*entry)
+			c.OnEvicted(kv.key, kv.value)
+		}
+	}
+	c.ll = nil
+	c.cache = nil
+}

--- a/vendor/k8s.io/utils/lru/lru.go
+++ b/vendor/k8s.io/utils/lru/lru.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package lru
+
+import (
+	"fmt"
+	"sync"
+
+	groupcache "k8s.io/utils/internal/third_party/forked/golang/golang-lru"
+)
+
+type Key = groupcache.Key
+type EvictionFunc = func(key Key, value interface{})
+
+// Cache is a thread-safe fixed size LRU cache.
+type Cache struct {
+	cache *groupcache.Cache
+	lock  sync.RWMutex
+}
+
+// New creates an LRU of the given size.
+func New(size int) *Cache {
+	return &Cache{
+		cache: groupcache.New(size),
+	}
+}
+
+// NewWithEvictionFunc creates an LRU of the given size with the given eviction func.
+func NewWithEvictionFunc(size int, f EvictionFunc) *Cache {
+	c := New(size)
+	c.cache.OnEvicted = f
+	return c
+}
+
+// SetEvictionFunc updates the eviction func
+func (c *Cache) SetEvictionFunc(f EvictionFunc) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.cache.OnEvicted != nil {
+		return fmt.Errorf("lru cache eviction function is already set")
+	}
+	c.cache.OnEvicted = f
+	return nil
+}
+
+// Add adds a value to the cache.
+func (c *Cache) Add(key Key, value interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.Add(key, value)
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key Key) (value interface{}, ok bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cache.Get(key)
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key Key) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.Remove(key)
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.RemoveOldest()
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.cache.Len()
+}
+
+// Clear purges all stored items from the cache.
+func (c *Cache) Clear() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.Clear()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -180,6 +180,8 @@ github.com/pkg/errors
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.24.1
 ## explicit; go 1.25.0
+github.com/prometheus/client_golang/api
+github.com/prometheus/client_golang/api/prometheus/v1
 github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil
 github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil/header
 github.com/prometheus/client_golang/prometheus
@@ -1058,8 +1060,11 @@ k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/tools/clientcmd/api
 k8s.io/client-go/tools/clientcmd/api/latest
 k8s.io/client-go/tools/clientcmd/api/v1
+k8s.io/client-go/tools/internal/events
 k8s.io/client-go/tools/metrics
 k8s.io/client-go/tools/pager
+k8s.io/client-go/tools/record
+k8s.io/client-go/tools/record/util
 k8s.io/client-go/tools/reference
 k8s.io/client-go/transport
 k8s.io/client-go/util/apply
@@ -1104,7 +1109,9 @@ k8s.io/kube-openapi/pkg/validation/spec
 k8s.io/utils/buffer
 k8s.io/utils/clock
 k8s.io/utils/dump
+k8s.io/utils/internal/third_party/forked/golang/golang-lru
 k8s.io/utils/internal/third_party/forked/golang/net
+k8s.io/utils/lru
 k8s.io/utils/net
 k8s.io/utils/ptr
 k8s.io/utils/trace


### PR DESCRIPTION
## Summary

Combine phased Deployment rollouts with health-check driven rollout gating for end-to-end testing.

- Includes the changes from #461 and #469
- Evaluates `RolloutHealthCheck` after Deployment canaries become ready and before unpausing the main Deployment
- Isolates cached health policy state per workload and clears it when gates are bypassed or disabled

Ref: https://github.com/grafana/rollout-operator/issues/178

Made with [Cursor](https://cursor.com)