### PR TITLE
Backport standard image cross-compilation for v0.28.x

### DIFF
--- a/Dockerfile.boringcrypto
+++ b/Dockerfile.boringcrypto
@@ -1,13 +1,13 @@
-FROM --platform=$BUILDPLATFORM golang:1.26-trixie AS build
+FROM golang:1.26-trixie AS build
 
 ARG TARGETOS
 ARG TARGETARCH
 
 COPY . /src/rollout-operator
 WORKDIR /src/rollout-operator
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make rollout-operator
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make rollout-operator-boringcrypto
 
-FROM gcr.io/distroless/static-debian13:nonroot
+FROM gcr.io/distroless/base-nossl-debian13:nonroot
 
 COPY --from=build /src/rollout-operator/rollout-operator /usr/bin/rollout-operator
 ENTRYPOINT [ "/usr/bin/rollout-operator" ]

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,6 @@ GOARCH ?= $(shell go env GOARCH)
 DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune
 GO_FILES := $(shell find . $(DONT_FIND) -o -type f -name '*.go' -print)
 
-# Boringcrypto has a different base image for glibc
-BORINGCRYPTO_BASE_IMAGE=gcr.io/distroless/base-nossl-debian13:nonroot
-
 .DEFAULT_GOAL := rollout-operator
 
 # Adapted from https://www.thapaliya.com/en/writings/well-documented-makefiles/
@@ -39,7 +36,7 @@ build-image: clean ## Build the rollout-operator image
 .PHONY: build-image-boringcrypto
 build-image-boringcrypto: clean ## Build the rollout-operator image with boringcrypto
 	# Tags with the regular image repo for integration testing
-	docker buildx build --load --platform linux/$(GOARCH) --build-arg revision=$(GIT_REVISION) --build-arg BASEIMAGE=$(BORINGCRYPTO_BASE_IMAGE) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) .
+	docker buildx build --load --platform linux/$(GOARCH) --build-arg revision=$(GIT_REVISION) -t rollout-operator:latest -t rollout-operator:$(IMAGE_TAG) -f Dockerfile.boringcrypto .
 
 .PHONY: build-test-images
 build-test-images: build-image integration/mock-service/.uptodate ## Build both rollout-operator and mock-service images for testing
@@ -53,7 +50,7 @@ publish-standard-image: clean ## Build and publish only the standard rollout-ope
 
 .PHONY: publish-boringcrypto-image
 publish-boringcrypto-image: clean ## Build and publish only the boring-crypto rollout-operator image
-	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) --build-arg BASEIMAGE=$(BORINGCRYPTO_BASE_IMAGE) --build-arg BUILDTARGET=rollout-operator-boringcrypto -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) .
+	docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg revision=$(GIT_REVISION) -t $(IMAGE_PREFIX)/rollout-operator-boringcrypto:$(IMAGE_TAG) -f Dockerfile.boringcrypto .
 
 .PHONY: release-notes 
 release-notes: ## Generate the release notes for a GitHub release


### PR DESCRIPTION
The changes from https://github.com/grafana/rollout-operator/pull/483 to build releases for this branch from github actions worked, but the image build took ~40 minutes.

This backports the changes from #279 to split `Dockerfile` into two files: one for the standard image and one for boringcrypto. It speeds up the image build by cross-compiling the standard image ( `--platform=$BUILDPLATFORM` in `Dockerfile`). This should cut the build to 20-25m like when publishing from `main`.