### PR TITLE
Batch Kubernetes reads for ZPDB enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main / unreleased
 
+* [ENHANCEMENT] Reduce ZPDB eviction enforcement API calls by fetching related StatefulSets and pods once per request.
 * [ENHANCEMENT] Update Go to `1.27` #494
 * [ENHANCEMENT] Updated dependencies, including: #491
   * `github.com/stretchr/testify` from `v1.12.0` to `v1.12.1`

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -334,13 +334,16 @@ func TestZoneAwarePodDisruptionBudgetMaxUnavailableEq1(t *testing.T) {
 	}
 
 	{
-		t.Log("Create 2 zones each with 2 pods.")
+		t.Log("Create 3 zones each with 2 pods.")
 		createMockServiceZone(t, ctx, api, corev1.NamespaceDefault, "mock-zone-a", 2)
 		createMockServiceZone(t, ctx, api, corev1.NamespaceDefault, "mock-zone-b", 2)
+		createMockServiceZone(t, ctx, api, corev1.NamespaceDefault, "mock-zone-c", 2)
 		requireEventuallyPod(t, api, ctx, "mock-zone-a-0", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
 		requireEventuallyPod(t, api, ctx, "mock-zone-b-0", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
+		requireEventuallyPod(t, api, ctx, "mock-zone-c-0", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
 		requireEventuallyPod(t, api, ctx, "mock-zone-a-1", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
 		requireEventuallyPod(t, api, ctx, "mock-zone-b-1", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
+		requireEventuallyPod(t, api, ctx, "mock-zone-c-1", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
 	}
 
 	{
@@ -363,6 +366,12 @@ func TestZoneAwarePodDisruptionBudgetMaxUnavailableEq1(t *testing.T) {
 	{
 		t.Log("Deny a pod eviction in another zone.")
 		ev := &policyv1beta1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "mock-zone-b-0", Namespace: corev1.NamespaceDefault}}
+		require.ErrorContainsf(t, api.PolicyV1beta1().Evictions(corev1.NamespaceDefault).Evict(ctx, ev), "denied the request: 1 pod not ready in mock-zone-a", "Eviction denied")
+	}
+
+	{
+		t.Log("Deny a pod eviction in the third zone.")
+		ev := &policyv1beta1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "mock-zone-c-0", Namespace: corev1.NamespaceDefault}}
 		require.ErrorContainsf(t, api.PolicyV1beta1().Evictions(corev1.NamespaceDefault).Evict(ctx, ev), "denied the request: 1 pod not ready in mock-zone-a", "Eviction denied")
 	}
 

--- a/pkg/zpdb/eviction_controller.go
+++ b/pkg/zpdb/eviction_controller.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/spanlogger"
 	v1 "k8s.io/api/admission/v1"
-	appsv1 "k8s.io/api/apps/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -247,20 +246,36 @@ func (c *EvictionController) HandlePodEvictionRequest(ctx context.Context, ar v1
 		return request.allow()
 	}
 
-	// get the StatefulSet who manages this pod
-	var sts *appsv1.StatefulSet
-	if sts, err = request.client.owner(pod); err != nil {
+	owner, err := statefulSetOwner(pod)
+	if err != nil {
 		level.Error(request.log).Log("msg", logDenyMesg, "reason", "unable to find pod owner", "err", err)
 		c.metrics.EvictionRequests.WithLabelValues("sts-no-found", fmt.Sprintf("%d", http.StatusInternalServerError)).Inc()
 		return request.denyWithReason(err.Error(), http.StatusInternalServerError)
 	}
 
 	// ie ingester-zone-a
-	request.log.SetSpanAndLogTag("owner", sts.Name)
+	request.log.SetSpanAndLogTag("owner", owner.Name)
 
 	lock := c.findLock(pdbConfig.name)
 	lock.Lock()
 	defer lock.Unlock()
+
+	// Find the all StatefulSets which span all zones.
+	// Assumption - each StatefulSet manages all the pods for a single zone. This list of StatefulSets covers all zones.
+	// During a migration it may be possible to break this assumption, but during a migration the maxUnavailable will be set to 0 and the eviction request will be denied.
+	allStatefulSets, err := request.client.findRelatedStatefulSets(pod.Namespace, pdbConfig.selector)
+	if err != nil || allStatefulSets == nil {
+		level.Error(request.log).Log("msg", logDenyMesg, "reason", "unable to find related stateful sets - a minimum of 2 StatefulSets is required", "err", err)
+		c.metrics.EvictionRequests.WithLabelValues("min-sts-not-found", fmt.Sprintf("%d", http.StatusBadRequest)).Inc()
+		return request.denyWithReason("minimum number of StatefulSets not found", http.StatusBadRequest)
+	}
+
+	sts, err := findOwnerStatefulSet(owner, allStatefulSets)
+	if err != nil {
+		level.Error(request.log).Log("msg", logDenyMesg, "reason", "unable to find pod owner", "err", err)
+		c.metrics.EvictionRequests.WithLabelValues("sts-no-found", fmt.Sprintf("%d", http.StatusInternalServerError)).Inc()
+		return request.denyWithReason(err.Error(), http.StatusInternalServerError)
+	}
 
 	// the number of allowed unavailable pods in other zones.
 	maxUnavailable := pdbConfig.maxUnavailablePods(sts)
@@ -278,16 +293,8 @@ func (c *EvictionController) HandlePodEvictionRequest(ctx context.Context, ar v1
 		return request.denyWithReason("max unavailable = 0", http.StatusForbidden)
 	}
 
-	// Find the all StatefulSets which span all zones.
-	// Assumption - each StatefulSet manages all the pods for a single zone. This list of StatefulSets covers all zones.
-	// During a migration it may be possible to break this assumption, but during a migration the maxUnavailable will be set to 0 and the eviction request will be denied.
-	allStatefulSets, err := request.client.findRelatedStatefulSets(sts.Namespace, pdbConfig.selector)
-	if err != nil || allStatefulSets == nil || len(allStatefulSets.Items) <= 1 {
-		if err != nil {
-			level.Error(request.log).Log("msg", logDenyMesg, "reason", "unable to find related stateful sets - a minimum of 2 StatefulSets is required", "err", err)
-		} else {
-			level.Error(request.log).Log("msg", logDenyMesg, "reason", "unable to find related stateful sets - a minimum of 2 StatefulSets is required")
-		}
+	if len(allStatefulSets.Items) <= 1 {
+		level.Error(request.log).Log("msg", logDenyMesg, "reason", "unable to find related stateful sets - a minimum of 2 StatefulSets is required")
 		c.metrics.EvictionRequests.WithLabelValues("min-sts-not-found", fmt.Sprintf("%d", http.StatusBadRequest)).Inc()
 		return request.denyWithReason("minimum number of StatefulSets not found", http.StatusBadRequest)
 	}
@@ -318,18 +325,20 @@ func (c *EvictionController) HandlePodEvictionRequest(ctx context.Context, ar v1
 		pdb = newValidatorZoneAware(sts, len(allStatefulSets.Items), c.podObserver.podEvictCache)
 	}
 
+	relatedPods, err := request.client.findRelatedPods(pod.Namespace, pdbConfig.selector)
+	if err != nil {
+		level.Error(request.log).Log("msg", logDenyMesg, "reason", "unable to determine pod status in related StatefulSets")
+		c.metrics.EvictionRequests.WithLabelValues("err: sts-pod-status-not-determined", fmt.Sprintf("%d", http.StatusInternalServerError)).Inc()
+		return request.denyWithReason("unable to determine pod status in related StatefulSets", http.StatusInternalServerError)
+	}
+
 	for _, otherSts := range allStatefulSets.Items {
 		// test on whether we exclude the eviction pod's StatefulSet from the assessment
 		if !pdb.considerSts(&otherSts) {
 			continue
 		}
 
-		result, err := request.client.podsNotRunningAndReady(&otherSts, pod, pdb)
-		if err != nil {
-			level.Error(request.log).Log("msg", logDenyMesg, "reason", "unable to determine pod status in related StatefulSet", "sts", otherSts.Name)
-			c.metrics.EvictionRequests.WithLabelValues("err: sts-pod-status-not-determined", fmt.Sprintf("%d", http.StatusInternalServerError)).Inc()
-			return request.denyWithReason("unable to determine pod status in related StatefulSet", http.StatusInternalServerError)
-		}
+		result := podsNotRunningAndReady(&otherSts, pod, relatedPods, pdb)
 
 		if err = pdb.accumulateResult(&otherSts, result); err != nil {
 			// opportunity to fail fast

--- a/pkg/zpdb/eviction_controller_test.go
+++ b/pkg/zpdb/eviction_controller_test.go
@@ -497,8 +497,27 @@ func TestPodEviction_MultiZoneClassic(t *testing.T) {
 	// also check that the evicted pod has been stored in the eviction configCache
 	testCtx := newTestContext(t, createBasicEvictionAdmissionReview(testPodZoneA0, testNamespace), newPDBMaxUnavailable(1, rolloutGroupValue), objs...)
 	require.False(t, testCtx.controller.podObserver.podEvictCache.hasPendingEviction(zoneAPod0))
+	testCtx.kubeClient.ClearActions()
 	testCtx.assertAllowResponse(t)
 	require.Equal(t, float64(1), testutil.ToFloat64(testCtx.controller.metrics.EvictionRequests.WithLabelValues("allowed", "200")))
+
+	var podGets, podLists, statefulSetGets, statefulSetLists int
+	for _, action := range testCtx.kubeClient.Actions() {
+		switch {
+		case action.Matches("get", "pods"):
+			podGets++
+		case action.Matches("list", "pods"):
+			podLists++
+		case action.Matches("get", "statefulsets"):
+			statefulSetGets++
+		case action.Matches("list", "statefulsets"):
+			statefulSetLists++
+		}
+	}
+	require.Equal(t, 1, podGets)
+	require.Equal(t, 1, podLists)
+	require.Zero(t, statefulSetGets)
+	require.Equal(t, 1, statefulSetLists)
 
 	require.True(t, testCtx.controller.podObserver.podEvictCache.hasPendingEviction(zoneAPod0))
 	testCtx.controller.Stop()

--- a/pkg/zpdb/pod_eviction_k8s_clients.go
+++ b/pkg/zpdb/pod_eviction_k8s_clients.go
@@ -9,10 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/grafana/rollout-operator/pkg/util"
 )
 
 // A k8sClient holds the Kubernetes API client used to query Kubernetes
@@ -33,22 +30,26 @@ func (a *k8sClient) podByName(namespace string, name string) (*corev1.Pod, error
 	}
 }
 
-// owner returns the StatefulSet which manages a pod or an error if the owner can not be found or is not a StatefulSet
-func (a *k8sClient) owner(pod *corev1.Pod) (*appsv1.StatefulSet, error) {
+// statefulSetOwner returns the reference to the StatefulSet which manages a pod.
+func statefulSetOwner(pod *corev1.Pod) (*metav1.OwnerReference, error) {
 	owner := metav1.GetControllerOf(pod)
 	if owner == nil {
 		return nil, errors.New("unable to find a StatefulSet pod owner")
 	} else if owner.Kind != "StatefulSet" {
 		return nil, fmt.Errorf("pod owner is not a StatefulSet - %s has owner %s (%s)", pod.Name, owner.Name, owner.Kind)
 	}
+	return owner, nil
+}
 
-	if sts, err := a.kubeClient.AppsV1().StatefulSets(pod.Namespace).Get(a.ctx, owner.Name, metav1.GetOptions{}); err != nil {
-		return nil, fmt.Errorf("unable to find StatefulSet %s by name: %w", owner.Name, err)
-	} else if sts == nil {
-		return nil, fmt.Errorf("unable to find StatefulSet %s by name", owner.Name)
-	} else {
-		return sts, nil
+// findOwnerStatefulSet resolves an owner from the related StatefulSets already fetched for enforcement.
+func findOwnerStatefulSet(owner *metav1.OwnerReference, statefulSets *appsv1.StatefulSetList) (*appsv1.StatefulSet, error) {
+	for i := range statefulSets.Items {
+		sts := &statefulSets.Items[i]
+		if sts.Name == owner.Name && (owner.UID == "" || sts.UID == owner.UID) {
+			return sts, nil
+		}
 	}
+	return nil, fmt.Errorf("unable to find StatefulSet %s by name", owner.Name)
 }
 
 // findRelatedStatefulSets returns all StatefulSets which match the given Selector.
@@ -56,23 +57,16 @@ func (a *k8sClient) findRelatedStatefulSets(namespace string, selector *labels.S
 	return a.kubeClient.AppsV1().StatefulSets(namespace).List(a.ctx, metav1.ListOptions{LabelSelector: (*selector).String()})
 }
 
+// findRelatedPods returns all pods selected by the ZPDB in one consistent API snapshot.
+func (a *k8sClient) findRelatedPods(namespace string, selector *labels.Selector) (*corev1.PodList, error) {
+	return a.kubeClient.CoreV1().Pods(namespace).List(a.ctx, metav1.ListOptions{LabelSelector: (*selector).String()})
+}
+
 // podsNotRunningAndReady finds the pods managed by a given StatefulSet. Each pod is inspected to see if it is ready and running. A tally of the total number of pods and the number not ready/running is returned.
 // It is possible for pods to be in a state where they are not yet returned by the pod listing. These pods should be considered and are reported as unknown.
 // The number of unknown pods is determined as the difference between the StatefulSets Replica count minus the number of pods listed.
 // The given Pod is excluded from testing, but is included in the total of tested pods
-func (a *k8sClient) podsNotRunningAndReady(sts *appsv1.StatefulSet, pod *corev1.Pod, zpdb validator) (*zoneStatusResult, error) {
-	podsSelector := labels.NewSelector().Add(
-		util.MustNewLabelsRequirement("name", selection.Equals, []string{sts.Spec.Template.Labels["name"]}),
-	)
-
-	list, err := a.kubeClient.CoreV1().Pods(sts.Namespace).List(a.ctx, metav1.ListOptions{
-		LabelSelector: podsSelector.String(),
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
+func podsNotRunningAndReady(sts *appsv1.StatefulSet, pod *corev1.Pod, relatedPods *corev1.PodList, zpdb validator) *zoneStatusResult {
 	result := &zoneStatusResult{tested: 0, notReady: 0, unknown: 0}
 
 	// replicas is the number of Pods created by the StatefulSet controller.
@@ -90,7 +84,12 @@ func (a *k8sClient) podsNotRunningAndReady(sts *appsv1.StatefulSet, pod *corev1.
 
 	matcher := zpdb.considerPod()
 
-	for _, pd := range list.Items {
+	zonePodCount := 0
+	for _, pd := range relatedPods.Items {
+		if pd.Labels["name"] != sts.Spec.Template.Labels["name"] {
+			continue
+		}
+		zonePodCount++
 
 		// we do not consider pods which are in a different partition
 		if !matcher(&pd) {
@@ -108,9 +107,9 @@ func (a *k8sClient) podsNotRunningAndReady(sts *appsv1.StatefulSet, pod *corev1.
 
 	// we consider the pod as not ready if there should be a given replica count but it is not yet being found in the pods query
 	// note that the effect here is that we do not know which partition these other pods will be in, so we have to attribute them to this partition to be safe
-	if len(list.Items) < replicas {
-		result.unknown = replicas - len(list.Items)
+	if zonePodCount < replicas {
+		result.unknown = replicas - zonePodCount
 	}
 
-	return result, nil
+	return result
 }


### PR DESCRIPTION
## Summary

Reduce Kubernetes API calls for each in-scope ZPDB eviction by fetching related StatefulSets and pods once per request.

- Resolve the owner from the related StatefulSet snapshot instead of issuing a separate GET
- Evaluate every zone locally from one live Pod snapshot while preserving fail-closed enforcement

### API-call benchmark

For one healthy eviction check in a production-shaped group with 3 zones and 100 ready pods per zone:

| Kubernetes request | Before | After |
| --- | ---: | ---: |
| Pod GET | 1 | 1 |
| Pod LIST | 3 | 1 |
| StatefulSet GET | 1 | 0 |
| StatefulSet LIST | 1 | 1 |
| **Total** | **6** | **3** |

This cuts API requests per enforcement check by 50%. Replica count changes response size, not request count; across `Z` zones the total drops from `Z + 3` to 3.
