### PR TITLE
Reduce unnecessary ZPDB readiness annotation patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main / unreleased
 
+* [ENHANCEMENT] Maintain pod readiness annotations only while a ZPDB cross-zone eviction delay is enabled.
 * [ENHANCEMENT] Update Go to `1.27` #494
 * [ENHANCEMENT] Updated dependencies, including: #491
   * `github.com/stretchr/testify` from `v1.12.0` to `v1.12.1`

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -12,12 +12,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/grafana/rollout-operator/pkg/util"
 )
+
+const podReadyAnnotationKey = "grafana.com/ready-time"
 
 func TestRolloutHappyCase(t *testing.T) {
 	ctx := context.Background()
@@ -479,6 +482,14 @@ func TestZoneAwarePodDisruptionBudgetPartitionMode(t *testing.T) {
 		requireEventuallyPod(t, api, ctx, "mock-zone-b-0", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
 		requireEventuallyPod(t, api, ctx, "mock-zone-a-1", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
 		requireEventuallyPod(t, api, ctx, "mock-zone-b-1", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
+		require.Never(t, func() bool {
+			pod, err := api.CoreV1().Pods(corev1.NamespaceDefault).Get(ctx, "mock-zone-a-0", metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			_, ok := pod.Annotations[podReadyAnnotationKey]
+			return ok
+		}, 5*time.Second, 100*time.Millisecond, "Pods should not be annotated when crossZoneEvictionDelay is disabled")
 	}
 
 	{
@@ -559,12 +570,27 @@ func TestZoneAwarePodDisruptionBudgetPartitionModeWithCrossZoneEvictionDelay(t *
 
 	{
 		t.Log("Create 2 zones each with 2 pods. There are 2 partitions across 2 zones.")
+		podNames := []string{"mock-zone-a-0", "mock-zone-a-1", "mock-zone-b-0", "mock-zone-b-1"}
 		createMockServiceZone(t, ctx, api, corev1.NamespaceDefault, "mock-zone-a", 2)
 		createMockServiceZone(t, ctx, api, corev1.NamespaceDefault, "mock-zone-b", 2)
 		requireEventuallyPod(t, api, ctx, "mock-zone-a-0", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
 		requireEventuallyPod(t, api, ctx, "mock-zone-b-0", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
 		requireEventuallyPod(t, api, ctx, "mock-zone-a-1", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
 		requireEventuallyPod(t, api, ctx, "mock-zone-b-1", expectPodPhase(corev1.PodRunning), expectReady(), expectVersion("1"))
+		for _, podName := range podNames {
+			requireEventuallyPod(t, api, ctx, podName, expectAnnotation(podReadyAnnotationKey))
+		}
+
+		updateCrossZoneEvictionDelay(t, ctx, cluster, "0s")
+		for _, podName := range podNames {
+			awaitReadyAnnotation(t, ctx, api, podName, false, time.Time{})
+		}
+
+		reenabledAt := time.Now().UTC().Truncate(time.Second)
+		updateCrossZoneEvictionDelay(t, ctx, cluster, "15s")
+		for _, podName := range podNames {
+			awaitReadyAnnotation(t, ctx, api, podName, true, reenabledAt)
+		}
 	}
 
 	{
@@ -812,4 +838,39 @@ func awaitZoneAwarePodDisruptionBudgetCreation(t *testing.T, ctx context.Context
 	// note - this retry should not be needed, as the rollout-operator pod should be ready and running
 	// however in the CI environments there have been intermittent errors which this retry is attempting to workaround
 	require.Eventually(t, task, time.Second*30, time.Millisecond*10, "Zpdb configuration create failed")
+}
+
+func updateCrossZoneEvictionDelay(t *testing.T, ctx context.Context, cluster *kindCluster, delay string) {
+	resource := cluster.DynK().Resource(zoneAwarePodDisruptionBudgetSchema()).Namespace(corev1.NamespaceDefault)
+	config, err := resource.Get(ctx, "mock-rollout", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NoError(t, unstructured.SetNestedField(config.Object, delay, "spec", "crossZoneEvictionDelay"))
+	_, err = resource.Update(ctx, config, metav1.UpdateOptions{})
+	require.NoError(t, err)
+}
+
+func awaitReadyAnnotation(t *testing.T, ctx context.Context, api *kubernetes.Clientset, podName string, expected bool, notBefore time.Time) {
+	require.Eventually(t, func() bool {
+		patch, err := json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{"integration-test-touch": time.Now().UTC().Format(time.RFC3339Nano)},
+			},
+		})
+		if err != nil {
+			return false
+		}
+		if _, err := api.CoreV1().Pods(corev1.NamespaceDefault).Patch(ctx, podName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+			return false
+		}
+		pod, err := api.CoreV1().Pods(corev1.NamespaceDefault).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		value, exists := pod.Annotations[podReadyAnnotationKey]
+		if !expected {
+			return !exists
+		}
+		readyTime, err := time.Parse(time.RFC3339, value)
+		return exists && err == nil && !readyTime.Before(notBefore)
+	}, 30*time.Second, 200*time.Millisecond)
 }

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -131,6 +131,13 @@ func expectVersion(expectedVersion string) func(t *testing.T, pod *corev1.Pod) b
 	}
 }
 
+func expectAnnotation(key string) func(t *testing.T, pod *corev1.Pod) bool {
+	return func(t *testing.T, pod *corev1.Pod) bool {
+		_, ok := pod.Annotations[key]
+		return ok
+	}
+}
+
 func expectContainerWaitingReason(expectedReason string) func(t *testing.T, pod *corev1.Pod) bool {
 	return func(t *testing.T, pod *corev1.Pod) bool {
 		for _, s := range pod.Status.ContainerStatuses {

--- a/pkg/zpdb/pod_observer.go
+++ b/pkg/zpdb/pod_observer.go
@@ -111,48 +111,63 @@ func (c *podObserver) invalidatePodEvictionCache(pod *corev1.Pod, action string)
 	c.podEvictCache.delete(pod)
 }
 
-// accept will return a pod and true if the given object is a pod and the is within the scope of our pdb
-func (c *podObserver) accept(obj interface{}) (*corev1.Pod, bool) {
+// accept returns valid pods even when no ZPDB matches so stale operator-owned annotations can be removed.
+func (c *podObserver) accept(obj interface{}) (*corev1.Pod, *config, bool) {
 	pod, isPod := obj.(*corev1.Pod)
 	if !isPod {
 		level.Warn(c.logger).Log("msg", "unexpected object passed through informer", "type", reflect.TypeOf(obj))
-		return nil, false
+		return nil, nil, false
 	}
 	pdbConfig, err := c.configObserver.pdbCache.find(pod)
 	if err != nil {
 		level.Warn(c.logger).Log("msg", "observer ignoring pod - unable to look up configuration for pod", "pod", pod.Name, "err", err)
-		return nil, false
+		return nil, nil, false
 	}
 	if pdbConfig == nil {
-		level.Debug(c.logger).Log("msg", "observer ignoring pod - not within zpdb scope", "pod", pod.Name)
-		return nil, false
+		return pod, nil, true
 	}
 
-	return pod, true
+	return pod, pdbConfig, true
 }
 
 func (c *podObserver) onPodAdded(obj interface{}) {
-	pod, ok := c.accept(obj)
+	pod, pdbConfig, ok := c.accept(obj)
 	if !ok {
 		return
 	}
+	if pdbConfig == nil {
+		c.podReadinessTracker.remove(pod)
+		return
+	}
 
-	c.podReadinessTracker.observed(pod)
+	if pdbConfig.crossZoneEvictionDelay > 0 {
+		c.podReadinessTracker.observed(pod)
+	} else {
+		c.podReadinessTracker.remove(pod)
+	}
 	c.invalidatePodEvictionCache(pod, "added")
 }
 
 func (c *podObserver) onPodUpdated(_, new interface{}) {
-	pod, ok := c.accept(new)
+	pod, pdbConfig, ok := c.accept(new)
 	if !ok {
 		return
 	}
+	if pdbConfig == nil {
+		c.podReadinessTracker.remove(pod)
+		return
+	}
 
-	c.podReadinessTracker.observed(pod)
+	if pdbConfig.crossZoneEvictionDelay > 0 {
+		c.podReadinessTracker.observed(pod)
+	} else {
+		c.podReadinessTracker.remove(pod)
+	}
 	c.invalidatePodEvictionCache(pod, "updated")
 }
 
 func (c *podObserver) onPodDeleted(obj interface{}) {
-	pod, ok := c.accept(obj)
+	pod, _, ok := c.accept(obj)
 	if !ok {
 		return
 	}

--- a/pkg/zpdb/pod_observer_test.go
+++ b/pkg/zpdb/pod_observer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
@@ -18,18 +19,105 @@ import (
 )
 
 func newPodObserverTestCase(t *testing.T) (*k8sfake.Clientset, *podObserver) {
+	return newPodObserverTestCaseWithConfig(t, newPDB("test-zpdb"))
+}
+
+func newPodObserverTestCaseWithConfig(t *testing.T, rawConfig *unstructured.Unstructured) (*k8sfake.Clientset, *podObserver) {
 	client := k8sfake.NewClientset()
 
 	dynamicClient := newFakeDynamicClient()
 	cfgObserver := newConfigObserver(dynamicClient, testNamespace, log.NewNopLogger(), NewMetrics(prometheus.NewRegistry()))
 
 	// Seed the config cache with a config that matches the rollout-group used by createTestPod.
-	updated, _, err := cfgObserver.pdbCache.addOrUpdateRaw(newPDB("test-zpdb"))
+	updated, _, err := cfgObserver.pdbCache.addOrUpdateRaw(rawConfig)
 	require.NoError(t, err)
 	require.True(t, updated)
 
 	observer := newPodObserver(client, testNamespace, newTestPodsFactory(client), 5*time.Second, cfgObserver, log.NewNopLogger())
 	return client, observer
+}
+
+func TestObserver_TracksReadinessOnlyForCrossZoneEvictionDelay(t *testing.T) {
+	testCases := map[string]struct {
+		config      *unstructured.Unstructured
+		expectPatch bool
+	}{
+		"delay disabled": {
+			config: newPDB("test-zpdb"),
+		},
+		"delay enabled": {
+			config:      rawConfigWithCrossZoneEvictionDelay("test-zpdb", "test-group", 1, 1, `test-(.*)`, "1m"),
+			expectPatch: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			client, observer := newPodObserverTestCaseWithConfig(t, testCase.config)
+			pod := createTestPod("test-pod", testNamespace)
+			pod.Status = readyRunningPod(pod.Name).Status
+			_, err := client.CoreV1().Pods(testNamespace).Create(context.Background(), pod, metav1.CreateOptions{})
+			require.NoError(t, err)
+			client.ClearActions()
+
+			observer.onPodAdded(pod)
+
+			patches := 0
+			for _, action := range client.Actions() {
+				if action.Matches("patch", "pods") {
+					patches++
+				}
+			}
+			if testCase.expectPatch {
+				require.Equal(t, 1, patches)
+			} else {
+				require.Zero(t, patches)
+			}
+		})
+	}
+}
+
+func TestObserver_ResetsReadinessTimestampBeforeDelayIsReenabled(t *testing.T) {
+	client, observer := newPodObserverTestCase(t)
+	pod := createTestPod("test-pod", testNamespace)
+	pod.Status = readyRunningPod(pod.Name).Status
+	pod.Annotations = map[string]string{podReadyAnnotationKey: "2026-01-01T00:00:00Z"}
+	_, err := client.CoreV1().Pods(testNamespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	observer.onPodAdded(pod)
+	pod, err = client.CoreV1().Pods(testNamespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotContains(t, pod.Annotations, podReadyAnnotationKey)
+
+	updated, _, err := observer.configObserver.pdbCache.addOrUpdateRaw(
+		rawConfigWithCrossZoneEvictionDelay("test-zpdb", "test-group", 2, 1, `test-(.*)`, "1m"),
+	)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	before := time.Now().UTC()
+	observer.onPodUpdated(pod, pod)
+	pod, err = client.CoreV1().Pods(testNamespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	readyTime, err := time.Parse(time.RFC3339, pod.Annotations[podReadyAnnotationKey])
+	require.NoError(t, err)
+	require.False(t, readyTime.Before(before.Truncate(time.Second)))
+}
+
+func TestObserver_RemovesReadinessTimestampOutsideZpdbScope(t *testing.T) {
+	client, observer := newPodObserverTestCase(t)
+	pod := createTestPod("test-pod", testNamespace)
+	pod.Labels[rolloutconfig.RolloutGroupLabelKey] = "other-group"
+	pod.Annotations = map[string]string{podReadyAnnotationKey: "2026-01-01T00:00:00Z"}
+	_, err := client.CoreV1().Pods(testNamespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	observer.onPodAdded(pod)
+
+	pod, err = client.CoreV1().Pods(testNamespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotContains(t, pod.Annotations, podReadyAnnotationKey)
 }
 
 // TestObserver_SharesThePodInformerFromTheFactory asserts that the observer attaches to the pod informer

--- a/pkg/zpdb/pod_readiness_tracker.go
+++ b/pkg/zpdb/pod_readiness_tracker.go
@@ -69,9 +69,6 @@ func newPodReadinessTracker(kubeClient kubernetes.Interface, namespace string, p
 // observed() touches no in-memory tracker state and is safe to call concurrently; the
 // SharedInformer's single processor goroutine already serialises informer-driven calls.
 func (c *podReadinessTracker) observed(pod *corev1.Pod) {
-	ctx, cancel := context.WithTimeout(context.Background(), c.patchTimeout)
-	defer cancel()
-
 	// A nil value here means "remove the annotation" (strategic merge interprets null on a map
 	// value as a delete). A non-nil value means "set the annotation to *value".
 	var value *string
@@ -92,6 +89,21 @@ func (c *podReadinessTracker) observed(pod *corev1.Pod) {
 			return
 		}
 	}
+
+	c.patch(pod, value)
+}
+
+// remove clears a readiness timestamp that could otherwise be reused if delay tracking is enabled again.
+func (c *podReadinessTracker) remove(pod *corev1.Pod) {
+	if _, ok := pod.Annotations[podReadyAnnotationKey]; !ok {
+		return
+	}
+	c.patch(pod, nil)
+}
+
+func (c *podReadinessTracker) patch(pod *corev1.Pod, value *string) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.patchTimeout)
+	defer cancel()
 
 	patch, err := json.Marshal(podAnnotationsPatch{
 		Metadata: podAnnotationsPatchMetadata{


### PR DESCRIPTION
## Summary

Limit grafana.com/ready-time maintenance to ZPDBs that enable a cross-zone eviction delay, avoiding unnecessary Pod PATCH traffic.

- Remove stale timestamps when delay tracking is disabled or a pod leaves ZPDB scope
- Reset readiness timestamps safely when delay tracking is enabled again
