### PR TITLE
Cut v0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+## v0.40.0
+
 * [CHANGE] ZPDB cross-zone eviction delays use the Pod Ready condition's `lastTransitionTime` instead of the `grafana.com/ready-time` annotation, eliminating annotation PATCH requests and measuring the delay from Kubernetes readiness transitions. The `-zpdb.pod-ready-annotation-patch-timeout` flag is deprecated, has no effect, and logs a warning when supplied. #498
 * [ENHANCEMENT] Update Go to `1.27` #494
 * [ENHANCEMENT] Updated dependencies, including: #491
@@ -10,6 +12,8 @@
   * `k8s.io/apiextensions-apiserver` from `v0.36.3` to `v0.36.4`
   * `k8s.io/apimachinery` from `v0.36.3` to `v0.36.4`
   * `k8s.io/client-go` from `v0.36.3` to `v0.36.4`
+* [ENHANCEMENT] Updated dependencies to address CVEs, including: #501 #502
+  * `google.golang.org/grpc` from `v1.83.0` to `v1.83.2` for CVE-2026-84304, CVE-2026-84303 and CVE-2026-84445
 
 
 ## v0.39.0

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-default-generated.yaml
@@ -297,7 +297,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.39.0
+        image: grafana/rollout-operator:v0.40.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-no-webhooks-generated.yaml
@@ -91,7 +91,7 @@ spec:
         - -kubernetes.namespace=default
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.39.0
+        image: grafana/rollout-operator:v0.40.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-enabled-with-webhooks-ignore-policy-generated.yaml
@@ -297,7 +297,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.39.0
+        image: grafana/rollout-operator:v0.40.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-enabled-generated.yaml
@@ -229,7 +229,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.39.0
+        image: grafana/rollout-operator:v0.40.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-replica-template-zdb-enabled-generated.yaml
@@ -305,7 +305,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.39.0
+        image: grafana/rollout-operator:v0.40.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-cross-zone-eviction-delay-generated.yaml
@@ -221,7 +221,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.39.0
+        image: grafana/rollout-operator:v0.40.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-as-string-generated.yaml
@@ -221,7 +221,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.39.0
+        image: grafana/rollout-operator:v0.40.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-0-generated.yaml
@@ -221,7 +221,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.39.0
+        image: grafana/rollout-operator:v0.40.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-generated.yaml
@@ -221,7 +221,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.39.0
+        image: grafana/rollout-operator:v0.40.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-1-partition-regex-group-generated.yaml
@@ -221,7 +221,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.39.0
+        image: grafana/rollout-operator:v0.40.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
+++ b/operations/rollout-operator-tests/test-rollout-operator-zpdb-ingester-max-unavailable-50%-generated.yaml
@@ -221,7 +221,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.39.0
+        image: grafana/rollout-operator:v0.40.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/rollout-operator/images.libsonnet
+++ b/operations/rollout-operator/images.libsonnet
@@ -1,5 +1,5 @@
 {
   _images+:: {
-    rollout_operator: 'grafana/rollout-operator:v0.39.0',
+    rollout_operator: 'grafana/rollout-operator:v0.40.0',
   },
 }


### PR DESCRIPTION
Cuts v0.40.0, following [RELEASE.md](https://github.com/grafana/rollout-operator/blob/main/RELEASE.md) step 1 (same shape as #490):

- `CHANGELOG.md`: add the `## v0.40.0` heading
- `operations/rollout-operator/images.libsonnet`: `v0.39.0` → `v0.40.0`
- `make build-jsonnet-tests` to regenerate the jsonnet test fixtures (image tag only)

## Why now

`main` carries `google.golang.org/grpc` v1.83.0 → **v1.83.2** (#501, #502), which clears three CVEs currently outstanding on both the `rollout-operator` and `rollout-operator-boringcrypto` v0.39.0 images:

| CVE | Severity | SLO remaining |
|---|---|---|
| CVE-2026-84304 | HIGH | **22 days** |
| CVE-2026-84303 | MEDIUM | 59 days |
| CVE-2026-84445 | unscored | — |

The fix is on `main` but unreleased, so deployed cells are still exposed.

## Not just a security patch

Worth flagging for reviewers — v0.40.0 also ships:

- **Go 1.26 → 1.27** (#494), a toolchain change for every consumer of the image
- **ZPDB cross-zone eviction delays now use the Pod Ready condition's `lastTransitionTime`** instead of the `grafana.com/ready-time` annotation (#498). `-zpdb.pod-ready-annotation-patch-timeout` is deprecated, has no effect, and warns when supplied.
- Self-signed TLS certificate test coverage (#462)

## Verification

- `make rollout-operator` — passes
- `go test ./...` — passes (10 packages)
- `make build-jsonnet-tests` — regenerated fixtures differ only by the image tag

The 7 `libc6` MEDIUMs on `rollout-operator-boringcrypto` (37–47 days) are **not** addressed here; no upstream fix exists yet.