### PR TITLE
Define RolloutHealthCheck API and validation

### DIFF
--- a/operations/rollout-operator/crds/rollout-health-check.yaml
+++ b/operations/rollout-operator/crds/rollout-health-check.yaml
@@ -1,0 +1,134 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouthealthchecks.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - selector
+                - prometheusURL
+                - checks
+              properties:
+                selector:
+                  type: object
+                  description: Selector preventing this policy from being attached to an unrelated workload.
+                  required:
+                    - matchLabels
+                  properties:
+                    matchLabels:
+                      type: object
+                      additionalProperties:
+                        type: string
+                prometheusURL:
+                  type: string
+                  description: Base URL of the Prometheus HTTP API used to evaluate checks.
+                  minLength: 1
+                checks:
+                  type: array
+                  description: Ordered list of PromQL health checks evaluated before progressing to the next zone.
+                  minItems: 1
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - query
+                      - successQuery
+                    properties:
+                      name:
+                        type: string
+                        description: Unique name of this check within the RolloutHealthCheck.
+                        minLength: 1
+                      currentRange:
+                        type: string
+                        description: Range vector duration substituted for ${range} when evaluating candidate pods. Defaults to 5m.
+                      baselineRange:
+                        type: string
+                        description: Range vector duration substituted for ${range} when evaluating stable pods at the pre-rollout timestamp. Defaults to 10m.
+                      errorPolicy:
+                        type: object
+                        description: Retry and action policy when a Prometheus query fails or is unreachable. Defaults to retryInterval=10s, maxAttempts=3, exhaustedAction=Pause.
+                        properties:
+                          retryInterval:
+                            type: string
+                            description: Delay between query attempts after an error. Defaults to 10s.
+                          maxAttempts:
+                            type: integer
+                            description: Maximum query attempts including the first. Defaults to 3.
+                            minimum: 1
+                          exhaustedAction:
+                            type: string
+                            description: Behavior when all attempts fail. Defaults to Pause.
+                            enum:
+                              - Pause
+                              - Warn
+                              - Disabled
+                      failurePolicy:
+                        type: object
+                        description: How failed successQuery results accumulate before gating. Defaults to reevaluationInterval=2m30s, consecutiveFailures=3, consecutiveSuccesses=1, exceededAction=Pause.
+                        properties:
+                          reevaluationInterval:
+                            type: string
+                            description: Minimum time between evaluations that update consecutive counters. Defaults to 2m30s.
+                          consecutiveFailures:
+                            type: integer
+                            description: Number of consecutive failed evaluations required before exceededAction. Defaults to 3.
+                            minimum: 1
+                          consecutiveSuccesses:
+                            type: integer
+                            description: Number of consecutive successful evaluations required to pass. Defaults to 1.
+                            minimum: 1
+                          exceededAction:
+                            type: string
+                            description: Behavior when consecutiveFailures is reached. Defaults to Pause.
+                            enum:
+                              - Pause
+                              - Warn
+                              - Disabled
+                      noDataPolicy:
+                        type: object
+                        description: Retry and action policy when a query returns no data. Defaults to retryInterval=30s, maxAttempts=3, exhaustedAction=Pause.
+                        properties:
+                          retryInterval:
+                            type: string
+                            description: Delay between query attempts after no-data. Defaults to 30s.
+                          maxAttempts:
+                            type: integer
+                            description: Maximum query attempts including the first. Defaults to 3.
+                            minimum: 1
+                          exhaustedAction:
+                            type: string
+                            description: Behavior when all attempts return no data. Defaults to Pause.
+                            enum:
+                              - Pause
+                              - Warn
+                              - Disabled
+                      disabled:
+                        type: boolean
+                        description: When true, this check is skipped while other checks remain active.
+                      query:
+                        type: string
+                        description: |
+                          PromQL that must return exactly one scalar. Required placeholders: ${targetMatchers} (namespace, zone/name, and pod matchers) and ${range}.
+                        minLength: 1
+                      successQuery:
+                        type: string
+                        description: |
+                          PromQL evaluated after substituting ${current} and ${baseline} scalars. Must return scalar 1 (pass) or 0 (fail).
+                        minLength: 1
+  scope: Namespaced
+  names:
+    kind: RolloutHealthCheck
+    plural: rollouthealthchecks
+    singular: rollouthealthcheck
+    shortNames:
+      - rhc

--- a/pkg/admission/rollout_health_check_validating_webhook.go
+++ b/pkg/admission/rollout_health_check_validating_webhook.go
@@ -1,0 +1,92 @@
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/spanlogger"
+	v1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/rollout-operator/pkg/healthcheck"
+)
+
+const (
+	RolloutHealthCheckValidatorWebhookPath = "/admission/rollout-health-check-validation"
+)
+
+type rolloutHealthCheckValidatingWebhook struct {
+	ctx     context.Context
+	logger  *spanlogger.SpanLogger
+	request v1.AdmissionReview
+}
+
+func (v *rolloutHealthCheckValidatingWebhook) initLogger() {
+	v.logger.SetSpanAndLogTag("object.name", v.request.Request.Name)
+	v.logger.SetSpanAndLogTag("object.resource", v.request.Request.Resource.Resource)
+	v.logger.SetSpanAndLogTag("object.namespace", v.request.Request.Namespace)
+	v.logger.SetSpanAndLogTag("request.uid", v.request.Request.UID)
+
+	if v.request.Request.DryRun != nil {
+		v.logger.SetSpanAndLogTag("request.dry_run", v.request.Request.DryRun)
+	}
+}
+
+func (v *rolloutHealthCheckValidatingWebhook) parse() (int32, error) {
+	var obj unstructured.Unstructured
+	if err := json.Unmarshal(v.request.Request.Object.Raw, &obj); err != nil {
+		level.Info(v.logger).Log("msg", errors.New("failed to unmarshal object"), "err", err)
+		return int32(http.StatusBadRequest), err
+	}
+
+	_, err := healthcheck.ParseAndValidate(&obj)
+	if err != nil {
+		level.Info(v.logger).Log("msg", errors.New("parsing failed"), "err", err)
+		return int32(http.StatusBadRequest), err
+	}
+
+	return 0, nil
+}
+
+func (v *rolloutHealthCheckValidatingWebhook) allow() *v1.AdmissionResponse {
+	return &v1.AdmissionResponse{
+		Allowed: true,
+		UID:     v.request.Request.UID,
+	}
+}
+
+func (v *rolloutHealthCheckValidatingWebhook) deny(reason string, httpStatusCode int32) *v1.AdmissionResponse {
+	return &v1.AdmissionResponse{
+		Allowed: false,
+		UID:     v.request.Request.UID,
+		Result: &metav1.Status{
+			Message: reason,
+			Code:    httpStatusCode,
+		},
+	}
+}
+
+// RolloutHealthCheckValidatingWebhookHandler validates RolloutHealthCheck custom resources.
+func RolloutHealthCheckValidatingWebhookHandler(ctx context.Context, l log.Logger, ar v1.AdmissionReview) *v1.AdmissionResponse {
+	logger, ctx := spanlogger.New(ctx, l, "admission.RolloutHealthCheckValidatingWebhookHandler()", tenantResolver)
+	defer logger.Finish()
+
+	validator := &rolloutHealthCheckValidatingWebhook{
+		ctx:     ctx,
+		logger:  logger,
+		request: ar,
+	}
+
+	validator.initLogger()
+
+	if httpStatusCode, err := validator.parse(); err != nil {
+		return validator.deny(err.Error(), httpStatusCode)
+	}
+
+	return validator.allow()
+}

--- a/pkg/admission/rollout_health_check_validating_webhook_test.go
+++ b/pkg/admission/rollout_health_check_validating_webhook_test.go
@@ -1,0 +1,105 @@
+package admission
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestRolloutHealthCheckValidatorHandlerSuccess(t *testing.T) {
+	request := createRolloutHealthCheckAdmissionReviewValid()
+	response := RolloutHealthCheckValidatingWebhookHandler(context.Background(), log.NewNopLogger(), request)
+	require.NotNil(t, response.UID)
+	require.True(t, response.Allowed)
+}
+
+func TestRolloutHealthCheckValidatorHandlerBadConfig(t *testing.T) {
+	request := createRolloutHealthCheckAdmissionReviewInvalid()
+	response := RolloutHealthCheckValidatingWebhookHandler(context.Background(), log.NewNopLogger(), request)
+	require.NotNil(t, response.UID)
+	require.False(t, response.Allowed)
+	require.Contains(t, response.Result.Message, "prometheusURL")
+	require.Equal(t, int32(http.StatusBadRequest), response.Result.Code)
+}
+
+func TestRolloutHealthCheckValidatorHandlerParseError(t *testing.T) {
+	request := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID:    "test-request-uid",
+			Object: runtime.RawExtension{Raw: []byte(``)},
+		},
+	}
+	response := RolloutHealthCheckValidatingWebhookHandler(context.Background(), log.NewNopLogger(), request)
+	require.False(t, response.Allowed)
+	require.Equal(t, int32(http.StatusBadRequest), response.Result.Code)
+}
+
+func createRolloutHealthCheckAdmissionReviewValid() admissionv1.AdmissionReview {
+	return admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID: "test-request-uid",
+			Object: runtime.RawExtension{
+				Raw: []byte(`{
+					"apiVersion": "rollout-operator.grafana.com/v1",
+					"kind": "RolloutHealthCheck",
+					"metadata": {
+						"name": "ingester-cell-health",
+						"namespace": "test"
+					},
+					"spec": {
+						"selector": {
+							"matchLabels": {
+								"rollout-group": "ingester"
+							}
+						},
+						"prometheusURL": "http://prometheus:9090",
+						"checks": [
+							{
+								"name": "errors",
+								"query": "scalar(sum(rate(errors{${targetMatchers}}[${range}])))",
+								"successQuery": "(${current} < bool (${baseline}))"
+							}
+						]
+					}
+				}`),
+			},
+		},
+	}
+}
+
+func createRolloutHealthCheckAdmissionReviewInvalid() admissionv1.AdmissionReview {
+	return admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID: "test-request-uid",
+			Object: runtime.RawExtension{
+				Raw: []byte(`{
+					"apiVersion": "rollout-operator.grafana.com/v1",
+					"kind": "RolloutHealthCheck",
+					"metadata": {
+						"name": "ingester-cell-health",
+						"namespace": "test"
+					},
+					"spec": {
+						"selector": {
+							"matchLabels": {
+								"rollout-group": "ingester"
+							}
+						},
+						"checks": [
+							{
+								"name": "errors",
+								"query": "scalar(sum(rate(errors{${targetMatchers}}[${range}])))",
+								"successQuery": "(${current} < bool (${baseline}))"
+							}
+						]
+					}
+				}`),
+			},
+		},
+	}
+}

--- a/pkg/healthcheck/config.go
+++ b/pkg/healthcheck/config.go
@@ -1,0 +1,364 @@
+package healthcheck
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	RolloutHealthCheckKind       = "RolloutHealthCheck"
+	RolloutHealthChecksPlural    = "rollouthealthchecks"
+	RolloutHealthChecksSpecGroup = "rollout-operator.grafana.com"
+	RolloutHealthChecksVersion   = "v1"
+
+	placeholderTargetMatchers = "${targetMatchers}"
+	placeholderRange          = "${range}"
+	placeholderCurrent        = "${current}"
+	placeholderBaseline       = "${baseline}"
+
+	defaultCurrentRange         = 5 * time.Minute
+	defaultBaselineRange        = 10 * time.Minute
+	defaultQueryTimeout         = 10 * time.Second
+	defaultErrorRetryInterval   = 10 * time.Second
+	defaultErrorMaxAttempts     = 3
+	defaultNoDataRetryInterval  = 30 * time.Second
+	defaultNoDataMaxAttempts    = 3
+	defaultReevaluationInterval = 2*time.Minute + 30*time.Second
+	defaultConsecutiveFailures  = 3
+	defaultConsecutiveSuccesses = 1
+)
+
+// FailureAction controls how a failed, no-data, or exhausted check affects the rollout.
+type FailureAction string
+
+const (
+	ActionPause    FailureAction = "Pause"
+	ActionWarn     FailureAction = "Warn"
+	ActionDisabled FailureAction = "Disabled"
+)
+
+// RetryPolicy controls retries for query errors or no-data responses.
+type RetryPolicy struct {
+	RetryInterval   time.Duration
+	MaxAttempts     int
+	ExhaustedAction FailureAction
+}
+
+// FailurePolicy controls how consecutive success/failure evaluations accumulate.
+type FailurePolicy struct {
+	ReevaluationInterval time.Duration
+	ConsecutiveFailures  int
+	ConsecutiveSuccesses int
+	ExceededAction       FailureAction
+}
+
+// Check is a single PromQL health check within a RolloutHealthCheck.
+type Check struct {
+	Name          string
+	CurrentRange  time.Duration
+	BaselineRange time.Duration
+	QueryTimeout  time.Duration
+	ErrorPolicy   RetryPolicy
+	FailurePolicy FailurePolicy
+	NoDataPolicy  RetryPolicy
+	Disabled      bool
+	Query         string
+	SuccessQuery  string
+}
+
+// Config is the parsed RolloutHealthCheck custom resource.
+type Config struct {
+	Name          string
+	Generation    int64
+	Selector      labels.Selector
+	PrometheusURL string
+	Checks        []Check
+}
+
+// MatchesLabels returns true if this Config's selector matches the given labels.
+func (c *Config) MatchesLabels(set labels.Set) bool {
+	if c.Selector == nil {
+		return false
+	}
+	return c.Selector.Matches(set)
+}
+
+// ParseAndValidate parses an unstructured RolloutHealthCheck into a Config.
+func ParseAndValidate(obj *unstructured.Unstructured) (*Config, error) {
+	if obj.GetKind() != RolloutHealthCheckKind {
+		return nil, fmt.Errorf("unexpected object kind - expecting %s", RolloutHealthCheckKind)
+	}
+
+	cfg := &Config{
+		Name:       obj.GetName(),
+		Generation: obj.GetGeneration(),
+	}
+
+	prometheusURL, found, err := unstructured.NestedString(obj.Object, "spec", "prometheusURL")
+	if err != nil {
+		return nil, fmt.Errorf("invalid prometheusURL: %w", err)
+	}
+	if !found || strings.TrimSpace(prometheusURL) == "" {
+		return nil, errors.New("invalid value: prometheusURL is required")
+	}
+	cfg.PrometheusURL = strings.TrimSpace(prometheusURL)
+	parsedURL, err := url.Parse(cfg.PrometheusURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid value: prometheusURL is not a valid URL: %w", err)
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return nil, errors.New("invalid value: prometheusURL scheme must be http or https")
+	}
+	if parsedURL.Host == "" {
+		return nil, errors.New("invalid value: prometheusURL must include a host")
+	}
+
+	if mlMap, found, err := unstructured.NestedStringMap(obj.Object, "spec", "selector", "matchLabels"); err != nil {
+		return nil, fmt.Errorf("invalid value: selector is not valid, got %v", err)
+	} else if !found || len(mlMap) == 0 {
+		return nil, errors.New("invalid value: selector.matchLabels is required")
+	} else {
+		cfg.Selector = labels.SelectorFromSet(mlMap)
+	}
+
+	rawChecks, found, err := unstructured.NestedSlice(obj.Object, "spec", "checks")
+	if err != nil {
+		return nil, fmt.Errorf("invalid checks: %w", err)
+	}
+	if !found || len(rawChecks) == 0 {
+		return nil, errors.New("invalid value: checks must contain at least one entry")
+	}
+
+	seenNames := map[string]struct{}{}
+	for i, raw := range rawChecks {
+		checkMap, ok := raw.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid value: checks[%d] must be an object", i)
+		}
+		check, err := parseCheck(checkMap, i)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := seenNames[check.Name]; exists {
+			return nil, fmt.Errorf("invalid value: duplicate check name %q", check.Name)
+		}
+		seenNames[check.Name] = struct{}{}
+		cfg.Checks = append(cfg.Checks, check)
+	}
+
+	return cfg, nil
+}
+
+func parseCheck(m map[string]interface{}, index int) (Check, error) {
+	check := Check{
+		CurrentRange:  defaultCurrentRange,
+		BaselineRange: defaultBaselineRange,
+		QueryTimeout:  defaultQueryTimeout,
+		ErrorPolicy: RetryPolicy{
+			RetryInterval:   defaultErrorRetryInterval,
+			MaxAttempts:     defaultErrorMaxAttempts,
+			ExhaustedAction: ActionPause,
+		},
+		FailurePolicy: FailurePolicy{
+			ReevaluationInterval: defaultReevaluationInterval,
+			ConsecutiveFailures:  defaultConsecutiveFailures,
+			ConsecutiveSuccesses: defaultConsecutiveSuccesses,
+			ExceededAction:       ActionPause,
+		},
+		NoDataPolicy: RetryPolicy{
+			RetryInterval:   defaultNoDataRetryInterval,
+			MaxAttempts:     defaultNoDataMaxAttempts,
+			ExhaustedAction: ActionPause,
+		},
+	}
+
+	name, ok := m["name"].(string)
+	if !ok || strings.TrimSpace(name) == "" {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].name is required", index)
+	}
+	check.Name = strings.TrimSpace(name)
+
+	query, ok := m["query"].(string)
+	if !ok || strings.TrimSpace(query) == "" {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].query is required", index)
+	}
+	check.Query = query
+	if !strings.Contains(check.Query, placeholderTargetMatchers) {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].query must contain %s", index, placeholderTargetMatchers)
+	}
+	if !strings.Contains(check.Query, placeholderRange) {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].query must contain %s", index, placeholderRange)
+	}
+
+	successQuery, ok := m["successQuery"].(string)
+	if !ok || strings.TrimSpace(successQuery) == "" {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].successQuery is required", index)
+	}
+	check.SuccessQuery = successQuery
+	if !strings.Contains(check.SuccessQuery, placeholderCurrent) {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].successQuery must contain %s", index, placeholderCurrent)
+	}
+	if !strings.Contains(check.SuccessQuery, placeholderBaseline) {
+		return Check{}, fmt.Errorf("invalid value: checks[%d].successQuery must contain %s", index, placeholderBaseline)
+	}
+
+	if v, found := m["currentRange"]; found {
+		d, err := parseDurationField(v, "currentRange", index)
+		if err != nil {
+			return Check{}, err
+		}
+		check.CurrentRange = d
+	}
+	if v, found := m["baselineRange"]; found {
+		d, err := parseDurationField(v, "baselineRange", index)
+		if err != nil {
+			return Check{}, err
+		}
+		check.BaselineRange = d
+	}
+	if v, found := m["disabled"]; found {
+		disabled, ok := v.(bool)
+		if !ok {
+			return Check{}, fmt.Errorf("invalid value: checks[%d].disabled must be a boolean", index)
+		}
+		check.Disabled = disabled
+	}
+	if v, found := m["errorPolicy"]; found {
+		policy, err := parseRetryPolicy(v, "errorPolicy", index, check.ErrorPolicy)
+		if err != nil {
+			return Check{}, err
+		}
+		check.ErrorPolicy = policy
+	}
+	if v, found := m["noDataPolicy"]; found {
+		policy, err := parseRetryPolicy(v, "noDataPolicy", index, check.NoDataPolicy)
+		if err != nil {
+			return Check{}, err
+		}
+		check.NoDataPolicy = policy
+	}
+	if v, found := m["failurePolicy"]; found {
+		policy, err := parseFailurePolicy(v, index, check.FailurePolicy)
+		if err != nil {
+			return Check{}, err
+		}
+		check.FailurePolicy = policy
+	}
+
+	return check, nil
+}
+
+func parseRetryPolicy(v interface{}, field string, index int, defaults RetryPolicy) (RetryPolicy, error) {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return RetryPolicy{}, fmt.Errorf("invalid value: checks[%d].%s must be an object", index, field)
+	}
+	policy := defaults
+	if raw, found := m["retryInterval"]; found {
+		d, err := parseDurationField(raw, field+".retryInterval", index)
+		if err != nil {
+			return RetryPolicy{}, err
+		}
+		policy.RetryInterval = d
+	}
+	if raw, found := m["maxAttempts"]; found {
+		n, ok := asInt(raw)
+		if !ok || n < 1 {
+			return RetryPolicy{}, fmt.Errorf("invalid value: checks[%d].%s.maxAttempts must be >= 1", index, field)
+		}
+		policy.MaxAttempts = n
+	}
+	if raw, found := m["exhaustedAction"]; found {
+		action, err := parseFailureAction(raw, field+".exhaustedAction", index)
+		if err != nil {
+			return RetryPolicy{}, err
+		}
+		policy.ExhaustedAction = action
+	}
+	return policy, nil
+}
+
+func parseFailurePolicy(v interface{}, index int, defaults FailurePolicy) (FailurePolicy, error) {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return FailurePolicy{}, fmt.Errorf("invalid value: checks[%d].failurePolicy must be an object", index)
+	}
+	policy := defaults
+	if raw, found := m["reevaluationInterval"]; found {
+		d, err := parseDurationField(raw, "failurePolicy.reevaluationInterval", index)
+		if err != nil {
+			return FailurePolicy{}, err
+		}
+		policy.ReevaluationInterval = d
+	}
+	if raw, found := m["consecutiveFailures"]; found {
+		n, ok := asInt(raw)
+		if !ok || n < 1 {
+			return FailurePolicy{}, fmt.Errorf("invalid value: checks[%d].failurePolicy.consecutiveFailures must be >= 1", index)
+		}
+		policy.ConsecutiveFailures = n
+	}
+	if raw, found := m["consecutiveSuccesses"]; found {
+		n, ok := asInt(raw)
+		if !ok || n < 1 {
+			return FailurePolicy{}, fmt.Errorf("invalid value: checks[%d].failurePolicy.consecutiveSuccesses must be >= 1", index)
+		}
+		policy.ConsecutiveSuccesses = n
+	}
+	if raw, found := m["exceededAction"]; found {
+		action, err := parseFailureAction(raw, "failurePolicy.exceededAction", index)
+		if err != nil {
+			return FailurePolicy{}, err
+		}
+		policy.ExceededAction = action
+	}
+	return policy, nil
+}
+
+func parseDurationField(v interface{}, field string, index int) (time.Duration, error) {
+	s, ok := v.(string)
+	if !ok || strings.TrimSpace(s) == "" {
+		return 0, fmt.Errorf("invalid value: checks[%d].%s must be a duration string", index, field)
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid value: checks[%d].%s is not a valid duration: %w", index, field, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("invalid value: checks[%d].%s must be > 0", index, field)
+	}
+	return d, nil
+}
+
+func parseFailureAction(v interface{}, field string, index int) (FailureAction, error) {
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("invalid value: checks[%d].%s must be a string", index, field)
+	}
+	switch FailureAction(s) {
+	case ActionPause, ActionWarn, ActionDisabled:
+		return FailureAction(s), nil
+	default:
+		return "", fmt.Errorf("invalid value: checks[%d].%s must be Pause, Warn, or Disabled", index, field)
+	}
+}
+
+func asInt(v interface{}) (int, bool) {
+	switch n := v.(type) {
+	case int64:
+		return int(n), true
+	case int:
+		return int(n), true
+	case float64:
+		if n == float64(int(n)) {
+			return int(n), true
+		}
+	}
+	return 0, false
+}

--- a/pkg/healthcheck/config_test.go
+++ b/pkg/healthcheck/config_test.go
@@ -1,0 +1,159 @@
+package healthcheck
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestParseAndValidate(t *testing.T) {
+	t.Run("valid defaults", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name":         "errors",
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool 1) + (${current} < bool (2 * ${baseline})) > bool 0`,
+				},
+			},
+		})
+		cfg, err := ParseAndValidate(obj)
+		require.NoError(t, err)
+		require.Equal(t, "ingester-cell-health", cfg.Name)
+		require.Equal(t, "http://prometheus:9090", cfg.PrometheusURL)
+		require.Len(t, cfg.Checks, 1)
+		require.Equal(t, ActionPause, cfg.Checks[0].FailurePolicy.ExceededAction)
+		require.Equal(t, ActionPause, cfg.Checks[0].ErrorPolicy.ExhaustedAction)
+		require.Equal(t, ActionPause, cfg.Checks[0].NoDataPolicy.ExhaustedAction)
+		require.Equal(t, defaultCurrentRange, cfg.Checks[0].CurrentRange)
+		require.Equal(t, defaultConsecutiveFailures, cfg.Checks[0].FailurePolicy.ConsecutiveFailures)
+		require.Equal(t, defaultErrorRetryInterval, cfg.Checks[0].ErrorPolicy.RetryInterval)
+		require.Equal(t, defaultNoDataRetryInterval, cfg.Checks[0].NoDataPolicy.RetryInterval)
+	})
+
+	t.Run("explicit policies", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name": "errors",
+					"errorPolicy": map[string]interface{}{
+						"retryInterval":   "5s",
+						"maxAttempts":     int64(2),
+						"exhaustedAction": "Warn",
+					},
+					"failurePolicy": map[string]interface{}{
+						"reevaluationInterval": "1m",
+						"consecutiveFailures":  int64(2),
+						"consecutiveSuccesses": int64(2),
+						"exceededAction":       "Pause",
+					},
+					"noDataPolicy": map[string]interface{}{
+						"retryInterval":   "15s",
+						"maxAttempts":     int64(4),
+						"exhaustedAction": "Disabled",
+					},
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool (${baseline}))`,
+				},
+			},
+		})
+		cfg, err := ParseAndValidate(obj)
+		require.NoError(t, err)
+		c := cfg.Checks[0]
+		require.Equal(t, 5*time.Second, c.ErrorPolicy.RetryInterval)
+		require.Equal(t, 2, c.ErrorPolicy.MaxAttempts)
+		require.Equal(t, ActionWarn, c.ErrorPolicy.ExhaustedAction)
+		require.Equal(t, time.Minute, c.FailurePolicy.ReevaluationInterval)
+		require.Equal(t, 2, c.FailurePolicy.ConsecutiveFailures)
+		require.Equal(t, 2, c.FailurePolicy.ConsecutiveSuccesses)
+		require.Equal(t, 15*time.Second, c.NoDataPolicy.RetryInterval)
+		require.Equal(t, 4, c.NoDataPolicy.MaxAttempts)
+		require.Equal(t, ActionDisabled, c.NoDataPolicy.ExhaustedAction)
+	})
+
+	t.Run("missing placeholders", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name":         "errors",
+					"query":        `scalar(1)`,
+					"successQuery": `${current} < bool 1`,
+				},
+			},
+		})
+		_, err := ParseAndValidate(obj)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), placeholderTargetMatchers)
+	})
+
+	t.Run("duplicate check names", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name":         "errors",
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool (${baseline}))`,
+				},
+				map[string]interface{}{
+					"name":         "errors",
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool (${baseline}))`,
+				},
+			},
+		})
+		_, err := ParseAndValidate(obj)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "duplicate")
+	})
+
+	t.Run("invalid exhaustedAction", func(t *testing.T) {
+		obj := mockHealthCheckUnstructured(map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"rollout-group": "ingester"},
+			},
+			"prometheusURL": "http://prometheus:9090",
+			"checks": []interface{}{
+				map[string]interface{}{
+					"name": "errors",
+					"errorPolicy": map[string]interface{}{
+						"exhaustedAction": "Nope",
+					},
+					"query":        `scalar(sum(rate(errors{${targetMatchers}}[${range}])))`,
+					"successQuery": `(${current} < bool (${baseline}))`,
+				},
+			},
+		})
+		_, err := ParseAndValidate(obj)
+		require.Error(t, err)
+	})
+}
+
+func mockHealthCheckUnstructured(spec map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": RolloutHealthChecksSpecGroup + "/" + RolloutHealthChecksVersion,
+		"kind":       RolloutHealthCheckKind,
+		"metadata": map[string]interface{}{
+			"name":       "ingester-cell-health",
+			"generation": int64(1),
+		},
+		"spec": spec,
+	}}
+}

--- a/pkg/healthcheck/types.go
+++ b/pkg/healthcheck/types.go
@@ -1,0 +1,31 @@
+package healthcheck
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Decision describes whether a workload controller may advance its rollout.
+type Decision struct {
+	ShouldPause  bool
+	Reason       string
+	RequeueAfter time.Duration
+}
+
+// Request carries the workload context needed to evaluate a rollout transition.
+type Request struct {
+	RolloutGroup      string
+	StateKey          string
+	Namespace         string
+	TargetName        string
+	TargetKind        string
+	TargetLabels      map[string]string
+	TargetAnnotations map[string]string
+	EventTarget       runtime.Object
+	CandidatePods     []*corev1.Pod
+	StablePods        []*corev1.Pod
+	BaselineTime      time.Time
+	Now               time.Time
+}


### PR DESCRIPTION
## Summary

Define the `RolloutHealthCheck` API contract so policy authoring and workload-controller integration can evolve against a stable schema.

- Validate selectors, Prometheus endpoints, queries, and retry/failure policies
- Keep the new resource dormant until later runtime wiring lands
- Expose workload-neutral request and decision types for controller adapters

Fixes https://github.com/grafana/databases-sre/issues/472
