### PR TITLE
Add phased Deployment rollout primitives

### DIFF
--- a/pkg/admission/phased_deployment.go
+++ b/pkg/admission/phased_deployment.go
@@ -1,0 +1,343 @@
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/spanlogger"
+	v1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/phased"
+)
+
+const (
+	PhasedDeploymentWebhookPath = "/admission/phased-deployment"
+)
+
+type jsonPatchOp struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+// PhasedDeployment is a mutating webhook that pauses opted-in Deployments with canary
+// dependencies when their shared rollout revision changes, and re-applies pause while
+// the gate is active. A time-limited bypass annotation skips gating.
+func PhasedDeployment(ctx context.Context, l log.Logger, ar v1.AdmissionReview, _ *kubernetes.Clientset) *v1.AdmissionResponse {
+	logger, ctx := spanlogger.New(ctx, l, "admission.PhasedDeployment()", tenantResolver)
+	defer logger.Finish()
+	_ = ctx
+
+	if ar.Request == nil {
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	logger.SetSpanAndLogTag("object.name", ar.Request.Name)
+	logger.SetSpanAndLogTag("object.namespace", ar.Request.Namespace)
+	logger.SetSpanAndLogTag("object.operation", string(ar.Request.Operation))
+
+	if ar.Request.Kind.Kind != "Deployment" {
+		return allowWarn(logger, fmt.Sprintf("unsupported kind %s, allowing", ar.Request.Kind.Kind))
+	}
+
+	obj, _, err := codecs.UniversalDeserializer().Decode(ar.Request.Object.Raw, nil, nil)
+	if err != nil {
+		return allowErr(logger, "can't decode object, allowing the change", err)
+	}
+	dep, ok := obj.(*appsv1.Deployment)
+	if !ok {
+		return allowWarn(logger, fmt.Sprintf("unexpected type %T, allowing", obj))
+	}
+
+	if !phased.IsOptedIn(dep) {
+		level.Debug(logger).Log("msg", "deployment not opted into phased rollouts, allowing")
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	canaries := phased.Canaries(dep)
+	if len(canaries) == 0 {
+		// Canary / first Deployment in a chain: clear leftover gate state if present.
+		if patch := clearGateStatePatch(dep); patch != nil {
+			level.Info(logger).Log("msg", "clearing leftover phased gate state from canary deployment")
+			return mutate(patch)
+		}
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	if until, ok, err := phased.BypassUntil(dep); err != nil {
+		level.Warn(logger).Log("msg", "invalid rollout-bypass-until, ignoring", "err", err)
+	} else if ok && phased.BypassActive(dep, time.Now()) {
+		level.Info(logger).Log(
+			"msg", "phased rollout bypass active, allowing without gate",
+			"revision", phased.Revision(dep),
+			"bypass_until", until.Format(time.RFC3339),
+			"gate_phase", phased.Phase(dep),
+			"paused", dep.Spec.Paused,
+		)
+		if patch := bypassReleasePatch(dep); patch != nil {
+			return mutate(patch)
+		}
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	revision := phased.Revision(dep)
+	if revision == "" {
+		level.Warn(logger).Log("msg", "phased deployment missing rollout revision, allowing without gate")
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	// Gate already completed for this revision: allow (including unpause).
+	if phased.Phase(dep) == config.RolloutDependencyPhaseComplete && phased.DependencyRevision(dep) == revision {
+		level.Debug(logger).Log(
+			"msg", "phased gate complete for revision, allowing",
+			"revision", revision,
+			"paused", dep.Spec.Paused,
+		)
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	var oldDep *appsv1.Deployment
+	if len(ar.Request.OldObject.Raw) > 0 {
+		oldObj, _, err := codecs.UniversalDeserializer().Decode(ar.Request.OldObject.Raw, nil, nil)
+		if err == nil {
+			oldDep, _ = oldObj.(*appsv1.Deployment)
+		}
+	}
+
+	needsNewGate := phased.NeedsNewGate(dep)
+	if needsNewGate {
+		previousRevision := phased.DependencyRevision(dep)
+		if oldDep != nil && previousRevision == "" {
+			previousRevision = phased.Revision(oldDep)
+		}
+		level.Info(logger).Log(
+			"msg", "phased deployment revision change detected",
+			"previous_revision", previousRevision,
+			"target_revision", revision,
+			"canaries", strings.Join(canaries, ","),
+		)
+	}
+
+	patch, err := buildGatePatch(dep, oldDep, revision)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to build phased gate patch", "err", err)
+		return &v1.AdmissionResponse{
+			Allowed: false,
+			Result:  &metav1.Status{Message: err.Error()},
+		}
+	}
+	if patch == nil {
+		level.Debug(logger).Log(
+			"msg", "phased deployment gate already enforced",
+			"revision", revision,
+			"phase", phased.Phase(dep),
+			"paused", dep.Spec.Paused,
+		)
+		return &v1.AdmissionResponse{Allowed: true}
+	}
+
+	if !needsNewGate && !dep.Spec.Paused {
+		level.Warn(logger).Log(
+			"msg", "re-pausing deployment while phased rollout gate is active",
+			"canaries", strings.Join(canaries, ","),
+			"revision", revision,
+			"phase", phased.Phase(dep),
+		)
+	} else {
+		level.Info(logger).Log(
+			"msg", "pausing deployment for phased rollout gate",
+			"canaries", strings.Join(canaries, ","),
+			"revision", revision,
+			"phase", phased.Phase(dep),
+			"had_paused", resolveHadPaused(dep, oldDep, needsNewGate),
+		)
+	}
+	return mutate(patch)
+}
+
+func mutate(patch []byte) *v1.AdmissionResponse {
+	pt := v1.PatchTypeJSONPatch
+	return &v1.AdmissionResponse{
+		Allowed:   true,
+		Patch:     patch,
+		PatchType: &pt,
+	}
+}
+
+func buildGatePatch(dep, oldDep *appsv1.Deployment, revision string) ([]byte, error) {
+	ops := []jsonPatchOp{}
+
+	if dep.Annotations == nil {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/metadata/annotations", Value: map[string]string{}})
+	}
+
+	needsNewGate := phased.NeedsNewGate(dep)
+	hadPaused := resolveHadPaused(dep, oldDep, needsNewGate)
+
+	if !dep.Spec.Paused {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+	}
+
+	setAnn := func(key, value string) {
+		cur := ""
+		if dep.Annotations != nil {
+			cur = dep.Annotations[key]
+		}
+		if cur == value {
+			return
+		}
+		ops = append(ops, jsonPatchOp{Op: "add", Path: phased.AnnotationJSONPointer(key), Value: value})
+	}
+	removeAnn := func(key string) {
+		if dep.Annotations != nil && dep.Annotations[key] != "" {
+			ops = append(ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(key)})
+		}
+	}
+
+	if needsNewGate {
+		setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseWaiting)
+		setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
+		setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for canary deployment(s)")
+		setAnn(config.RolloutHadPausedAnnotationKey, hadPaused)
+		removeAnn(config.RolloutCanariesReadyRevisionAnnotationKey)
+	} else {
+		setAnn(config.RolloutHadPausedAnnotationKey, hadPaused)
+		if phased.Phase(dep) == "" {
+			setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseWaiting)
+			setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
+			setAnn(config.RolloutDependencyReasonAnnotationKey, "waiting for canary deployment(s)")
+		}
+	}
+
+	if len(ops) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(ops)
+}
+
+func resolveHadPaused(dep, oldDep *appsv1.Deployment, needsNewGate bool) string {
+	if !needsNewGate {
+		if dep.Annotations != nil && dep.Annotations[config.RolloutHadPausedAnnotationKey] != "" {
+			return dep.Annotations[config.RolloutHadPausedAnnotationKey]
+		}
+		if oldDep != nil && oldDep.Annotations != nil && oldDep.Annotations[config.RolloutHadPausedAnnotationKey] != "" {
+			return oldDep.Annotations[config.RolloutHadPausedAnnotationKey]
+		}
+		return phased.HadPausedAnnotationFalse
+	}
+
+	// New gate: preserve prior user pause intent across revision changes.
+	if oldDep != nil {
+		if wasPausedByOurGate(oldDep) && oldDep.Annotations != nil && oldDep.Annotations[config.RolloutHadPausedAnnotationKey] != "" {
+			return oldDep.Annotations[config.RolloutHadPausedAnnotationKey]
+		}
+		if oldDep.Spec.Paused && !wasPausedByOurGate(oldDep) {
+			return phased.HadPausedAnnotationTrue
+		}
+		return phased.HadPausedAnnotationFalse
+	}
+	if dep.Spec.Paused {
+		return phased.HadPausedAnnotationTrue
+	}
+	return phased.HadPausedAnnotationFalse
+}
+
+func wasPausedByOurGate(d *appsv1.Deployment) bool {
+	if d == nil || !d.Spec.Paused {
+		return false
+	}
+	return phased.GateActive(d)
+}
+
+func clearGateStatePatch(dep *appsv1.Deployment) []byte {
+	if dep.Annotations == nil {
+		return nil
+	}
+	keys := []string{
+		config.RolloutDependencyPhaseAnnotationKey,
+		config.RolloutDependencyRevisionAnnotationKey,
+		config.RolloutDependencyReasonAnnotationKey,
+		config.RolloutHadPausedAnnotationKey,
+		config.RolloutCanariesReadyRevisionAnnotationKey,
+	}
+	hasGateState := false
+	for _, key := range keys {
+		if dep.Annotations[key] != "" {
+			hasGateState = true
+			break
+		}
+	}
+	if !hasGateState {
+		return nil
+	}
+
+	ops := []jsonPatchOp{}
+	hadPaused := dep.Annotations[config.RolloutHadPausedAnnotationKey] == phased.HadPausedAnnotationTrue
+	phase := dep.Annotations[config.RolloutDependencyPhaseAnnotationKey]
+	gateWasActive := phase != "" && phase != config.RolloutDependencyPhaseComplete
+	for _, key := range keys {
+		if dep.Annotations[key] != "" {
+			ops = append(ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(key)})
+		}
+	}
+	// Only unpause when releasing an active gate that we owned.
+	if gateWasActive && dep.Spec.Paused && !hadPaused {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: false})
+	}
+	if len(ops) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(ops)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// bypassReleasePatch unpauses a Deployment that is still held by an active gate when bypass is used.
+func bypassReleasePatch(dep *appsv1.Deployment) []byte {
+	if !phased.GateActive(dep) && !dep.Spec.Paused {
+		return nil
+	}
+	hadPaused := dep.Annotations != nil && dep.Annotations[config.RolloutHadPausedAnnotationKey] == phased.HadPausedAnnotationTrue
+	ops := []jsonPatchOp{}
+	if dep.Annotations == nil {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/metadata/annotations", Value: map[string]string{}})
+	}
+	revision := phased.Revision(dep)
+	setAnn := func(key, value string) {
+		cur := ""
+		if dep.Annotations != nil {
+			cur = dep.Annotations[key]
+		}
+		if cur == value {
+			return
+		}
+		ops = append(ops, jsonPatchOp{Op: "add", Path: phased.AnnotationJSONPointer(key), Value: value})
+	}
+	if revision != "" {
+		setAnn(config.RolloutDependencyPhaseAnnotationKey, config.RolloutDependencyPhaseComplete)
+		setAnn(config.RolloutDependencyRevisionAnnotationKey, revision)
+		setAnn(config.RolloutDependencyReasonAnnotationKey, "bypassed until "+strings.TrimSpace(dep.Annotations[config.RolloutBypassUntilAnnotationKey]))
+	}
+	if dep.Spec.Paused && !hadPaused {
+		ops = append(ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: false})
+	}
+	if len(ops) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(ops)
+	if err != nil {
+		return nil
+	}
+	return b
+}

--- a/pkg/admission/phased_deployment_test.go
+++ b/pkg/admission/phased_deployment_test.go
@@ -1,0 +1,171 @@
+package admission
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+	"github.com/grafana/rollout-operator/pkg/phased"
+)
+
+func TestPhasedDeployment_PausesOnRevisionChange(t *testing.T) {
+	newDep := phasedDeployment("query-frontend-zone-b", "query-frontend-zone-a", "r2", false, "", "")
+	oldDep := phasedDeployment("query-frontend-zone-b", "query-frontend-zone-a", "r1", false, config.RolloutDependencyPhaseComplete, "r1")
+	newDep.Annotations[config.RolloutCanariesReadyRevisionAnnotationKey] = "r1"
+	oldDep.Annotations[config.RolloutCanariesReadyRevisionAnnotationKey] = "r1"
+	var logs bytes.Buffer
+
+	resp := PhasedDeployment(context.Background(), log.NewLogfmtLogger(&logs), admissionReview(oldDep, newDep), nil)
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.PatchType)
+	require.NotEmpty(t, resp.Patch)
+
+	var ops []jsonPatchOp
+	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
+	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+	require.Contains(t, ops, jsonPatchOp{Op: "remove", Path: phased.AnnotationJSONPointer(config.RolloutCanariesReadyRevisionAnnotationKey)})
+	require.True(t, strings.Contains(logs.String(), `msg="phased deployment revision change detected"`))
+	require.Contains(t, logs.String(), "previous_revision=r1")
+	require.Contains(t, logs.String(), "target_revision=r2")
+}
+
+func TestPhasedDeployment_RePausesWhileGateActive(t *testing.T) {
+	newDep := phasedDeployment("b", "a", "r1", false, config.RolloutDependencyPhaseWaiting, "r1")
+	oldDep := phasedDeployment("b", "a", "r1", true, config.RolloutDependencyPhaseWaiting, "r1")
+	oldDep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
+	newDep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
+	var logs bytes.Buffer
+
+	resp := PhasedDeployment(context.Background(), log.NewLogfmtLogger(&logs), admissionReview(oldDep, newDep), nil)
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patch)
+
+	var ops []jsonPatchOp
+	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
+	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: true})
+	require.Contains(t, logs.String(), `msg="re-pausing deployment while phased rollout gate is active"`)
+	require.Contains(t, logs.String(), "revision=r1")
+}
+
+func TestPhasedDeployment_AllowsWhenComplete(t *testing.T) {
+	dep := phasedDeployment("b", "a", "r1", false, config.RolloutDependencyPhaseComplete, "r1")
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(dep, dep), nil)
+	require.True(t, resp.Allowed)
+	require.Nil(t, resp.Patch)
+}
+
+func TestPhasedDeployment_AllowsWithoutCanary(t *testing.T) {
+	dep := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "a",
+			Labels: map[string]string{config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue},
+			Annotations: map[string]string{
+				config.RolloutRevisionAnnotationKey: "r1",
+			},
+		},
+	}
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(nil, dep), nil)
+	require.True(t, resp.Allowed)
+	require.Nil(t, resp.Patch)
+}
+
+func TestPhasedDeployment_AllowsWhenBypassActive(t *testing.T) {
+	dep := phasedDeployment("b", "a", "r2", true, config.RolloutDependencyPhaseWaiting, "r2")
+	dep.Annotations[config.RolloutHadPausedAnnotationKey] = "false"
+	dep.Annotations[config.RolloutBypassUntilAnnotationKey] = time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(nil, dep), nil)
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patch)
+
+	var ops []jsonPatchOp
+	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
+	require.Contains(t, ops, jsonPatchOp{Op: "add", Path: "/spec/paused", Value: false})
+}
+
+func TestPhasedDeployment_PreservesPreExistingPause(t *testing.T) {
+	oldDep := phasedDeployment("b", "a", "r1", true, "", "")
+	newDep := phasedDeployment("b", "a", "r2", true, "", "")
+
+	resp := PhasedDeployment(context.Background(), log.NewNopLogger(), admissionReview(oldDep, newDep), nil)
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patch)
+
+	var ops []jsonPatchOp
+	require.NoError(t, json.Unmarshal(resp.Patch, &ops))
+	found := false
+	for _, op := range ops {
+		if op.Path == "/metadata/annotations/grafana.com~1rollout-had-paused" {
+			require.Equal(t, "true", op.Value)
+			found = true
+		}
+	}
+	require.True(t, found, "expected had-paused annotation in patch")
+}
+
+func phasedDeployment(name, canary, revision string, paused bool, phase, depRevision string) *appsv1.Deployment {
+	ann := map[string]string{
+		config.RolloutCanaryAnnotationKey:   canary,
+		config.RolloutRevisionAnnotationKey: revision,
+	}
+	if phase != "" {
+		ann[config.RolloutDependencyPhaseAnnotationKey] = phase
+	}
+	if depRevision != "" {
+		ann[config.RolloutDependencyRevisionAnnotationKey] = depRevision
+	}
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "default",
+			Labels:      map[string]string{config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue},
+			Annotations: ann,
+		},
+		Spec: appsv1.DeploymentSpec{Paused: paused},
+	}
+}
+
+func admissionReview(oldDep, newDep *appsv1.Deployment) admissionv1.AdmissionReview {
+	rawNew, err := json.Marshal(newDep)
+	if err != nil {
+		panic(err)
+	}
+	ar := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID:       "test",
+			Kind:      metav1.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			Resource:  metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			Name:      newDep.Name,
+			Namespace: newDep.Namespace,
+			Operation: admissionv1.Update,
+			Object:    runtime.RawExtension{Raw: rawNew},
+		},
+	}
+	if oldDep != nil {
+		rawOld, err := json.Marshal(oldDep)
+		if err != nil {
+			panic(err)
+		}
+		ar.Request.OldObject = runtime.RawExtension{Raw: rawOld}
+	}
+	return ar
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,4 +61,31 @@ const (
 	// StatefulSets in the same rollout group to continue rolling out.
 	RolloutPausedAnnotationKey   = "grafana.com/rollout-paused"
 	RolloutPausedAnnotationValue = "true"
+
+	// RolloutPhasedLabelKey opts a Deployment into phased (canary-gated) rollouts.
+	RolloutPhasedLabelKey   = "grafana.com/rollout-phased"
+	RolloutPhasedLabelValue = "true"
+
+	// RolloutCanaryAnnotationKey names one or more canary Deployments (comma-separated) that must
+	// finish rolling before this Deployment is allowed to proceed.
+	RolloutCanaryAnnotationKey = "grafana.com/rollout-canary"
+
+	// RolloutRevisionAnnotationKey is a shared revision stamp set by Git/jsonnet. The operator
+	// only gates when this value changes, so zone-local template differences are ignored.
+	RolloutRevisionAnnotationKey = "grafana.com/rollout-revision"
+
+	// RolloutBypassUntilAnnotationKey is an RFC3339 timestamp. While now is before that time,
+	// the operator skips pausing and unpauses an already-gated Deployment.
+	RolloutBypassUntilAnnotationKey = "grafana.com/rollout-bypass-until"
+
+	// Operator-owned state annotations written by the webhook and phased Deployment controller.
+	RolloutDependencyPhaseAnnotationKey       = "grafana.com/rollout-dependency-phase"
+	RolloutDependencyRevisionAnnotationKey    = "grafana.com/rollout-dependency-revision"
+	RolloutDependencyReasonAnnotationKey      = "grafana.com/rollout-dependency-reason"
+	RolloutHadPausedAnnotationKey             = "grafana.com/rollout-had-paused"
+	RolloutCanariesReadyRevisionAnnotationKey = "grafana.com/rollout-canaries-ready-revision"
+
+	// Dependency phase values.
+	RolloutDependencyPhaseWaiting  = "waiting"
+	RolloutDependencyPhaseComplete = "complete"
 )

--- a/pkg/phased/phased.go
+++ b/pkg/phased/phased.go
@@ -1,0 +1,193 @@
+package phased
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+const (
+	HadPausedAnnotationTrue  = "true"
+	HadPausedAnnotationFalse = "false"
+)
+
+// IsOptedIn reports whether the Deployment participates in phased rollouts.
+func IsOptedIn(d *appsv1.Deployment) bool {
+	if d == nil || d.Labels == nil {
+		return false
+	}
+	return d.Labels[config.RolloutPhasedLabelKey] == config.RolloutPhasedLabelValue
+}
+
+// Canaries returns the canary Deployment names this Deployment depends on.
+// Values are comma-separated in grafana.com/rollout-canary.
+func Canaries(d *appsv1.Deployment) []string {
+	if d == nil || d.Annotations == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(d.Annotations[config.RolloutCanaryAnnotationKey])
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+	for _, p := range parts {
+		name := strings.TrimSpace(p)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}
+
+// Revision returns the shared rollout revision stamp.
+func Revision(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return strings.TrimSpace(d.Annotations[config.RolloutRevisionAnnotationKey])
+}
+
+// Phase returns the current dependency gate phase.
+func Phase(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return d.Annotations[config.RolloutDependencyPhaseAnnotationKey]
+}
+
+// DependencyRevision returns the revision currently being gated.
+func DependencyRevision(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return d.Annotations[config.RolloutDependencyRevisionAnnotationKey]
+}
+
+// CanariesReadyRevision returns the revision for which every canary reached full readiness.
+func CanariesReadyRevision(d *appsv1.Deployment) string {
+	if d == nil || d.Annotations == nil {
+		return ""
+	}
+	return strings.TrimSpace(d.Annotations[config.RolloutCanariesReadyRevisionAnnotationKey])
+}
+
+// BypassUntil parses grafana.com/rollout-bypass-until. ok is false when unset.
+func BypassUntil(d *appsv1.Deployment) (until time.Time, ok bool, err error) {
+	if d == nil || d.Annotations == nil {
+		return time.Time{}, false, nil
+	}
+	raw := strings.TrimSpace(d.Annotations[config.RolloutBypassUntilAnnotationKey])
+	if raw == "" {
+		return time.Time{}, false, nil
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("invalid %s %q: %w", config.RolloutBypassUntilAnnotationKey, raw, err)
+	}
+	return t, true, nil
+}
+
+// BypassActive reports whether a valid bypass-until annotation is still in the future.
+func BypassActive(d *appsv1.Deployment, now time.Time) bool {
+	until, ok, err := BypassUntil(d)
+	if err != nil || !ok {
+		return false
+	}
+	return now.Before(until)
+}
+
+// GateActive reports whether the Deployment must stay paused for the current revision.
+func GateActive(d *appsv1.Deployment) bool {
+	if !IsOptedIn(d) || len(Canaries(d)) == 0 {
+		return false
+	}
+	rev := Revision(d)
+	if rev == "" || DependencyRevision(d) != rev {
+		return false
+	}
+	phase := Phase(d)
+	return phase != "" && phase != config.RolloutDependencyPhaseComplete
+}
+
+// NeedsNewGate reports whether a revision change requires (re)starting the gate.
+func NeedsNewGate(d *appsv1.Deployment) bool {
+	if !IsOptedIn(d) || len(Canaries(d)) == 0 {
+		return false
+	}
+	rev := Revision(d)
+	if rev == "" {
+		return false
+	}
+	return DependencyRevision(d) != rev
+}
+
+// IsFullyRolledOut reports whether every replica is updated, ready, and available.
+func IsFullyRolledOut(d *appsv1.Deployment) bool {
+	if d == nil {
+		return false
+	}
+	if d.Spec.Paused {
+		return false
+	}
+	desired := int32(1)
+	if d.Spec.Replicas != nil {
+		desired = *d.Spec.Replicas
+	}
+	if desired == 0 {
+		return d.Status.Replicas == 0 && d.Status.ObservedGeneration >= d.Generation
+	}
+	if d.Status.ObservedGeneration < d.Generation {
+		return false
+	}
+	return d.Status.UpdatedReplicas == desired &&
+		d.Status.ReadyReplicas == desired &&
+		d.Status.AvailableReplicas == desired &&
+		d.Status.Replicas == desired
+}
+
+// DetectDependencyCycle walks canary links starting from start.
+// deployments is keyed by name. Returns true if a cycle involving start is found.
+func DetectDependencyCycle(start string, deployments map[string]*appsv1.Deployment) bool {
+	onPath := map[string]struct{}{}
+	seen := map[string]struct{}{}
+	var walk func(string) bool
+	walk = func(cur string) bool {
+		if _, ok := onPath[cur]; ok {
+			return true
+		}
+		if _, ok := seen[cur]; ok {
+			return false
+		}
+		onPath[cur] = struct{}{}
+		seen[cur] = struct{}{}
+		if d, ok := deployments[cur]; ok {
+			for _, next := range Canaries(d) {
+				if walk(next) {
+					return true
+				}
+			}
+		}
+		delete(onPath, cur)
+		return false
+	}
+	return walk(start)
+}
+
+// AnnotationJSONPointer escapes an annotation key for use in a JSON Patch path.
+func AnnotationJSONPointer(key string) string {
+	// JSON Pointer: ~ -> ~0, / -> ~1
+	escaped := strings.ReplaceAll(key, "~", "~0")
+	escaped = strings.ReplaceAll(escaped, "/", "~1")
+	return "/metadata/annotations/" + escaped
+}

--- a/pkg/phased/phased_test.go
+++ b/pkg/phased/phased_test.go
@@ -1,0 +1,90 @@
+package phased
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/rollout-operator/pkg/config"
+)
+
+func TestCanaries(t *testing.T) {
+	d := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		config.RolloutCanaryAnnotationKey: " zone-a , query-frontend-zone-a,zone-a ",
+	}}}
+	require.Equal(t, []string{"zone-a", "query-frontend-zone-a"}, Canaries(d))
+	require.Nil(t, Canaries(&appsv1.Deployment{}))
+}
+
+func TestIsFullyRolledOut(t *testing.T) {
+	replicas := int32(3)
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Generation: 2},
+		Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 2,
+			Replicas:           3,
+			UpdatedReplicas:    3,
+			ReadyReplicas:      3,
+			AvailableReplicas:  3,
+		},
+	}
+	require.True(t, IsFullyRolledOut(d))
+
+	d.Spec.Paused = true
+	require.False(t, IsFullyRolledOut(d))
+	d.Spec.Paused = false
+
+	d.Status.ReadyReplicas = 2
+	require.False(t, IsFullyRolledOut(d))
+}
+
+func TestDetectDependencyCycle(t *testing.T) {
+	a := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "a", Annotations: map[string]string{config.RolloutCanaryAnnotationKey: "c"}}}
+	b := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "b", Annotations: map[string]string{config.RolloutCanaryAnnotationKey: "a"}}}
+	c := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "c", Annotations: map[string]string{config.RolloutCanaryAnnotationKey: "b"}}}
+	byName := map[string]*appsv1.Deployment{"a": a, "b": b, "c": c}
+	require.True(t, DetectDependencyCycle("a", byName))
+
+	c.Annotations = nil
+	require.False(t, DetectDependencyCycle("a", byName))
+
+	// Multi-canary diamond is not a cycle.
+	main := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "main", Annotations: map[string]string{config.RolloutCanaryAnnotationKey: "left,right"}}}
+	left := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "left"}}
+	right := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "right"}}
+	require.False(t, DetectDependencyCycle("main", map[string]*appsv1.Deployment{"main": main, "left": left, "right": right}))
+}
+
+func TestGateActive(t *testing.T) {
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{config.RolloutPhasedLabelKey: config.RolloutPhasedLabelValue},
+			Annotations: map[string]string{
+				config.RolloutCanaryAnnotationKey:             "upstream",
+				config.RolloutRevisionAnnotationKey:           "r1",
+				config.RolloutDependencyPhaseAnnotationKey:    config.RolloutDependencyPhaseWaiting,
+				config.RolloutDependencyRevisionAnnotationKey: "r1",
+			},
+		},
+	}
+	require.True(t, GateActive(d))
+
+	d.Annotations[config.RolloutDependencyPhaseAnnotationKey] = config.RolloutDependencyPhaseComplete
+	require.False(t, GateActive(d))
+}
+
+func TestBypassActive(t *testing.T) {
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	d := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		config.RolloutBypassUntilAnnotationKey: now.Add(time.Hour).Format(time.RFC3339),
+	}}}
+	require.True(t, BypassActive(d, now))
+	require.False(t, BypassActive(d, now.Add(2*time.Hour)))
+
+	d.Annotations[config.RolloutBypassUntilAnnotationKey] = "not-a-time"
+	require.False(t, BypassActive(d, now))
+}


### PR DESCRIPTION
## Summary

Define the opt-in phased Deployment contract so canary rollout mechanics can land independently from health-check evaluation.

- Add revision, dependency, bypass, and operator-owned state annotations
- Pause opted-in Deployments when a new gated revision is admitted
- Keep runtime controller wiring out of scope, leaving the behavior dormant

Fixes https://github.com/grafana/databases-sre/issues/473
